### PR TITLE
Remove production `as unknown as` casts

### DIFF
--- a/api/src/functions/me.ts
+++ b/api/src/functions/me.ts
@@ -60,9 +60,7 @@ export async function getMe(
     // stored docs have been re-saved.
     const normalized: UserDocument = {
       ...doc,
-      preferences: normalizeStoredPreferences(
-        doc.preferences as unknown as Record<string, unknown>
-      ) as unknown as UserDocument['preferences']
+      preferences: normalizeStoredPreferences(doc.preferences)
     };
     return { status: 200, jsonBody: normalized };
   } catch (err) {

--- a/api/src/shared/auth.ts
+++ b/api/src/shared/auth.ts
@@ -107,14 +107,21 @@ function getJwksClient(authority: string): JwksClientLike {
   if (testOverrideClient) return testOverrideClient;
   if (cachedClient && cachedAuthority === authority) return cachedClient;
   cachedAuthority = authority;
-  cachedClient = jwksClient({
+  const lib = jwksClient({
     jwksUri: buildJwksUri(authority),
     cache: true,
     cacheMaxEntries: 5,
     cacheMaxAge: 10 * 60 * 1000,
     rateLimit: true,
     jwksRequestsPerMinute: 10
-  }) as unknown as JwksClientLike;
+  });
+  // Wrap the library client in a narrow adapter so callers see only the
+  // single overload of `getSigningKey` that we actually use. The library's
+  // overloaded callback/promise signatures don't structurally match
+  // `JwksClientLike` directly.
+  cachedClient = {
+    getSigningKey: (kid: string) => lib.getSigningKey(kid)
+  };
   return cachedClient;
 }
 

--- a/api/src/shared/preferences.ts
+++ b/api/src/shared/preferences.ts
@@ -248,23 +248,23 @@ function coerceRecentlyViewedEnabled(raw: Record<string, unknown>): boolean {
  * read-time validation failure must never break `GET /api/me`. We only
  * patch the one field that changed shape.
  */
-export function normalizeStoredPreferences<T extends Record<string, unknown>>(
-  prefs: T
-): T & { recentlyViewedEnabled: boolean } {
-  const out: Record<string, unknown> = { ...prefs };
-  if (typeof out['recentlyViewedEnabled'] === 'boolean') {
-    // New field already present; drop the legacy one if it lingers.
-    delete out['historyTrackingMode'];
-    return out as T & { recentlyViewedEnabled: boolean };
+export function normalizeStoredPreferences(
+  prefs: UserPreferences
+): UserPreferences {
+  // Stored docs may include a legacy `historyTrackingMode` key that's
+  // not part of the current `UserPreferences` shape. Use an extended
+  // view to read and then strip it.
+  const view: UserPreferences & { historyTrackingMode?: unknown } = { ...prefs };
+  if (typeof view.recentlyViewedEnabled !== 'boolean') {
+    const legacy = view.historyTrackingMode;
+    // Both legacy values coerce to true. Anything else (missing or
+    // malformed) falls back to the new default of true.
+    view.recentlyViewedEnabled =
+      typeof legacy !== 'string' ||
+      (LEGACY_HISTORY_MODES as readonly string[]).includes(legacy);
   }
-  const legacy = out['historyTrackingMode'];
-  // Both legacy values coerce to true. Anything else (missing or
-  // malformed) falls back to the new default of true.
-  out['recentlyViewedEnabled'] =
-    typeof legacy !== 'string' ||
-    (LEGACY_HISTORY_MODES as readonly string[]).includes(legacy);
-  delete out['historyTrackingMode'];
-  return out as T & { recentlyViewedEnabled: boolean };
+  delete view.historyTrackingMode;
+  return view;
 }
 
 function assertEnum<T extends string>(


### PR DESCRIPTION
## Summary

The two production-code `as unknown as ...` double-casts can both be expressed cast-free. After this change, every `as unknown as` cast in the repo lives in a test file (canonical pattern for partial mocks).

## Changes

- **`api/src/shared/auth.ts`** -- replace the cast on `jwksClient(...)` with a small adapter object that implements `JwksClientLike` directly. The library's overloaded `getSigningKey` doesn't structurally match our narrow promise-only interface, so a one-line wrapper does the bridging instead of laundering the whole library type.
- **`api/src/shared/preferences.ts`** -- tighten `normalizeStoredPreferences` from `<T extends Record<string, unknown>>(prefs: T) => T & { recentlyViewedEnabled: boolean }` to `(prefs: UserPreferences) => UserPreferences`. The legacy `historyTrackingMode` field is read and deleted through a typed extended view (`UserPreferences & { historyTrackingMode?: unknown }`) rather than via `Record<string, unknown>` laundering.
- **`api/src/functions/me.ts`** -- the `GET /api/me` call site becomes `normalizeStoredPreferences(doc.preferences)` with no casts.

## Validation

- `npm run lint` (root + api) clean
- `npm test` (api): 168/168 pass
- `npm run test:ci` (root): 614 pass, 2 skipped
- `npm run build` succeeds
- `npm run check:ascii` clean

No behavior change.