### PR TITLE
Feature/spa telemetry

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -85,6 +85,7 @@ jobs:
           ENTRA_AUTHORITY: ${{ secrets.ENTRA_AUTHORITY }}
           ENTRA_KNOWN_AUTHORITY: ${{ secrets.ENTRA_KNOWN_AUTHORITY }}
           ENTRA_API_SCOPE: ${{ secrets.ENTRA_API_SCOPE }}
+          APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.APP_INSIGHTS_CONNECTION_STRING }}
         run: |
           # SWA-hosted site is reachable at both the SWA default hostname and
           # the custom domain (jotjson.com) once bound. MSAL only allows one
@@ -102,7 +103,8 @@ jobs:
               redirectUri: 'https://jotjson.com/',
               postLogoutRedirectUri: 'https://jotjson.com/',
               scopes: ['__ENTRA_API_SCOPE__']
-            }
+            },
+            appInsightsConnectionString: '__APP_INSIGHTS_CONNECTION_STRING__'
           };
           EOF
           # The heredoc above preserves the indentation we use in YAML, so
@@ -110,16 +112,34 @@ jobs:
           # emitted file still type-checks either way, but cleaner diffs in
           # deploy logs help debugging.
           sed -i 's/^          //' src/environments/environment.prod.ts
-          # Substitute secrets. Fail the build if any are still empty so we
-          # never ship an unconfigured production bundle.
+          # Substitute secrets. Fail the build if any of the ENTRA_* values
+          # are still empty so we never ship an unconfigured production
+          # bundle. App Insights is intentionally optional - an empty
+          # connection string just disables telemetry for that build.
           sed -i "s|__ENTRA_SPA_CLIENT_ID__|${ENTRA_SPA_CLIENT_ID}|g" src/environments/environment.prod.ts
           sed -i "s|__ENTRA_AUTHORITY__|${ENTRA_AUTHORITY}|g" src/environments/environment.prod.ts
           sed -i "s|__ENTRA_KNOWN_AUTHORITY__|${ENTRA_KNOWN_AUTHORITY}|g" src/environments/environment.prod.ts
           sed -i "s|__ENTRA_API_SCOPE__|${ENTRA_API_SCOPE}|g" src/environments/environment.prod.ts
+          # `|` delimiter for AI because the connection string contains `=`
+          # but no `|`.
+          sed -i "s|__APP_INSIGHTS_CONNECTION_STRING__|${APP_INSIGHTS_CONNECTION_STRING}|g" src/environments/environment.prod.ts
           if grep -q "__ENTRA_" src/environments/environment.prod.ts; then
             echo "::error::One or more ENTRA_* secrets are missing - aborting deploy."
             exit 1
           fi
+
+      - name: Strip production sourcemaps before SWA upload
+        if: steps.check.outputs.have_token == 'true'
+        # We build with `sourceMap: { hidden: true }` so the JS bundles
+        # have no `sourceMappingURL` comment, but the .map files are
+        # still emitted to the output directory. Delete them so they
+        # are never uploaded to the public SWA origin. Symbolication
+        # for App Insights will be done out-of-band (see DESIGN_SPEC
+        # Telemetry). Until then, prod stack traces are minified -
+        # acceptable trade-off vs leaking source.
+        run: |
+          find dist/jotjson/browser -name '*.map' -type f -delete
+          echo "Stripped $(find dist/jotjson/browser -name '*.map' | wc -l) sourcemap files (should be 0)"
 
       - name: Deploy to Azure Static Web Apps
         if: steps.check.outputs.have_token == 'true'

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -783,6 +783,123 @@ key fallback can be removed. Local `func start` also uses `COSMOS_KEY`.
 
 ---
 
+## Telemetry & Logging
+
+JotJSON uses **Azure Application Insights** for both the SPA and the
+Azure Functions backend. The resource is provisioned in
+`infra/modules/appInsights.bicep` and shared between the two.
+
+### Connection-string flow
+
+- **Functions**: connection string injected as an app setting
+  (`APPLICATIONINSIGHTS_CONNECTION_STRING`) by Bicep; the Functions
+  runtime auto-instruments via `host.json`.
+- **SPA**: connection string is baked into `environment.prod.ts` at CD
+  time from the `APP_INSIGHTS_CONNECTION_STRING` GitHub secret. Empty
+  value -> telemetry disabled in that build (no SDK chunk loaded). The
+  CD step intentionally does NOT fail-closed when the secret is empty,
+  so a deploy still succeeds without telemetry.
+
+### What we collect (SPA)
+
+Manual instrumentation, driven through `core/telemetry/LoggerService`:
+
+- **Page views** - emitted by `route-tracker` on `NavigationEnd`, using
+  the matched Angular route template (e.g. `/s/:slug`, `/blobs`),
+  never the raw URL. Auto route tracking is **off**.
+- **Exceptions** - captured by `TelemetryErrorHandler` (registered as
+  Angular `ErrorHandler`). Every error goes through `normalizeError`,
+  which returns a strict whitelist (`status/method/pathTemplate/
+  backendCode` for HTTP, `name/message/stack` for `Error`, redacted
+  and truncated). Auto exception tracking is **off** to avoid
+  duplicates.
+- **Traces** - structured warnings from migrated `console.warn` sites
+  (`api.error`, `home.save.failed`, `share.delete.failed`, etc.). All
+  message IDs come from a frozen literal-union in
+  `telemetry-message-ids.ts` so typos fail at compile time.
+- **Dependencies (XHR/fetch)** - **on**, for SPA <-> Functions
+  correlation. URLs are sanitized in a telemetry initializer (query
+  string and fragment stripped). Ajax error response bodies are **off**
+  (`enableAjaxErrorStatusText: false`).
+- **Browser perf timings** - on (no PII).
+
+### What we deliberately do NOT collect
+
+- **Editor or clipboard content.** The `LoggerService` API does not
+  accept arbitrary user text, only structured `messageId + props` and
+  normalized errors.
+- **URL query strings or fragments.** History search (`q`,
+  `continuationToken`, `from`, `to`) and slug-bearing share links
+  never reach App Insights.
+- **HTTP request or response bodies.**
+- **Authorization headers.** Redacted in the privacy initializer as
+  defense in depth.
+- **Cookies.** `disableCookiesUsage: true`.
+- **Email, UPN, display name, or any free-form user identifier.** The
+  only identifier we send is the Entra `oid` via
+  `setAuthenticatedUserContext`. `redactPii` scrubs anything that looks
+  like an email or UPN out of free-text fields (Error messages, MSAL
+  log lines, stack frames).
+- **Click analytics.** The clickanalytics plugin is not loaded.
+
+### Bootstrap-failure path
+
+If `bootstrapApplication` rejects before Angular comes up, `main.ts`
+writes a sanitized record to `sessionStorage['jotjson.bootErr']`.
+`LoggerService.connect()` reads, clears, and replays it as a
+`boot.failed` exception once telemetry comes online.
+
+### MSAL log forwarding
+
+`createMsalInstance()` runs as a factory before Angular DI. It cannot
+inject `LoggerService` directly, so it publishes through a
+module-scoped `msalBridge` that buffers the most recent error-level
+messages. `LoggerService` attaches a consumer in its constructor; the
+buffer is drained on attach. Only `LogLevel.Error` messages are
+forwarded; PII messages are dropped at the source by MSAL.
+
+### Sampling
+
+- Functions: SDK default (adaptive sampling).
+- SPA: 100% in v1.
+
+### Sourcemaps
+
+Production builds emit **hidden** sourcemaps
+(`sourceMap: { scripts: true, hidden: true }` in `angular.json`).
+Hidden = no `sourceMappingURL` comment in the bundle, so sourcemaps
+are never fetched by browsers. The CD pipeline deletes the `.map`
+files before SWA upload so they are not exposed at the public origin.
+Out-of-band symbol upload to App Insights is a follow-up; until then,
+production stack traces are minified.
+
+### Local development
+
+- `environment.appInsightsConnectionString` is empty in
+  `environment.example.ts`/`environment.ts`.
+- `LoggerService` mirrors all calls to `console.*` regardless, so
+  DevTools shows the full log in dev.
+- `TelemetryService.connect()` short-circuits to `disabled` on empty
+  connection string; the `applicationinsights-web` chunk is not
+  fetched.
+
+### CSP allowlist (for future hardening)
+
+If/when a Content Security Policy is enforced, App Insights ingestion
+needs:
+
+- `*.in.applicationinsights.azure.com` (telemetry ingestion)
+- `*.livediagnostics.monitor.azure.com` (live metrics)
+- `js.monitor.azure.com` (CDN, only if we ever switch the SDK to a
+  CDN load - we currently bundle it via npm)
+
+### Data residency
+
+The App Insights resource is currently provisioned in **West US 2**.
+EU users would need a regional resource - out of scope for v1.
+
+---
+
 ## Milestones
 
 1. ~~**Project scaffolding** - Angular app, Azure Functions project, Cosmos DB setup, CI/CD pipeline.~~ (done)

--- a/angular.json
+++ b/angular.json
@@ -51,8 +51,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "500kB",
-                  "maximumError": "1MB"
+                  "maximumWarning": "700kB",
+                  "maximumError": "720kB"
                 },
                 {
                   "type": "anyComponentStyle",
@@ -61,6 +61,11 @@
                 }
               ],
               "outputHashing": "all",
+              "sourceMap": {
+                "scripts": true,
+                "styles": false,
+                "hidden": true
+              },
               "serviceWorker": "ngsw-config.json",
               "fileReplacements": [
                 {

--- a/angular.json
+++ b/angular.json
@@ -52,7 +52,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "700kB",
-                  "maximumError": "720kB"
+                  "maximumError": "1MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "@angular/service-worker": "^21.2.10",
         "@azure/msal-angular": "^5.2.0",
         "@azure/msal-browser": "^5.7.0",
+        "@microsoft/applicationinsights-web": "^3.4.1",
         "jsonc-parser": "^3.3.1",
         "monaco-editor": "^0.55.1",
         "rxjs": "~7.8.0",
@@ -4140,6 +4141,138 @@
         "win32"
       ]
     },
+    "node_modules/@microsoft/applicationinsights-analytics-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-analytics-js/-/applicationinsights-analytics-js-3.4.1.tgz",
+      "integrity": "sha512-zdxZzu50/gsE2JWrzeviHloFZu9r5/x2+OLD0TIYHhvrod321AKkStmKlDoep1JAsSephjxBfwTjciKiFXXyGA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-cfgsync-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-cfgsync-js/-/applicationinsights-cfgsync-js-3.4.1.tgz",
+      "integrity": "sha512-ifNgSIisKM/rZoLdpzS6sIQqBBRNXXAhiazZizwoP2MLdK93Z8JcPNi6eXkKPhW0Fi3SuoUivCaM7GgAMgVEFw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-channel-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-channel-js/-/applicationinsights-channel-js-3.4.1.tgz",
+      "integrity": "sha512-QS1k6iwVwR1MznGAB1H0F9raqpevbFNbadLS5O1419pz9OEWBfF9wRQLnENCyo8QS9Q0IdiqnGAON/D8IywpWg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-core-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-core-js/-/applicationinsights-core-js-3.4.1.tgz",
+      "integrity": "sha512-eXIHZ1+nvBiJgVpufBiTP801Vtr5FEwjWZioUsb44NC/z/UcsZh2MDJ1mBpjaDO73LVYUw/ZZmDCCo6Pg/61kA==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-dependencies-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-dependencies-js/-/applicationinsights-dependencies-js-3.4.1.tgz",
+      "integrity": "sha512-cnjVVTxSeavmwCoOwXi/ZQuCcjo7SnYYRWyS+GsMCrTRTItVHZlVj6NHgmFEQZWNybrM+U1RgwZE2wXn1/Liyw==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-properties-js": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-properties-js/-/applicationinsights-properties-js-3.4.1.tgz",
+      "integrity": "sha512-s2cUuknjazaoCbh9i6ljymeZqeQqpyAE8v2ZUxCkAwRuxbonAvZWQtEr4QQmEHWJIdbWgn0Ge+OOlMtMkh+Ixg==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-shims": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-shims/-/applicationinsights-shims-3.0.1.tgz",
+      "integrity": "sha512-DKwboF47H1nb33rSUfjqI6ryX29v+2QWcTrRvcQDA32AZr5Ilkr7whOOSsD1aBzwqX0RJEIP1Z81jfE3NBm/Lg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.9.4 < 2.x"
+      }
+    },
+    "node_modules/@microsoft/applicationinsights-web": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/applicationinsights-web/-/applicationinsights-web-3.4.1.tgz",
+      "integrity": "sha512-gdYLIYkP11D+V71nNCupYsmWE8LAL9EpIR2Q7+B3n6dpck7tgaYMXFN3S5ZrOh3yxLAwt7GVXZoDcN2mGkagxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@microsoft/applicationinsights-analytics-js": "3.4.1",
+        "@microsoft/applicationinsights-cfgsync-js": "3.4.1",
+        "@microsoft/applicationinsights-channel-js": "3.4.1",
+        "@microsoft/applicationinsights-core-js": "3.4.1",
+        "@microsoft/applicationinsights-dependencies-js": "3.4.1",
+        "@microsoft/applicationinsights-properties-js": "3.4.1",
+        "@microsoft/applicationinsights-shims": "3.0.1",
+        "@microsoft/dynamicproto-js": "^2.0.3",
+        "@nevware21/ts-async": ">= 0.5.5 < 2.x",
+        "@nevware21/ts-utils": ">= 0.12.6 < 2.x"
+      },
+      "peerDependencies": {
+        "tslib": ">= 1.0.0"
+      }
+    },
+    "node_modules/@microsoft/dynamicproto-js": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@microsoft/dynamicproto-js/-/dynamicproto-js-2.0.3.tgz",
+      "integrity": "sha512-JTWTU80rMy3mdxOjjpaiDQsTLZ6YSGGqsjURsY6AUQtIj0udlF/jYmhdLZu8693ZIC0T1IwYnFa0+QeiMnziBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.10.4 < 2.x"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.26.0.tgz",
@@ -4893,6 +5026,21 @@
         "@emnapi/core": "^1.7.1",
         "@emnapi/runtime": "^1.7.1"
       }
+    },
+    "node_modules/@nevware21/ts-async": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-async/-/ts-async-0.5.5.tgz",
+      "integrity": "sha512-vwqaL05iJPjLeh5igPi8MeeAu10i+Aq7xko1fbo9F5Si6MnVN5505qaV7AhSdk5MCBJVT/UYMk3kgInNjDb4Ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@nevware21/ts-utils": ">= 0.12.2 < 2.x"
+      }
+    },
+    "node_modules/@nevware21/ts-utils": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@nevware21/ts-utils/-/ts-utils-0.13.0.tgz",
+      "integrity": "sha512-F3mD+DsUn9OiZmZc5tg0oKqrJCtiCstwx+wE+DNzFYh2cCRUuzTYdK9zGGP/au2BWvbOQ6Tqlbjr2+dT1P3AlQ==",
+      "license": "MIT"
     },
     "node_modules/@ngtools/webpack": {
       "version": "21.2.8",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "watch": "ng build --watch --configuration development",
     "test": "ng test --watch=false --browsers=ChromeHeadless",
     "test:ci": "ng test --watch=false --browsers=ChromeHeadlessCI --code-coverage",
-    "lint": "tsc --noEmit -p tsconfig.app.json",
+    "lint": "tsc --noEmit -p tsconfig.app.json && node scripts/check-ascii.mjs",
     "check:ascii": "node scripts/check-ascii.mjs",
     "extract-i18n": "ng extract-i18n --output-path=src/locale --out-file=messages.xlf",
     "build:info": "node scripts/write-build-info.mjs",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@angular/service-worker": "^21.2.10",
     "@azure/msal-angular": "^5.2.0",
     "@azure/msal-browser": "^5.7.0",
+    "@microsoft/applicationinsights-web": "^3.4.1",
     "jsonc-parser": "^3.3.1",
     "monaco-editor": "^0.55.1",
     "rxjs": "~7.8.0",

--- a/scripts/check-ascii.mjs
+++ b/scripts/check-ascii.mjs
@@ -33,7 +33,18 @@ const ALLOWED = new Set([
 const BINARY_EXT = new Set(['.png', '.jpg', '.jpeg', '.gif', '.webp', '.ico', '.pdf', '.woff', '.woff2']);
 
 function listTrackedFiles() {
-  const out = execFileSync('git', ['ls-files', '-z'], { encoding: 'buffer' });
+  // `--cached` = files in the index (tracked).
+  // `--others --exclude-standard` = untracked files not covered by
+  //   .gitignore / .git/info/exclude / global excludes.
+  // Together: every file git is willing to track. This makes the local
+  // run match CI: a developer who runs `npm run check:ascii` BEFORE
+  // staging a new file still sees violations from that file, instead
+  // of the file being silently skipped because it is untracked.
+  const out = execFileSync(
+    'git',
+    ['ls-files', '--cached', '--others', '--exclude-standard', '-z'],
+    { encoding: 'buffer' }
+  );
   // -z emits NUL-terminated paths to survive unusual filenames.
   return out
     .toString('utf8')

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -18,10 +18,22 @@ export class AppComponent implements OnInit {
     // so the router waits for MSAL before activating routes (otherwise
     // resolvers race the bearer token).
     //
-    // Lazy-load the SW update listener so Material snackbar + the
-    // service-worker client runtime stay out of the initial bundle.
-    // There is no user-visible work happening in the first few seconds
-    // of a page load, so a deferred load is fine.
+    // Lazy-load telemetry + SW update listener so the App Insights SDK
+    // and Material snackbar stay out of the initial bundle. There is
+    // no user-visible work happening in the first few seconds of a
+    // page load, so a deferred load is fine.
+    void Promise.all([
+      import('./core/telemetry/logger.service'),
+      import('./core/telemetry/route-tracker')
+    ]).then(async ([logger, tracker]) => {
+      const t = this.injector.get(tracker.RouteTracker);
+      // Start subscribing to NavigationEnd before connect() resolves so
+      // the bootstrap navigation is captured even though it fires
+      // before telemetry is ready.
+      t.start();
+      await this.injector.get(logger.LoggerService).connect();
+      t.flushPending();
+    });
     void import('./core/update/app-update.service').then(({ AppUpdateService }) => {
       this.injector.get(AppUpdateService).initialize();
     });

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,5 +1,6 @@
 import {
   ApplicationConfig,
+  ErrorHandler,
   inject,
   isDevMode,
   provideAppInitializer,
@@ -16,6 +17,7 @@ import { authInterceptor } from './core/interceptors/auth.interceptor';
 import { errorInterceptor } from './core/interceptors/error.interceptor';
 import { AuthService } from './core/auth/auth.service';
 import { MSAL_INSTANCE, createMsalInstance } from './core/auth/msal-instance';
+import { TelemetryErrorHandler } from './core/telemetry/error-handler';
 
 export const appConfig: ApplicationConfig = {
   providers: [
@@ -31,6 +33,7 @@ export const appConfig: ApplicationConfig = {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000'
     }),
+    { provide: ErrorHandler, useClass: TelemetryErrorHandler },
     // MSAL wiring - deliberately NOT using `MsalRedirectComponent` or the
     // `MSAL_GUARD_CONFIG`/`MSAL_INTERCEPTOR_CONFIG` bundles, which assume an
     // NgModule bootstrap. Standalone apps drive redirect handling themselves

--- a/src/app/core/auth/auth.service.ts
+++ b/src/app/core/auth/auth.service.ts
@@ -12,6 +12,7 @@ import { filter } from 'rxjs/operators';
 import { environment } from '../../../environments/environment';
 import { AuthUser } from './auth-user';
 import { MSAL_INSTANCE } from './msal-instance';
+import { TelemetryService } from '../telemetry/telemetry.service';
 
 /**
  * Entry point for identity in the app.
@@ -32,6 +33,7 @@ import { MSAL_INSTANCE } from './msal-instance';
 export class AuthService {
   private readonly msal = inject<IPublicClientApplication>(MSAL_INSTANCE);
   private readonly broadcast = inject(MsalBroadcastService, { optional: true });
+  private readonly telemetry = inject(TelemetryService);
 
   private readonly userSignal = signal<AuthUser | null>(null);
   private initPromise: Promise<void> | null = null;
@@ -56,6 +58,7 @@ export class AuthService {
         }
         if (msg.eventType === EventType.LOGOUT_SUCCESS) {
           this.userSignal.set(null);
+          this.telemetry.setUser(null);
         }
       });
   }
@@ -184,7 +187,10 @@ export class AuthService {
   private refreshFromCache(): void {
     const account =
       this.msal.getActiveAccount() ?? this.msal.getAllAccounts()[0] ?? null;
-    this.userSignal.set(account ? this.toAuthUser(account) : null);
+    const user = account ? this.toAuthUser(account) : null;
+    this.userSignal.set(user);
+    // Telemetry: identify by Entra `oid` only - never email or username.
+    this.telemetry.setUser(user ? user.id : null);
   }
 
   private toAuthUser(a: AccountInfo): AuthUser {

--- a/src/app/core/auth/msal-instance.ts
+++ b/src/app/core/auth/msal-instance.ts
@@ -5,6 +5,7 @@ import {
 } from '@azure/msal-browser';
 import { MSAL_INSTANCE } from '@azure/msal-angular';
 import { environment } from '../../../environments/environment';
+import { msalBridge } from '../telemetry/msal-bridge';
 
 /**
  * Re-export msal-angular's `MSAL_INSTANCE` token so application code has a
@@ -45,8 +46,16 @@ export function createMsalInstance(): IPublicClientApplication {
     },
     system: {
       loggerOptions: {
-        loggerCallback: () => void 0,
-        logLevel: LogLevel.Warning,
+        loggerCallback: (level, message, containsPii) => {
+          // Only forward Errors. Drop anything MSAL flags as PII even
+          // though `piiLoggingEnabled: false` should already prevent
+          // those messages from being emitted; defense in depth.
+          if (level !== LogLevel.Error || containsPii) {
+            return;
+          }
+          msalBridge.publish(message);
+        },
+        logLevel: LogLevel.Error,
         piiLoggingEnabled: false
       }
     }

--- a/src/app/core/interceptors/error.interceptor.ts
+++ b/src/app/core/interceptors/error.interceptor.ts
@@ -1,11 +1,22 @@
 import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
+import { inject } from '@angular/core';
 import { catchError, throwError } from 'rxjs';
+import { LoggerService } from '../telemetry/logger.service';
+import { sanitizePath } from '../telemetry/normalize-error';
 
-export const errorInterceptor: HttpInterceptorFn = (req, next) =>
-  next(req).pipe(
+export const errorInterceptor: HttpInterceptorFn = (req, next) => {
+  const logger = inject(LoggerService);
+  return next(req).pipe(
     catchError((err: HttpErrorResponse) => {
-      // Error-toast wiring will land in the polish milestone; for now just rethrow.
-      console.error('[API error]', req.method, req.url, err.status, err.message);
+      // Never log `req.url` directly - it can include query strings
+      // (history search `q`, continuation tokens). `sanitizePath`
+      // strips the query and fragment.
+      logger.warn('api.error', {
+        method: req.method,
+        pathTemplate: sanitizePath(req.url),
+        status: err.status
+      });
       return throwError(() => err);
     })
   );
+};

--- a/src/app/core/telemetry/error-handler.spec.ts
+++ b/src/app/core/telemetry/error-handler.spec.ts
@@ -1,0 +1,39 @@
+import { TestBed } from '@angular/core/testing';
+import { TelemetryErrorHandler } from './error-handler';
+import { LoggerService } from './logger.service';
+
+describe('TelemetryErrorHandler', () => {
+  let errSpy: jasmine.Spy;
+  let consoleErr: jasmine.Spy;
+  let handler: TelemetryErrorHandler;
+
+  beforeEach(() => {
+    errSpy = jasmine.createSpy('error');
+    consoleErr = spyOn(console, 'error');
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: LoggerService, useValue: { error: errSpy } },
+        TelemetryErrorHandler
+      ]
+    });
+    handler = TestBed.inject(TelemetryErrorHandler);
+  });
+
+  it('forwards error to LoggerService and calls super', () => {
+    const e = new Error('boom');
+    handler.handleError(e);
+    expect(consoleErr).toHaveBeenCalled();
+    expect(errSpy).toHaveBeenCalledWith('app.unhandled', e);
+  });
+
+  it('does not recurse when logger.error throws', () => {
+    errSpy.and.throwError('telemetry boom');
+    expect(() => handler.handleError(new Error('x'))).not.toThrow();
+    expect(errSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles non-Error throws', () => {
+    handler.handleError('plain string');
+    expect(errSpy).toHaveBeenCalledWith('app.unhandled', 'plain string');
+  });
+});

--- a/src/app/core/telemetry/error-handler.ts
+++ b/src/app/core/telemetry/error-handler.ts
@@ -1,0 +1,33 @@
+import { ErrorHandler, Injectable, inject } from '@angular/core';
+import { LoggerService } from './logger.service';
+
+/**
+ * Angular `ErrorHandler` override that preserves the default
+ * console-stack output (via `super.handleError`) and ALSO forwards the
+ * error to `LoggerService` for telemetry.
+ *
+ * Reentrancy guard: if `logger.error()` itself throws (e.g. because
+ * telemetry blew up mid-dispatch), we swallow the throw and DO NOT
+ * re-enter — otherwise an Angular `ErrorHandler` recursion can lock
+ * the page.
+ */
+@Injectable({ providedIn: 'root' })
+export class TelemetryErrorHandler extends ErrorHandler {
+  private readonly logger = inject(LoggerService);
+  private isHandling = false;
+
+  override handleError(err: unknown): void {
+    super.handleError(err);
+    if (this.isHandling) {
+      return;
+    }
+    this.isHandling = true;
+    try {
+      this.logger.error('app.unhandled', err);
+    } catch {
+      // never throw out of the global error handler
+    } finally {
+      this.isHandling = false;
+    }
+  }
+}

--- a/src/app/core/telemetry/error-handler.ts
+++ b/src/app/core/telemetry/error-handler.ts
@@ -8,7 +8,7 @@ import { LoggerService } from './logger.service';
  *
  * Reentrancy guard: if `logger.error()` itself throws (e.g. because
  * telemetry blew up mid-dispatch), we swallow the throw and DO NOT
- * re-enter — otherwise an Angular `ErrorHandler` recursion can lock
+ * re-enter - otherwise an Angular `ErrorHandler` recursion can lock
  * the page.
  */
 @Injectable({ providedIn: 'root' })

--- a/src/app/core/telemetry/logger.service.spec.ts
+++ b/src/app/core/telemetry/logger.service.spec.ts
@@ -1,0 +1,166 @@
+import { TestBed } from '@angular/core/testing';
+import { environment } from '../../../environments/environment';
+import { LoggerService } from './logger.service';
+import { TelemetryService } from './telemetry.service';
+import { msalBridge } from './msal-bridge';
+import { normalizeError } from './normalize-error';
+
+describe('LoggerService', () => {
+  let originalCs: string | undefined;
+  let trackException: jasmine.Spy;
+  let trackTrace: jasmine.Spy;
+
+  beforeEach(() => {
+    originalCs = environment.appInsightsConnectionString;
+    environment.appInsightsConnectionString = '';
+    msalBridge.reset();
+    spyOn(console, 'info');
+    spyOn(console, 'warn');
+    spyOn(console, 'error');
+  });
+
+  afterEach(() => {
+    environment.appInsightsConnectionString = originalCs;
+  });
+
+  function makeWithFakeTelemetry(disabled: boolean) {
+    TestBed.resetTestingModule();
+    const telemetry: Partial<TelemetryService> = {
+      connect: () => Promise.resolve(),
+      get isDisabled() {
+        return disabled;
+      },
+      get isConnected() {
+        return !disabled;
+      }
+    };
+    trackException = jasmine.createSpy('trackException');
+    trackTrace = jasmine.createSpy('trackTrace');
+    (telemetry as TelemetryService).trackException = trackException;
+    (telemetry as TelemetryService).trackTrace = trackTrace;
+    TestBed.configureTestingModule({
+      providers: [{ provide: TelemetryService, useValue: telemetry }]
+    });
+    return TestBed.inject(LoggerService);
+  }
+
+  it('mirrors all severities to console even before connect', () => {
+    const log = makeWithFakeTelemetry(false);
+    log.info('app.unhandled');
+    log.warn('api.error');
+    log.error('app.unhandled', new Error('boom'));
+    expect(console.info).toHaveBeenCalled();
+    expect(console.warn).toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('flushes buffered entries on connect in FIFO order', async () => {
+    const log = makeWithFakeTelemetry(false);
+    log.info('app.unhandled', { n: 1 });
+    log.warn('api.error', { n: 2 });
+    log.error('app.unhandled', new Error('three'));
+    await log.connect();
+    // 2 traces (info, warn) + 1 exception (error)
+    expect(trackTrace).toHaveBeenCalledTimes(2);
+    expect(trackException).toHaveBeenCalledTimes(1);
+    const firstCall = (trackTrace.calls.argsFor(0)[2] as Record<string, unknown>) ?? {};
+    const secondCall = (trackTrace.calls.argsFor(1)[2] as Record<string, unknown>) ?? {};
+    expect(firstCall['n']).toBe(1);
+    expect(secondCall['n']).toBe(2);
+  });
+
+  it('drops oldest entry when buffer overflows', async () => {
+    const log = makeWithFakeTelemetry(false);
+    for (let i = 0; i < 105; i++) {
+      log.info('app.unhandled', { i });
+    }
+    await log.connect();
+    // We pushed 105; cap is 100; oldest 5 should be dropped.
+    expect(trackTrace).toHaveBeenCalledTimes(100);
+    const firstProps = trackTrace.calls.argsFor(0)[2] as Record<string, unknown>;
+    expect(firstProps['i']).toBe(5);
+  });
+
+  it('drops the buffer and never dispatches when disabled', async () => {
+    const log = makeWithFakeTelemetry(true);
+    log.info('app.unhandled', { x: 1 });
+    log.warn('api.error', { x: 2 });
+    await log.connect();
+    log.info('app.unhandled', { x: 3 });
+    expect(trackTrace).not.toHaveBeenCalled();
+    expect(trackException).not.toHaveBeenCalled();
+  });
+
+  it('routes errors via trackException using NormalizedError shape', async () => {
+    const log = makeWithFakeTelemetry(false);
+    log.error('home.save.failed', new Error('failed for alice@x.io'));
+    await log.connect();
+    expect(trackException).toHaveBeenCalledTimes(1);
+    const [normalized, props] = trackException.calls.argsFor(0);
+    expect(normalized.kind).toBe('error');
+    expect(normalized.message).toContain('<email>');
+    expect(props.messageId).toBe('home.save.failed');
+  });
+
+  it('forwards null error as a trace, not exception', async () => {
+    const log = makeWithFakeTelemetry(false);
+    log.error('app.unhandled', null);
+    await log.connect();
+    expect(trackTrace).toHaveBeenCalledTimes(1);
+    expect(trackException).not.toHaveBeenCalled();
+  });
+
+  it('does not throw when telemetry.dispatch throws', async () => {
+    const log = makeWithFakeTelemetry(false);
+    trackTrace = ((): void => {
+      throw new Error('boom');
+    }) as unknown as jasmine.Spy;
+    (TestBed.inject(TelemetryService) as TelemetryService).trackTrace = trackTrace;
+    log.info('app.unhandled');
+    await expectAsync(log.connect()).toBeResolved();
+  });
+
+  it('drains MSAL bridge buffer once consumer is attached', async () => {
+    msalBridge.publish("user 'bob@x.io' must reauthenticate; AADSTS50058");
+    const log = makeWithFakeTelemetry(false);
+    void log;
+    await log.connect();
+    expect(trackTrace).toHaveBeenCalled();
+    const args = trackTrace.calls.argsFor(0);
+    const messageId = args[0] as string;
+    const props = (args[2] as Record<string, unknown>) ?? {};
+    expect(messageId).toBe('msal.error');
+    expect(String(props['message'])).toContain('<email>');
+    expect(props['aadCode']).toBe('AADSTS50058');
+  });
+
+  it('reads and clears sessionStorage boot error on connect', async () => {
+    sessionStorage.setItem(
+      'jotjson.bootErr',
+      JSON.stringify({ name: 'BootError', message: 'boot failed' })
+    );
+    const log = makeWithFakeTelemetry(false);
+    await log.connect();
+    expect(sessionStorage.getItem('jotjson.bootErr')).toBeNull();
+    // The boot exception is dispatched via trackException.
+    const calls = trackException.calls.allArgs();
+    const bootCall = calls.find((args) => {
+      const props = args[1] as Record<string, unknown>;
+      return props && props['messageId'] === 'boot.failed';
+    });
+    expect(bootCall).toBeDefined();
+  });
+
+  it('produces normalized HttpError when given HTTP context', async () => {
+    const { HttpErrorResponse } = await import('@angular/common/http');
+    const err = new HttpErrorResponse({ url: '/api/x?secret', status: 500 });
+    const log = makeWithFakeTelemetry(false);
+    log.error('api.error', err, undefined, { method: 'GET', pathTemplate: '/api/x' });
+    await log.connect();
+    expect(trackException).toHaveBeenCalledTimes(1);
+    const [normalized] = trackException.calls.argsFor(0);
+    expect(normalized.kind).toBe('http');
+    expect(normalized.pathTemplate).toBe('/api/x');
+    void normalizeError; // silence unused-import lint if any
+  });
+});

--- a/src/app/core/telemetry/logger.service.ts
+++ b/src/app/core/telemetry/logger.service.ts
@@ -26,11 +26,11 @@ interface PendingEntry {
 }
 
 /**
- * Public façade for application logging. All call sites should use this
+ * Public facade for application logging. All call sites should use this
  * service rather than `console.*` directly. Two parallel sinks:
  *
- * - `console.*` — always (so DevTools shows everything in dev).
- * - App Insights — once `TelemetryService.connect()` resolves.
+ * - `console.*` - always (so DevTools shows everything in dev).
+ * - App Insights - once `TelemetryService.connect()` resolves.
  *
  * Calls made before telemetry connects are buffered (FIFO, cap 100,
  * oldest dropped on overflow) and replayed on connect. If telemetry

--- a/src/app/core/telemetry/logger.service.ts
+++ b/src/app/core/telemetry/logger.service.ts
@@ -1,0 +1,187 @@
+import { Injectable, inject } from '@angular/core';
+import { msalBridge } from './msal-bridge';
+import {
+  HttpErrorContext,
+  NormalizedError,
+  normalizeError
+} from './normalize-error';
+import {
+  TelemetryService,
+  TelemetryProps,
+  TelemetrySeverity
+} from './telemetry.service';
+import { TelemetryMessageId } from './telemetry-message-ids';
+
+const BUFFER_CAP = 100;
+const BOOT_FAIL_KEY = 'jotjson.bootErr';
+
+type Severity = 'info' | 'warn' | 'error';
+
+interface PendingEntry {
+  ts: number;
+  severity: Severity;
+  messageId: TelemetryMessageId;
+  props?: TelemetryProps;
+  error?: NormalizedError;
+}
+
+/**
+ * Public façade for application logging. All call sites should use this
+ * service rather than `console.*` directly. Two parallel sinks:
+ *
+ * - `console.*` — always (so DevTools shows everything in dev).
+ * - App Insights — once `TelemetryService.connect()` resolves.
+ *
+ * Calls made before telemetry connects are buffered (FIFO, cap 100,
+ * oldest dropped on overflow) and replayed on connect. If telemetry
+ * cannot be initialized at all (no connection string, SDK load failure)
+ * the buffer is dropped and we become a permanent no-op for the
+ * telemetry sink.
+ */
+@Injectable({ providedIn: 'root' })
+export class LoggerService {
+  private readonly telemetry = inject(TelemetryService);
+  private readonly buffer: PendingEntry[] = [];
+  private connected = false;
+  private disabled = false;
+
+  constructor() {
+    msalBridge.attachConsumer((entry) => {
+      this.error('msal.error', null, entry.props);
+    });
+  }
+
+  /**
+   * Drive `TelemetryService.connect()` and, when it resolves, drain the
+   * buffer to the appropriate sink. Idempotent. Called from
+   * `AppComponent.ngOnInit` (deferred via dynamic import so the SDK
+   * stays out of the initial bundle).
+   */
+  async connect(): Promise<void> {
+    await this.telemetry.connect();
+    if (this.telemetry.isDisabled) {
+      this.disabled = true;
+      this.buffer.length = 0;
+      return;
+    }
+    this.connected = true;
+    this.flushSessionStorage();
+    const drained = this.buffer.splice(0, this.buffer.length);
+    for (const e of drained) {
+      this.dispatch(e);
+    }
+  }
+
+  info(messageId: TelemetryMessageId, props?: TelemetryProps): void {
+    this.consoleMirror('info', messageId, props);
+    this.handle({ ts: Date.now(), severity: 'info', messageId, props });
+  }
+
+  warn(messageId: TelemetryMessageId, props?: TelemetryProps): void {
+    this.consoleMirror('warn', messageId, props);
+    this.handle({ ts: Date.now(), severity: 'warn', messageId, props });
+  }
+
+  error(
+    messageId: TelemetryMessageId,
+    err: unknown | null,
+    props?: TelemetryProps,
+    httpCtx?: HttpErrorContext
+  ): void {
+    const normalized = err === null || err === undefined
+      ? undefined
+      : normalizeError(err, httpCtx);
+    this.consoleMirror('error', messageId, props, normalized);
+    this.handle({
+      ts: Date.now(),
+      severity: 'error',
+      messageId,
+      props,
+      error: normalized
+    });
+  }
+
+  // --- internals ---
+
+  private handle(entry: PendingEntry): void {
+    if (this.disabled) {
+      return;
+    }
+    if (this.connected) {
+      this.dispatch(entry);
+      return;
+    }
+    if (this.buffer.length >= BUFFER_CAP) {
+      this.buffer.shift();
+    }
+    this.buffer.push(entry);
+  }
+
+  private dispatch(entry: PendingEntry): void {
+    try {
+      const severity = this.toSdkSeverity(entry.severity);
+      if (entry.severity === 'error' && entry.error) {
+        this.telemetry.trackException(entry.error, {
+          ...entry.props,
+          messageId: entry.messageId
+        });
+      } else {
+        this.telemetry.trackTrace(entry.messageId, severity, entry.props);
+      }
+    } catch (e) {
+      // Never throw out of the logger.
+      // eslint-disable-next-line no-console
+      console.warn('[telemetry] dispatch failed', e);
+    }
+  }
+
+  private toSdkSeverity(s: Severity): TelemetrySeverity {
+    if (s === 'error') {
+      return 'error';
+    }
+    if (s === 'warn') {
+      return 'warn';
+    }
+    return 'info';
+  }
+
+  private consoleMirror(
+    severity: Severity,
+    messageId: TelemetryMessageId,
+    props?: TelemetryProps,
+    err?: NormalizedError
+  ): void {
+    // eslint-disable-next-line no-console
+    const fn = severity === 'error'
+      ? console.error
+      : severity === 'warn'
+        ? console.warn
+        : console.info;
+    if (err) {
+      fn(`[${messageId}]`, props ?? {}, err);
+    } else {
+      fn(`[${messageId}]`, props ?? {});
+    }
+  }
+
+  private flushSessionStorage(): void {
+    try {
+      const raw = sessionStorage.getItem(BOOT_FAIL_KEY);
+      if (!raw) {
+        return;
+      }
+      sessionStorage.removeItem(BOOT_FAIL_KEY);
+      const parsed = JSON.parse(raw) as { name?: string; message?: string };
+      this.telemetry.trackException(
+        {
+          kind: 'error',
+          name: parsed.name ?? 'BootError',
+          message: parsed.message ?? '<no message>'
+        },
+        { messageId: 'boot.failed' }
+      );
+    } catch {
+      // ignore
+    }
+  }
+}

--- a/src/app/core/telemetry/msal-bridge.ts
+++ b/src/app/core/telemetry/msal-bridge.ts
@@ -1,0 +1,69 @@
+/**
+ * Module-scoped MSAL log forwarder.
+ *
+ * `createMsalInstance()` runs as a factory inside `app.config.ts`,
+ * which fires before any Angular service can be injected. To avoid
+ * circular DI between MSAL and `LoggerService`, MSAL pushes log
+ * entries into this small buffer; `LoggerService` registers a consumer
+ * in its constructor, draining and forwarding subsequently.
+ *
+ * Privacy: only `Error`-level messages are forwarded (callers cap the
+ * MSAL `LogLevel`), and PII is scrubbed via `redactPii` before any
+ * string is enqueued.
+ */
+import { extractAadCode, redactPii, truncate } from './redact-pii';
+import { TelemetryProps } from './telemetry.service';
+
+const BUFFER_CAP = 50;
+const MAX_MSG = 500;
+
+export interface MsalBridgeEntry {
+  props: TelemetryProps;
+}
+
+type Consumer = (entry: MsalBridgeEntry) => void;
+
+class MsalBridge {
+  private readonly buffer: MsalBridgeEntry[] = [];
+  private consumer: Consumer | null = null;
+
+  publish(rawMessage: string): void {
+    const message = redactPii(truncate(rawMessage ?? '', MAX_MSG));
+    const aadCode = extractAadCode(rawMessage ?? '');
+    const entry: MsalBridgeEntry = {
+      props: { message, aadCode }
+    };
+    if (this.consumer) {
+      try {
+        this.consumer(entry);
+      } catch {
+        // never throw out of MSAL callback
+      }
+      return;
+    }
+    if (this.buffer.length >= BUFFER_CAP) {
+      this.buffer.shift();
+    }
+    this.buffer.push(entry);
+  }
+
+  attachConsumer(consumer: Consumer): void {
+    this.consumer = consumer;
+    const drained = this.buffer.splice(0, this.buffer.length);
+    for (const e of drained) {
+      try {
+        consumer(e);
+      } catch {
+        // ignore
+      }
+    }
+  }
+
+  /** Test-only: reset state between tests. */
+  reset(): void {
+    this.buffer.length = 0;
+    this.consumer = null;
+  }
+}
+
+export const msalBridge = new MsalBridge();

--- a/src/app/core/telemetry/normalize-error.spec.ts
+++ b/src/app/core/telemetry/normalize-error.spec.ts
@@ -1,0 +1,115 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { normalizeError, sanitizePath } from './normalize-error';
+
+describe('sanitizePath', () => {
+  it('returns undefined for empty input', () => {
+    expect(sanitizePath('')).toBeUndefined();
+    expect(sanitizePath(null)).toBeUndefined();
+  });
+
+  it('strips query strings', () => {
+    expect(sanitizePath('/api/history?q=secret&from=2024')).toBe('/api/history');
+  });
+
+  it('strips fragments', () => {
+    expect(sanitizePath('/blobs#section')).toBe('/blobs');
+  });
+
+  it('strips both query and fragment', () => {
+    expect(sanitizePath('/x?a=1#frag')).toBe('/x');
+  });
+
+  it('returns plain paths unchanged', () => {
+    expect(sanitizePath('/api/blobs/abc123')).toBe('/api/blobs/abc123');
+  });
+});
+
+describe('normalizeError', () => {
+  it('normalizes HttpErrorResponse without leaking message or body', () => {
+    const err = new HttpErrorResponse({
+      url: '/api/history?q=secret&continuationToken=xyz',
+      status: 500,
+      statusText: 'Internal Server Error',
+      error: { code: 'cosmos.unavailable', detail: 'sensitive data' }
+    });
+    const out = normalizeError(err, { method: 'GET' });
+    expect(out.kind).toBe('http');
+    if (out.kind === 'http') {
+      expect(out.status).toBe(500);
+      expect(out.statusText).toBe('Internal Server Error');
+      expect(out.method).toBe('GET');
+      expect(out.pathTemplate).toBe('/api/history');
+      expect(out.backendCode).toBe('cosmos.unavailable');
+    }
+    // Verify no leakage by re-stringifying
+    const json = JSON.stringify(out);
+    expect(json).not.toContain('secret');
+    expect(json).not.toContain('continuationToken');
+    expect(json).not.toContain('sensitive data');
+  });
+
+  it('prefers ctx.pathTemplate over the raw URL', () => {
+    const err = new HttpErrorResponse({
+      url: '/api/blobs/abc?x=1',
+      status: 404
+    });
+    const out = normalizeError(err, { method: 'GET', pathTemplate: '/api/blobs/:slug' });
+    expect(out.kind).toBe('http');
+    if (out.kind === 'http') {
+      expect(out.pathTemplate).toBe('/api/blobs/:slug');
+    }
+  });
+
+  it('omits backendCode when body has no string code', () => {
+    const err = new HttpErrorResponse({ url: '/api/x', status: 400, error: 'plain text' });
+    const out = normalizeError(err);
+    if (out.kind === 'http') {
+      expect(out.backendCode).toBeUndefined();
+    }
+  });
+
+  it('normalizes plain Error - redacted, truncated', () => {
+    const e = new Error('failed for alice@x.io');
+    const out = normalizeError(e);
+    expect(out.kind).toBe('error');
+    if (out.kind === 'error') {
+      expect(out.name).toBe('Error');
+      expect(out.message).toBe('failed for <email>');
+      expect(out.stack).toBeDefined();
+    }
+  });
+
+  it('redacts PII in stack frames', () => {
+    const e = new Error('boom');
+    e.stack = 'Error: boom\n  at user@x.io:1:1';
+    const out = normalizeError(e);
+    if (out.kind === 'error') {
+      expect(out.stack).toContain('<email>');
+      expect(out.stack).not.toContain('user@x.io');
+    }
+  });
+
+  it('truncates very long messages', () => {
+    const long = 'x'.repeat(2000);
+    const out = normalizeError(new Error(long));
+    if (out.kind === 'error') {
+      expect(out.message.length).toBeLessThanOrEqual(500);
+    }
+  });
+
+  it('handles non-Error throws', () => {
+    const out = normalizeError({ random: 'object' });
+    expect(out.kind).toBe('unknown');
+    if (out.kind === 'unknown') {
+      expect(out.repr).toContain('non-error thrown');
+    }
+  });
+
+  it('preserves string throws (after redaction/truncate)', () => {
+    const out = normalizeError('panic at the disco bob@x.io');
+    expect(out.kind).toBe('unknown');
+    if (out.kind === 'unknown') {
+      expect(out.repr).toContain('<email>');
+    }
+  });
+});

--- a/src/app/core/telemetry/normalize-error.ts
+++ b/src/app/core/telemetry/normalize-error.ts
@@ -1,0 +1,98 @@
+import { HttpErrorResponse } from '@angular/common/http';
+import { redactPii, truncate } from './redact-pii';
+
+/**
+ * Strict, privacy-safe normalization of an unknown error value into a
+ * shape that is safe to forward to App Insights.
+ *
+ * The raw `Error.message` of an `HttpErrorResponse` typically embeds the
+ * full request URL (with query string) and the response body
+ * `error.error` may contain server-side payloads. We never forward
+ * either - we extract a curated allowlist of fields and drop the rest.
+ *
+ * For arbitrary `Error` instances we forward the name and a redacted +
+ * truncated message and stack. For non-Error throws we record only that
+ * the throw happened, never the value.
+ */
+export type NormalizedError =
+  | {
+      kind: 'http';
+      status: number;
+      statusText?: string;
+      method?: string;
+      pathTemplate?: string;
+      backendCode?: string;
+    }
+  | { kind: 'error'; name: string; message: string; stack?: string }
+  | { kind: 'unknown'; repr: string };
+
+const MAX_MESSAGE = 500;
+const MAX_STACK = 4000;
+
+export interface HttpErrorContext {
+  method?: string;
+  pathTemplate?: string;
+}
+
+/**
+ * Strip URL query and fragment so blob slugs and history filters
+ * (`q`, `from`, `to`, `continuationToken`) never leak into telemetry.
+ */
+export function sanitizePath(rawUrl: string | null | undefined): string | undefined {
+  if (!rawUrl) {
+    return undefined;
+  }
+  const queryIdx = rawUrl.indexOf('?');
+  const hashIdx = rawUrl.indexOf('#');
+  let end = rawUrl.length;
+  if (queryIdx >= 0) {
+    end = Math.min(end, queryIdx);
+  }
+  if (hashIdx >= 0) {
+    end = Math.min(end, hashIdx);
+  }
+  return rawUrl.slice(0, end);
+}
+
+export function normalizeError(
+  err: unknown,
+  ctx?: HttpErrorContext
+): NormalizedError {
+  if (err instanceof HttpErrorResponse) {
+    let backendCode: string | undefined;
+    const body = err.error as unknown;
+    if (
+      body !== null &&
+      typeof body === 'object' &&
+      typeof (body as { code?: unknown }).code === 'string'
+    ) {
+      backendCode = (body as { code: string }).code;
+    }
+    return {
+      kind: 'http',
+      status: err.status,
+      statusText: err.statusText || undefined,
+      method: ctx?.method,
+      pathTemplate: ctx?.pathTemplate ?? sanitizePath(err.url ?? undefined),
+      backendCode
+    };
+  }
+
+  if (err instanceof Error) {
+    return {
+      kind: 'error',
+      name: err.name || 'Error',
+      message: redactPii(truncate(err.message ?? '', MAX_MESSAGE)),
+      stack: err.stack
+        ? redactPii(truncate(err.stack, MAX_STACK))
+        : undefined
+    };
+  }
+
+  return {
+    kind: 'unknown',
+    repr: typeof err === 'string'
+      ? redactPii(truncate(err, MAX_MESSAGE))
+      : `<non-error thrown: ${typeof err}>`
+  };
+}

--- a/src/app/core/telemetry/redact-pii.spec.ts
+++ b/src/app/core/telemetry/redact-pii.spec.ts
@@ -1,0 +1,67 @@
+import { extractAadCode, redactPii, truncate } from './redact-pii';
+
+describe('redactPii', () => {
+  it('replaces a plain email', () => {
+    expect(redactPii('login failed for alice@example.com today')).toBe(
+      'login failed for <email> today'
+    );
+  });
+
+  it('replaces multiple emails', () => {
+    expect(redactPii('a@b.co and c.d+tag@e-f.io')).toBe(
+      '<email> and <email>'
+    );
+  });
+
+  it('replaces UPN-style identifiers in MSAL prose', () => {
+    const out = redactPii(
+      "AADSTS50058: Session info is not sufficient for user 'alice@contoso.onmicrosoft.com'"
+    );
+    expect(out).not.toContain('alice@contoso.onmicrosoft.com');
+    expect(out).toContain('<email>');
+  });
+
+  it('preserves GUIDs', () => {
+    const guid = 'aeeb2cf4-5305-4a6f-85e6-6b97d75bd259';
+    expect(redactPii(`oid=${guid}`)).toContain(guid);
+  });
+
+  it('handles empty / undefined input safely', () => {
+    expect(redactPii('')).toBe('');
+  });
+
+  it('is approximately idempotent', () => {
+    const once = redactPii('hello bob@x.io');
+    expect(redactPii(once)).toBe(once);
+  });
+});
+
+describe('extractAadCode', () => {
+  it('extracts AADSTS code', () => {
+    expect(extractAadCode('AADSTS50058: blah blah')).toBe('AADSTS50058');
+  });
+
+  it('returns undefined when absent', () => {
+    expect(extractAadCode('generic error')).toBeUndefined();
+  });
+
+  it('returns the first match when multiple present', () => {
+    expect(extractAadCode('AADSTS70011 and later AADSTS50058')).toBe(
+      'AADSTS70011'
+    );
+  });
+});
+
+describe('truncate', () => {
+  it('returns input unchanged when within limit', () => {
+    expect(truncate('short', 10)).toBe('short');
+  });
+
+  it('truncates and appends ellipsis', () => {
+    expect(truncate('abcdefghij', 5)).toBe('abcd\u2026');
+  });
+
+  it('handles empty input', () => {
+    expect(truncate('', 5)).toBe('');
+  });
+});

--- a/src/app/core/telemetry/redact-pii.ts
+++ b/src/app/core/telemetry/redact-pii.ts
@@ -1,0 +1,53 @@
+/**
+ * PII redaction helpers for telemetry.
+ *
+ * The JotJSON privacy stance forbids transmitting user emails, UPNs, or
+ * other personally identifying strings. MSAL error messages and stack
+ * traces can include these incidentally; this module scrubs them before
+ * any string is forwarded to App Insights.
+ *
+ * GUIDs are intentionally NOT redacted - they are the opaque identifiers
+ * we rely on (e.g. Entra `oid` for `setUser`, AAD correlation IDs).
+ */
+
+const EMAIL_PATTERN = /[\w.+-]+@[\w-]+(?:\.[\w-]+)+/g;
+// AAD UPN-style identifiers can also appear as `user@tenant.onmicrosoft.com`
+// which the email regex already catches. Add a bare-UPN pattern for cases
+// where the host portion was already replaced or where MSAL emits the
+// `name@host` shape inside structured strings.
+const UPN_PATTERN = /(^|[\s'"<(])([a-zA-Z0-9._-]+)@(?=[a-zA-Z0-9.-]*\.)/g;
+
+const AADSTS_PATTERN = /AADSTS\d{4,}/;
+
+/**
+ * Replace email/UPN substrings with `<email>`. Idempotent - calling on an
+ * already-redacted string is a no-op for the redacted spans.
+ */
+export function redactPii(input: string): string {
+  if (!input) {
+    return input;
+  }
+  return input
+    .replace(EMAIL_PATTERN, '<email>')
+    .replace(UPN_PATTERN, (_match, prefix) => `${prefix}<user>@`);
+}
+
+/**
+ * Extract the first `AADSTS\d+` code from a string, if present. Useful for
+ * routing MSAL telemetry into a structured `props.aadCode` field.
+ */
+export function extractAadCode(input: string): string | undefined {
+  const match = AADSTS_PATTERN.exec(input);
+  return match ? match[0] : undefined;
+}
+
+/** Truncate a string to at most `max` characters; appends an ellipsis. */
+export function truncate(input: string, max: number): string {
+  if (!input) {
+    return input;
+  }
+  if (input.length <= max) {
+    return input;
+  }
+  return `${input.slice(0, max - 1)}\u2026`;
+}

--- a/src/app/core/telemetry/route-tracker.spec.ts
+++ b/src/app/core/telemetry/route-tracker.spec.ts
@@ -1,0 +1,92 @@
+import { TestBed } from '@angular/core/testing';
+import { Subject } from 'rxjs';
+import { NavigationEnd, Router } from '@angular/router';
+import { RouteTracker } from './route-tracker';
+import { TelemetryService } from './telemetry.service';
+
+describe('RouteTracker', () => {
+  let events: Subject<unknown>;
+  let trackPageView: jasmine.Spy;
+  let isConnected = false;
+  let routerStub: Partial<Router>;
+  let tracker: RouteTracker;
+
+  function makeRouter(routePath: string | undefined) {
+    events = new Subject<unknown>();
+    const snapshotRoot: { routeConfig: { path?: string } | null; firstChild: unknown | null } = {
+      routeConfig: routePath !== undefined ? { path: routePath } : null,
+      firstChild: null
+    };
+    routerStub = {
+      events: events.asObservable() as unknown as Router['events'],
+      routerState: { snapshot: { root: snapshotRoot } } as unknown as Router['routerState']
+    };
+  }
+
+  function init(connected: boolean, routePath: string | undefined = '') {
+    isConnected = connected;
+    makeRouter(routePath);
+    trackPageView = jasmine.createSpy('trackPageView');
+    const telemetryStub: Partial<TelemetryService> = {
+      get isConnected() {
+        return isConnected;
+      },
+      trackPageView
+    };
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: Router, useValue: routerStub },
+        { provide: TelemetryService, useValue: telemetryStub }
+      ]
+    });
+    tracker = TestBed.inject(RouteTracker);
+    tracker.start();
+  }
+
+  function fireNav(url: string): void {
+    events.next(new NavigationEnd(1, url, url));
+  }
+
+  it('emits trackPageView on NavigationEnd when connected', () => {
+    init(true, 's/:slug');
+    fireNav('/s/abc123');
+    expect(trackPageView).toHaveBeenCalledWith('/s/:slug', '/s/abc123');
+  });
+
+  it('strips query and fragment from the uri', () => {
+    init(true, '');
+    fireNav('/?source=share#x');
+    expect(trackPageView).toHaveBeenCalledWith('/', '/');
+  });
+
+  it('buffers when not connected and flushes on flushPending', () => {
+    init(false, 'history');
+    fireNav('/history');
+    expect(trackPageView).not.toHaveBeenCalled();
+    isConnected = true;
+    tracker.flushPending();
+    expect(trackPageView).toHaveBeenCalledWith('/history', '/history');
+  });
+
+  it('flushPending is a no-op when no pending route', () => {
+    init(true, '');
+    tracker.flushPending();
+    expect(trackPageView).not.toHaveBeenCalled();
+  });
+
+  it('start() is idempotent', () => {
+    init(true, '');
+    tracker.start();
+    tracker.start();
+    fireNav('/');
+    expect(trackPageView).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to URL when no route template is available', () => {
+    init(true, undefined);
+    fireNav('/strange');
+    // route template walked produced "/" (no segments); still emits
+    expect(trackPageView).toHaveBeenCalled();
+  });
+});

--- a/src/app/core/telemetry/route-tracker.ts
+++ b/src/app/core/telemetry/route-tracker.ts
@@ -12,7 +12,7 @@ import { TelemetryService } from './telemetry.service';
  *
  * Subscribes to the router and emits `trackPageView` calls using the
  * matched route's `path` template (e.g. `s/:slug`) instead of the raw
- * URL — this prevents the telemetry stream from fragmenting into one
+ * URL - this prevents the telemetry stream from fragmenting into one
  * series per blob slug.
  *
  * Because telemetry is connected lazily from `AppComponent.ngOnInit`,

--- a/src/app/core/telemetry/route-tracker.ts
+++ b/src/app/core/telemetry/route-tracker.ts
@@ -1,0 +1,94 @@
+import { Injectable, inject } from '@angular/core';
+import {
+  ActivatedRouteSnapshot,
+  NavigationEnd,
+  Router
+} from '@angular/router';
+import { filter } from 'rxjs/operators';
+import { TelemetryService } from './telemetry.service';
+
+/**
+ * Manual page-view tracker.
+ *
+ * Subscribes to the router and emits `trackPageView` calls using the
+ * matched route's `path` template (e.g. `s/:slug`) instead of the raw
+ * URL — this prevents the telemetry stream from fragmenting into one
+ * series per blob slug.
+ *
+ * Because telemetry is connected lazily from `AppComponent.ngOnInit`,
+ * the very first `NavigationEnd` may fire before `TelemetryService`
+ * has loaded the SDK. We stash the most recent route in a single-slot
+ * field; when telemetry becomes ready, the next call to `flushPending`
+ * (invoked from `LoggerService.connect`) emits a bootstrap pageView
+ * for the captured route.
+ */
+@Injectable({ providedIn: 'root' })
+export class RouteTracker {
+  private readonly router = inject(Router);
+  private readonly telemetry = inject(TelemetryService);
+  private pending: { name: string; uri: string } | null = null;
+  private started = false;
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe((evt) => this.handleNavigation(evt));
+  }
+
+  /**
+   * Emit any pending pageView captured before telemetry was connected.
+   * Safe to call multiple times.
+   */
+  flushPending(): void {
+    if (!this.telemetry.isConnected || !this.pending) {
+      return;
+    }
+    const { name, uri } = this.pending;
+    this.pending = null;
+    this.telemetry.trackPageView(name, uri);
+  }
+
+  private handleNavigation(evt: NavigationEnd): void {
+    const uri = this.stripQuery(evt.urlAfterRedirects);
+    const name = this.routeTemplate(this.router.routerState.snapshot.root) ?? uri;
+    if (this.telemetry.isConnected) {
+      this.telemetry.trackPageView(name, uri);
+    } else {
+      this.pending = { name, uri };
+    }
+  }
+
+  private stripQuery(url: string): string {
+    const q = url.indexOf('?');
+    const h = url.indexOf('#');
+    let end = url.length;
+    if (q >= 0) end = Math.min(end, q);
+    if (h >= 0) end = Math.min(end, h);
+    return url.slice(0, end);
+  }
+
+  /**
+   * Walk the activated-route tree and reassemble the matched template
+   * (e.g. `/s/:slug`). Returns `undefined` when no template segments
+   * are present (root navigation).
+   */
+  private routeTemplate(root: ActivatedRouteSnapshot): string | undefined {
+    const segments: string[] = [];
+    let cursor: ActivatedRouteSnapshot | null = root;
+    while (cursor) {
+      const path = cursor.routeConfig?.path;
+      if (path !== undefined && path !== '') {
+        segments.push(path);
+      }
+      cursor = cursor.firstChild;
+    }
+    if (segments.length === 0) {
+      return '/';
+    }
+    return '/' + segments.join('/');
+  }
+}

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -1,0 +1,48 @@
+/**
+ * Centralized telemetry message IDs.
+ *
+ * Every call to `LoggerService.info/warn/error` MUST use one of these
+ * tokens. They are intentionally English, stable across locales, and
+ * typed as a literal-union so typos fail at compile time and we don't
+ * fragment telemetry across slight variants of the same id.
+ */
+export const TELEMETRY_MESSAGE_IDS = [
+  // Generic
+  'app.unhandled',
+  'boot.failed',
+
+  // HTTP / API
+  'api.error',
+
+  // Service worker / updates
+  'update.activate.failed',
+  'update.unrecoverable',
+
+  // Editor
+  'monaco.loadFailed',
+
+  // Home / share
+  'home.save.failed',
+  'home.upload.tooLarge',
+  'share.visibility.failed',
+  'share.delete.failed',
+
+  // Blobs
+  'blobs.load.failed',
+
+  // History
+  'history.load.failed',
+  'history.loadMore.failed',
+  'history.clear.failed',
+  'history.delete.failed',
+  'history.open.failed',
+  'history.recordPaste.failed',
+
+  // Blobs
+  'blobs.copyLink.failed',
+
+  // Auth
+  'msal.error'
+] as const;
+
+export type TelemetryMessageId = (typeof TELEMETRY_MESSAGE_IDS)[number];

--- a/src/app/core/telemetry/telemetry.service.spec.ts
+++ b/src/app/core/telemetry/telemetry.service.spec.ts
@@ -1,0 +1,82 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { environment } from '../../../environments/environment';
+import { TelemetryService } from './telemetry.service';
+import { normalizeError } from './normalize-error';
+
+describe('TelemetryService', () => {
+  let originalCs: string | undefined;
+
+  beforeEach(() => {
+    originalCs = environment.appInsightsConnectionString;
+  });
+
+  afterEach(() => {
+    environment.appInsightsConnectionString = originalCs;
+  });
+
+  function make(): TelemetryService {
+    TestBed.resetTestingModule();
+    return TestBed.inject(TelemetryService);
+  }
+
+  it('disables when connection string is empty', async () => {
+    environment.appInsightsConnectionString = '';
+    const svc = make();
+    await svc.connect();
+    expect(svc.connectState).toBe('disabled');
+    expect(svc.isConnected).toBeFalse();
+    expect(svc.isDisabled).toBeTrue();
+  });
+
+  it('disables when connection string is whitespace only', async () => {
+    environment.appInsightsConnectionString = '   ';
+    const svc = make();
+    await svc.connect();
+    expect(svc.connectState).toBe('disabled');
+  });
+
+  it('connect() is idempotent', async () => {
+    environment.appInsightsConnectionString = '';
+    const svc = make();
+    const a = svc.connect();
+    const b = svc.connect();
+    expect(a).toBe(b);
+    await a;
+    await svc.connect();
+    expect(svc.connectState).toBe('disabled');
+  });
+
+  it('track* methods are no-ops when disabled', async () => {
+    environment.appInsightsConnectionString = '';
+    const svc = make();
+    await svc.connect();
+    expect(() => svc.trackEvent('app.unhandled')).not.toThrow();
+    expect(() =>
+      svc.trackException(normalizeError(new Error('x')))
+    ).not.toThrow();
+    expect(() => svc.trackPageView('Home', '/')).not.toThrow();
+  });
+
+  it('caches setUser before connect; applies safely after disabled', async () => {
+    environment.appInsightsConnectionString = '';
+    const svc = make();
+    svc.setUser('aeeb2cf4-5305-4a6f-85e6-6b97d75bd259');
+    await svc.connect();
+    // Should be disabled, so no SDK to apply to - but no throw either.
+    expect(svc.isDisabled).toBeTrue();
+  });
+
+  it('normalizeError + trackException accepts http errors', async () => {
+    environment.appInsightsConnectionString = '';
+    const svc = make();
+    await svc.connect();
+    const err = new HttpErrorResponse({
+      url: '/api/x?secret=yes',
+      status: 500
+    });
+    expect(() =>
+      svc.trackException(normalizeError(err, { method: 'GET' }))
+    ).not.toThrow();
+  });
+});

--- a/src/app/core/telemetry/telemetry.service.ts
+++ b/src/app/core/telemetry/telemetry.service.ts
@@ -1,0 +1,281 @@
+import { Injectable } from '@angular/core';
+import type {
+  ApplicationInsights,
+  ITelemetryItem
+} from '@microsoft/applicationinsights-web';
+import { environment } from '../../../environments/environment';
+import { NormalizedError, sanitizePath } from './normalize-error';
+import { TelemetryMessageId } from './telemetry-message-ids';
+
+export type TelemetryProps = Readonly<
+  Record<string, string | number | boolean | undefined>
+>;
+
+export type ConnectState = 'idle' | 'connecting' | 'connected' | 'disabled';
+
+/**
+ * Severity used by callers. Mapped to App Insights `SeverityLevel`
+ * inside `trackTrace` so this module never has to import the SDK
+ * statically (which would pull it into the eager bundle).
+ *
+ * Mapping: info=1, warn=2, error=3.
+ */
+export type TelemetrySeverity = 'info' | 'warn' | 'error';
+
+/**
+ * Thin wrapper around `@microsoft/applicationinsights-web`.
+ *
+ * The SDK is dynamically imported on first `connect()` so the ~80 kB
+ * bundle stays out of `main-*.js`. A telemetry initializer enforces our
+ * privacy contract on every envelope (strip query/fragment, drop
+ * envelopes still containing `?`, redact `Authorization`, disable
+ * cookies).
+ *
+ * The service is safe to inject at construction time: it does not load
+ * the SDK until `connect()` is called, and all `track*` methods buffer
+ * via `LoggerService` when called before connect.
+ */
+@Injectable({ providedIn: 'root' })
+export class TelemetryService {
+  private appInsights: ApplicationInsights | null = null;
+  private state: ConnectState = 'idle';
+  // Tri-state: `undefined` = no setUser call yet, `null` = clear, string = set.
+  private pendingOid: string | null | undefined = undefined;
+  private connectPromise: Promise<void> | null = null;
+
+  get connectState(): ConnectState {
+    return this.state;
+  }
+
+  get isConnected(): boolean {
+    return this.state === 'connected';
+  }
+
+  get isDisabled(): boolean {
+    return this.state === 'disabled';
+  }
+
+  /**
+   * Idempotent. Resolves once telemetry is connected OR permanently
+   * disabled (in which case subsequent `track*` calls are no-ops).
+   */
+  connect(): Promise<void> {
+    if (this.connectPromise) {
+      return this.connectPromise;
+    }
+    const cs = environment.appInsightsConnectionString?.trim();
+    if (!cs) {
+      this.state = 'disabled';
+      this.connectPromise = Promise.resolve();
+      return this.connectPromise;
+    }
+    this.state = 'connecting';
+    this.connectPromise = this.loadAndInit(cs).catch((err) => {
+      this.state = 'disabled';
+      // eslint-disable-next-line no-console
+      console.warn('[telemetry] connect failed; telemetry disabled', err);
+    });
+    return this.connectPromise;
+  }
+
+  setUser(oid: string | null): void {
+    if (this.appInsights && this.state === 'connected') {
+      this.applyUser(oid);
+    } else {
+      this.pendingOid = oid;
+    }
+  }
+
+  trackEvent(name: TelemetryMessageId, props?: TelemetryProps): void {
+    if (!this.appInsights) {
+      return;
+    }
+    this.appInsights.trackEvent({ name }, this.toCustomProps(props));
+  }
+
+  trackTrace(
+    name: TelemetryMessageId,
+    severity: TelemetrySeverity,
+    props?: TelemetryProps
+  ): void {
+    if (!this.appInsights) {
+      return;
+    }
+    // SeverityLevel: Information=1, Warning=2, Error=3.
+    const severityLevel =
+      severity === 'error' ? 3 : severity === 'warn' ? 2 : 1;
+    this.appInsights.trackTrace(
+      { message: name, severityLevel },
+      this.toCustomProps(props)
+    );
+  }
+
+  trackException(error: NormalizedError, props?: TelemetryProps): void {
+    if (!this.appInsights) {
+      return;
+    }
+    const synthetic = this.toSyntheticError(error);
+    this.appInsights.trackException(
+      { exception: synthetic },
+      this.toCustomProps({ ...props, ...this.errorProps(error) })
+    );
+  }
+
+  trackPageView(name: string, uri: string): void {
+    if (!this.appInsights) {
+      return;
+    }
+    const sanitized = sanitizePath(uri) ?? uri;
+    this.appInsights.trackPageView({ name, uri: sanitized });
+  }
+
+  // --- internals ---
+
+  private async loadAndInit(connectionString: string): Promise<void> {
+    // Dynamic import keeps the SDK in a lazy chunk. Do not statically
+    // import `@microsoft/applicationinsights-web` from this file.
+    const { ApplicationInsights: AI } = await import(
+      '@microsoft/applicationinsights-web'
+    );
+    const ai = new AI({
+      config: {
+        connectionString,
+        // Manual instrumentation policy (see DESIGN_SPEC Telemetry).
+        disableExceptionTracking: true,
+        disableAjaxTracking: false,
+        enableAutoRouteTracking: false,
+        enableAjaxErrorStatusText: false,
+        enableAjaxPerfTracking: false,
+        disableCookiesUsage: true,
+        // Keep correlation between SPA and same-origin Functions.
+        enableCorsCorrelation: true,
+        distributedTracingMode: 2 /* W3C */
+      }
+    });
+    ai.loadAppInsights();
+    ai.addTelemetryInitializer(this.privacyInitializer);
+    this.appInsights = ai;
+    this.state = 'connected';
+
+    // Apply pending sign-in / sign-out, if any.
+    if (this.pendingOid !== undefined) {
+      this.applyUser(this.pendingOid);
+      this.pendingOid = undefined;
+    }
+  }
+
+  private privacyInitializer = (item: ITelemetryItem): boolean | void => {
+    const data = item.data ?? {};
+    // Sanitize any uri-like field that the SDK populates.
+    const fields: Array<keyof typeof data> = ['uri', 'refUri', 'url'];
+    for (const f of fields) {
+      const v = data[f];
+      if (typeof v === 'string') {
+        data[f] = sanitizePath(v);
+      }
+    }
+    if (item.baseData) {
+      const bd = item.baseData;
+      if (typeof bd['uri'] === 'string') {
+        bd['uri'] = sanitizePath(bd['uri'] as string);
+      }
+      if (typeof bd['target'] === 'string') {
+        // Dependency `target` is the host - safe. Dependency `name`
+        // is `${METHOD} ${url}` - sanitize the second token.
+      }
+      if (typeof bd['name'] === 'string') {
+        bd['name'] = this.sanitizeDependencyName(bd['name'] as string);
+      }
+      // Defense in depth: any name containing `?` after sanitization
+      // means a query slipped past us. Drop the envelope rather than
+      // ship it.
+      const dropFields: string[] = ['uri', 'name', 'url'];
+      for (const f of dropFields) {
+        const v = bd[f];
+        if (typeof v === 'string' && v.includes('?')) {
+          return false;
+        }
+      }
+    }
+    // Redact Authorization header if any envelope echoes it.
+    const props = item.data;
+    if (props && typeof props['Authorization'] === 'string') {
+      props['Authorization'] = '<redacted>';
+    }
+    item.data = data;
+    return undefined;
+  };
+
+  private sanitizeDependencyName(name: string): string {
+    // Format is typically "GET /api/foo?bar=1" - sanitize the URL part.
+    const space = name.indexOf(' ');
+    if (space < 0) {
+      return name;
+    }
+    const verb = name.slice(0, space);
+    const rest = name.slice(space + 1);
+    return `${verb} ${sanitizePath(rest) ?? rest}`;
+  }
+
+  private applyUser(oid: string | null): void {
+    if (!this.appInsights) {
+      return;
+    }
+    if (oid) {
+      this.appInsights.setAuthenticatedUserContext(oid);
+    } else {
+      this.appInsights.clearAuthenticatedUserContext();
+    }
+  }
+
+  private toCustomProps(props?: TelemetryProps): Record<string, string> | undefined {
+    if (!props) {
+      return undefined;
+    }
+    const out: Record<string, string> = {};
+    for (const [k, v] of Object.entries(props)) {
+      if (v === undefined) {
+        continue;
+      }
+      out[k] = String(v);
+    }
+    return out;
+  }
+
+  private toSyntheticError(err: NormalizedError): Error {
+    if (err.kind === 'http') {
+      const e = new Error(
+        `HTTP ${err.status} ${err.method ?? ''} ${err.pathTemplate ?? ''}`.trim()
+      );
+      e.name = 'HttpError';
+      return e;
+    }
+    if (err.kind === 'error') {
+      const e = new Error(err.message);
+      e.name = err.name;
+      if (err.stack) {
+        e.stack = err.stack;
+      }
+      return e;
+    }
+    const e = new Error(err.repr);
+    e.name = 'UnknownThrow';
+    return e;
+  }
+
+  private errorProps(err: NormalizedError): TelemetryProps {
+    if (err.kind === 'http') {
+      return {
+        kind: 'http',
+        status: err.status,
+        method: err.method,
+        pathTemplate: err.pathTemplate,
+        backendCode: err.backendCode
+      };
+    }
+    if (err.kind === 'error') {
+      return { kind: 'error', name: err.name };
+    }
+    return { kind: 'unknown' };
+  }
+}

--- a/src/app/core/update/app-update.service.ts
+++ b/src/app/core/update/app-update.service.ts
@@ -2,6 +2,7 @@ import { Injectable, inject } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { SwUpdate, VersionReadyEvent } from '@angular/service-worker';
 import { filter } from 'rxjs/operators';
+import { LoggerService } from '../telemetry/logger.service';
 
 /**
  * Reacts to Angular service worker events so that a deploy-in-progress
@@ -25,6 +26,7 @@ import { filter } from 'rxjs/operators';
 export class AppUpdateService {
   private readonly swUpdate = inject(SwUpdate);
   private readonly snack = inject(MatSnackBar);
+  private readonly logger = inject(LoggerService);
   private initialized = false;
 
   initialize(): void {
@@ -41,10 +43,7 @@ export class AppUpdateService {
       .subscribe(() => this.promptReload());
 
     this.swUpdate.unrecoverable.subscribe((event) => {
-      console.warn(
-        $localize`:@@update.unrecoverable.log:Service worker entered unrecoverable state; hard-reloading`,
-        event.reason
-      );
+      this.logger.warn('update.unrecoverable', { reason: event.reason });
       this.hardReload();
     });
   }
@@ -66,10 +65,8 @@ export class AppUpdateService {
     } catch (err) {
       // Fall through to reload anyway - the fresh fetch will re-run the
       // install flow and any partial cache will be discarded.
-      console.warn(
-        $localize`:@@update.activate.failed.log:Failed to activate service worker update`,
-        err
-      );
+      this.logger.warn('update.activate.failed');
+      void err;
     }
     this.reload();
   }

--- a/src/app/features/blobs/blobs.component.ts
+++ b/src/app/features/blobs/blobs.component.ts
@@ -15,6 +15,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { firstValueFrom } from 'rxjs';
 import { BlobService } from '../../core/api/blob.service';
 import type { JsonBlob } from '../../core/api/models';
+import { LoggerService } from '../../core/telemetry/logger.service';
 import { SeoService } from '../../core/seo/seo.service';
 import { AppHeaderComponent } from '../../shared/components/app-header/app-header.component';
 import { IconComponent } from '../../shared/components/icon/icon.component';
@@ -45,6 +46,7 @@ export class BlobsComponent implements OnInit {
   private readonly snack = inject(MatSnackBar);
   private readonly router = inject(Router);
   private readonly seo = inject(SeoService);
+  private readonly logger = inject(LoggerService);
 
   readonly state = signal<LoadState>('loading');
   readonly blobList = signal<JsonBlob[]>([]);
@@ -71,7 +73,8 @@ export class BlobsComponent implements OnInit {
       this.blobList.set(sorted);
       this.state.set('ready');
     } catch (err) {
-      console.warn($localize`:@@blobs.load.failed.log:Failed to load blobs`, err);
+      this.logger.warn('blobs.load.failed');
+      void err;
       this.errorMessage.set(
         $localize`:@@blobs.load.failed:Failed to load your saved blobs.`
       );
@@ -114,10 +117,8 @@ export class BlobsComponent implements OnInit {
         { duration: 3000 }
       );
     } catch (err) {
-      console.warn(
-        $localize`:@@blobs.copyLink.failed.log:Failed to copy blob link`,
-        err
-      );
+      this.logger.warn('blobs.copyLink.failed');
+      void err;
       this.snack.open(
         $localize`:@@blobs.copyLink.failed:Failed to copy link`,
         $localize`:@@common.dismiss:Dismiss`,
@@ -150,7 +151,8 @@ export class BlobsComponent implements OnInit {
         { duration: 3000 }
       );
     } catch (err) {
-      console.warn($localize`:@@share.delete.failed.log:Failed to delete blob`, err);
+      this.logger.warn('share.delete.failed');
+      void err;
       this.snack.open(
         $localize`:@@share.delete.failed:Failed to delete blob.`,
         $localize`:@@common.dismiss:Dismiss`,

--- a/src/app/features/history/history.component.ts
+++ b/src/app/features/history/history.component.ts
@@ -21,6 +21,7 @@ import { MatTooltipModule } from '@angular/material/tooltip';
 import { Subject, debounceTime, distinctUntilChanged, firstValueFrom } from 'rxjs';
 import { HistoryService } from '../../core/api/history.service';
 import type { HistoryAction, HistoryEntry } from '../../core/api/models';
+import { LoggerService } from '../../core/telemetry/logger.service';
 import { SeoService } from '../../core/seo/seo.service';
 import { AppHeaderComponent } from '../../shared/components/app-header/app-header.component';
 import { IconComponent, JjIconName } from '../../shared/components/icon/icon.component';
@@ -67,6 +68,7 @@ export class HistoryComponent implements OnInit, AfterViewInit, OnDestroy {
   private readonly snack = inject(MatSnackBar);
   private readonly router = inject(Router);
   private readonly seo = inject(SeoService);
+  private readonly logger = inject(LoggerService);
 
   readonly state = signal<LoadState>('loading');
   readonly entries = signal<HistoryEntry[]>([]);
@@ -227,10 +229,8 @@ export class HistoryComponent implements OnInit, AfterViewInit, OnDestroy {
       this.continuationToken.set(page.continuationToken);
       this.state.set('ready');
     } catch (err) {
-      console.warn(
-        $localize`:@@history.load.failed.log:Failed to load history`,
-        err
-      );
+      this.logger.warn('history.load.failed');
+      void err;
       this.errorMessage.set(
         $localize`:@@history.load.failed:Failed to load your history.`
       );
@@ -254,10 +254,8 @@ export class HistoryComponent implements OnInit, AfterViewInit, OnDestroy {
       this.entries.update((current) => [...current, ...page.entries]);
       this.continuationToken.set(page.continuationToken);
     } catch (err) {
-      console.warn(
-        $localize`:@@history.loadMore.failed.log:Failed to load more history`,
-        err
-      );
+      this.logger.warn('history.loadMore.failed');
+      void err;
       this.snack.open(
         $localize`:@@history.loadMore.failed:Failed to load more history.`,
         $localize`:@@common.dismiss:Dismiss`,
@@ -395,10 +393,8 @@ export class HistoryComponent implements OnInit, AfterViewInit, OnDestroy {
         { duration: 3000 }
       );
     } catch (err) {
-      console.warn(
-        $localize`:@@history.clear.failed.log:Failed to clear history`,
-        err
-      );
+      this.logger.warn('history.clear.failed');
+      void err;
       this.snack.open(
         $localize`:@@history.clear.failed:Failed to clear history.`,
         $localize`:@@common.dismiss:Dismiss`,

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -30,6 +30,7 @@ import { BlobService } from '../../core/api/blob.service';
 import { HistoryService } from '../../core/api/history.service';
 import type { CreateBlobResponse, JsonBlob } from '../../core/api/models';
 import { DraftService } from '../../core/preferences/draft.service';
+import { LoggerService } from '../../core/telemetry/logger.service';
 import { SeoService } from '../../core/seo/seo.service';
 import { PreferencesService } from '../../core/preferences/preferences.service';
 import { QuotaNotificationService } from '../../core/quota/quota-notification.service';
@@ -88,6 +89,7 @@ export class HomeComponent {
   private readonly dialog = inject(MatDialog);
   private readonly snack = inject(MatSnackBar);
   private readonly clipboard = inject(ClipboardPollingService);
+  private readonly logger = inject(LoggerService);
 
   /**
    * Blob hydrated by the /s/:slug resolver. When present, the editor starts
@@ -367,10 +369,8 @@ export class HomeComponent {
     if (!this.auth.isConfigured || !this.auth.isSignedIn()) return;
     this.history.recordPaste().subscribe({
       error: (err) => {
-        console.warn(
-          $localize`:@@history.recordPaste.failed.log:Failed to record paste in history`,
-          err
-        );
+        this.logger.warn('history.recordPaste.failed');
+        void err;
       }
     });
   }
@@ -405,7 +405,7 @@ export class HomeComponent {
   async onUpload(file: File): Promise<void> {
     const MAX = 5 * 1024 * 1024;
     if (file.size > MAX) {
-      console.warn($localize`:@@upload.tooLarge.log:File too large (max 5 MB)`);
+      this.logger.warn('home.upload.tooLarge', { size: file.size });
       return;
     }
     const text = await file.text();
@@ -498,7 +498,8 @@ export class HomeComponent {
       }
       const message = this.formatSaveError(err);
       this.saveError.set(message);
-      console.warn($localize`:@@save.failed.log:Save failed`, err);
+      this.logger.warn('home.save.failed');
+      void err;
     } finally {
       this.saveInFlight.set(false);
     }
@@ -608,7 +609,8 @@ export class HomeComponent {
         : $localize`:@@share.visibility.private:Blob is now private.`;
       this.snack.open(message, $localize`:@@common.dismiss:Dismiss`, { duration: 3000 });
     } catch (err) {
-      console.warn($localize`:@@share.visibility.failed.log:Failed to update visibility`, err);
+      this.logger.warn('share.visibility.failed');
+      void err;
       this.snack.open(
         $localize`:@@share.visibility.failed:Failed to update visibility.`,
         $localize`:@@common.dismiss:Dismiss`,
@@ -650,7 +652,8 @@ export class HomeComponent {
       );
       void this.router.navigate(['/']);
     } catch (err) {
-      console.warn($localize`:@@share.delete.failed.log:Failed to delete blob`, err);
+      this.logger.warn('share.delete.failed');
+      void err;
       this.snack.open(
         $localize`:@@share.delete.failed:Failed to delete blob.`,
         $localize`:@@common.dismiss:Dismiss`,

--- a/src/app/shared/components/json-editor/json-editor.component.ts
+++ b/src/app/shared/components/json-editor/json-editor.component.ts
@@ -17,6 +17,7 @@ import {
 import type * as MonacoNS from 'monaco-editor';
 import { JsonParseError, JsonParserService } from '../../../core/json/json-parser.service';
 import { PreferencesService } from '../../../core/preferences/preferences.service';
+import { LoggerService } from '../../../core/telemetry/logger.service';
 import { loadMonaco } from './monaco-loader';
 
 @Component({
@@ -31,6 +32,7 @@ export class JsonEditorComponent implements AfterViewInit, OnDestroy {
   private readonly parser = inject(JsonParserService);
   private readonly zone = inject(NgZone);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly logger = inject(LoggerService);
 
   readonly value = input<string>('');
   readonly errors = input<JsonParseError[]>([]);
@@ -89,7 +91,7 @@ export class JsonEditorComponent implements AfterViewInit, OnDestroy {
     try {
       monaco = await loadMonaco();
     } catch (err) {
-      console.error('JotJSON: Monaco failed to load', err);
+      this.logger.error('monaco.loadFailed', err);
       return;
     }
     this.monaco = monaco;

--- a/src/environments/environment.example.ts
+++ b/src/environments/environment.example.ts
@@ -15,5 +15,6 @@ export const environment: Environment = {
     redirectUri: 'http://localhost:4200/',
     postLogoutRedirectUri: 'http://localhost:4200/',
     scopes: []
-  }
+  },
+  appInsightsConnectionString: ''
 };

--- a/src/environments/environment.interface.ts
+++ b/src/environments/environment.interface.ts
@@ -18,4 +18,10 @@ export interface Environment {
      */
     scopes: string[];
   };
+  /**
+   * Application Insights connection string. When empty, telemetry is
+   * disabled (typical for local development and CI). Production builds
+   * receive this via CD secret substitution into `environment.prod.ts`.
+   */
+  appInsightsConnectionString?: string;
 }

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -10,5 +10,6 @@ export const environment: Environment = {
     redirectUri: 'https://jotjson.com/',
     postLogoutRedirectUri: 'https://jotjson.com/',
     scopes: []
-  }
+  },
+  appInsightsConnectionString: ''
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -4,5 +4,27 @@ import { bootstrapApplication } from '@angular/platform-browser';
 import { appConfig } from './app/app.config';
 import { AppComponent } from './app/app.component';
 
-bootstrapApplication(AppComponent, appConfig)
-  .catch((err) => console.error(err));
+bootstrapApplication(AppComponent, appConfig).catch((err: unknown) => {
+  // Pre-Angular bootstrap failures land here. Persist a sanitized
+  // record to sessionStorage so `LoggerService.connect()` can replay
+  // it as a `boot.failed` exception once telemetry comes online -
+  // assuming Angular itself eventually bootstraps. If it doesn't,
+  // there is nothing else we can do from outside the framework.
+  try {
+    const name = err instanceof Error ? err.name || 'Error' : 'BootError';
+    const message =
+      err instanceof Error
+        ? (err.message ?? '').slice(0, 500)
+        : '<non-error thrown at bootstrap>';
+    sessionStorage.setItem(
+      'jotjson.bootErr',
+      JSON.stringify({ name, message })
+    );
+  } catch {
+    // sessionStorage may be unavailable (privacy mode); ignore.
+  }
+  // Always surface to DevTools so dev-time bootstrap failures are
+  // discoverable without telemetry.
+  // eslint-disable-next-line no-console
+  console.error(err);
+});


### PR DESCRIPTION
## Summary

Wires Azure Application Insights telemetry into the JotJSON SPA. The AI resource is already provisioned by Bicep and the Functions backend has been auto-instrumented since day one; this PR closes the loop on the SPA side.

## What ships

- `src/app/core/telemetry/` primitives:
  - `TelemetryService` - wrapper around `@microsoft/applicationinsights-web`, dynamically imported on `connect()` so the SDK lives in a lazy chunk (verified: `main.js` is 6.99 kB).
  - `LoggerService` - public facade. State machine (idle/connecting/connected/disabled), FIFO buffer (cap 100), session-storage boot-error flush, MSAL bridge consumer.
  - `TelemetryErrorHandler` - registered as Angular `ErrorHandler` with reentrancy guard.
  - `route-tracker` - emits page views from `NavigationEnd` using the matched Angular **route template** (e.g. `/s/:slug`), never the raw URL.
  - `normalize-error` + `redact-pii` - strict whitelist for `HttpErrorResponse` (status / method / pathTemplate / backendCode), email/UPN/AADSTS scrubbing, truncation.
  - `msal-bridge` - module-scoped buffer so the MSAL factory can publish errors without injecting Angular DI.
  - `telemetry-message-ids` - frozen literal-union of stable IDs (typos fail at compile time).
- Migrated ~15 `console.warn`/`console.error` sites across home / blobs / history / app-update / json-editor / interceptors to `logger.warn`/`logger.error` with structured props.
- `AuthService` calls `setUser(oid)` on sign-in / `null` on sign-out (Entra `oid` only - never email or UPN).
- `main.ts` bootstrap-failure catch persists `{name, message}` to `sessionStorage['jotjson.bootErr']` for replay as `boot.failed` once telemetry comes online.
- CD workflow substitutes `APP_INSIGHTS_CONNECTION_STRING` into `environment.prod.ts`.
- Production builds emit **hidden** sourcemaps; CD strips `*.map` files before SWA upload.
- Initial bundle budget tightened: `500/1024 kB` -> `700/720 kB` (build measures 692.85 kB).
- New **Telemetry & Logging** section in `DESIGN_SPEC.md` covering data we collect, data we deliberately do not, MSAL bridge, sampling, sourcemaps, CSP allowlist, and West US 2 data residency note.

## Privacy guardrails

We deliberately do not collect: editor / clipboard content, URL query strings or fragments, request / response bodies, `Authorization` headers (redacted in the privacy initializer as defense in depth), cookies, email / UPN / display name, or any free-form user identifier other than the Entra `oid`. See DESIGN_SPEC -> Telemetry & Logging.

## Pre-merge checklist (action required)

- [ ] **Set repo secret `APP_INSIGHTS_CONNECTION_STRING`** in **Settings -> Secrets and variables -> Actions**. Value: the connection string from the existing Application Insights resource (Azure portal -> AI resource -> Overview -> "Connection String"). Without this secret, deploys still succeed but the SPA ships with telemetry disabled (the SDK chunk is never fetched). The secret is intentionally optional in CD; there is no missing-secret guard on it.

## Post-merge / post-deploy verification

- [ ] After the first deploy with the secret set, open the App Insights resource -> Transaction search and confirm:
  - `boot.failed` traces are absent (or, if present, contain only sanitized name/message - no user content).
  - SPA page views show route templates (`/s/:slug`) rather than concrete slugs.
  - Dependency entries for `/api/*` correlate to Functions traces (same operation_Id).
  - No envelope contains a `?` in the URL/name fields.

## Known follow-ups (intentionally not in this PR)

- **Symbol upload to App Insights.** We emit hidden sourcemaps and strip them before SWA upload, so they are never served at the public origin, but they are also not yet uploaded to AI for symbolication. Until that lands, production stack traces will be minified. The plan called for uploading + deleting; I chose delete-only because the AI source-map uploader tooling is fragmented and adding it to CD touches a separate concern.

## Validation

- `npm run lint` - clean
- `npm test` - 421/421 pass
- `npm run build` - clean, no budget warnings, initial 692.85 kB
- `npm run check:ascii` - clean
