### PR TITLE
Truth-up AGENTS.md conventions to match enforced reality

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,10 +59,13 @@ Place new code in the correct bucket:
   `undefined`).
 - Production code must have **zero** `as unknown as ...` casts. If you
   hit a structural mismatch, change the function signature or write a
-  narrow adapter object instead. Test files may use `as unknown as X`
-  for partial framework stubs (`HttpRequest`, `Router`, `SwUpdate`,
-  `MatSnackBarRef`, etc.) -- prefer `jasmine.SpyObj<T>` or
-  `Partial<T>` intermediaries when feasible.
+  narrow adapter object instead. Test files (`*.spec.ts`, `*.test.ts`)
+  and test-helper modules under `src/testing/` or named `*.testing.ts`
+  may use `as unknown as X` for partial framework stubs (`HttpRequest`,
+  `Router`, `SwUpdate`, `MatSnackBarRef`, etc.) -- prefer
+  `jasmine.SpyObj<T>` or `Partial<T>` intermediaries when feasible.
+  Tier-2 lint rules will treat `src/testing/**` and `*.testing.ts` as
+  test code, not production.
 - Production code must have **zero** `as any`. The single test-file
   occurrence is grandfathered; do not add more.
 - Test-only seams on production classes use the `__<verb>ForTesting`
@@ -95,7 +98,8 @@ Place new code in the correct bucket:
 - Logging: use `LoggerService` (`src/app/core/telemetry/logger.service.ts`)
   for any log a developer might consult. Direct `console.*` calls are
   permitted only in `src/app/core/telemetry/` and `src/main.ts` (early-
-  boot bootstrap errors).
+  boot bootstrap errors). This is convention-only today; a Tier-2 lint
+  rule in `check-spec-patterns.mjs` will enforce it.
 
 ### Internationalization (i18n)
 - v1 ships in English only, but **all user-facing strings must be extractable**
@@ -117,13 +121,16 @@ Place new code in the correct bucket:
 ### Azure Functions
 - One function per folder. Keep handlers thin; put logic in `src/lib/`.
 - Validate all inputs with hand-written `assert<Shape>(value: unknown): Shape`
-  guards (see `assertEnum` / `assertInt` in `api/src/shared/preferences.ts`
+  guards (see `assertEnum` / `assertInt`, plus `assertBool` / `assertHex`
+  for booleans and 6-digit hex colors, in `api/src/shared/preferences.ts`
   for the pattern). Throw a typed validation error and translate to
   `400 Bad Request` at the handler edge. (We do not use zod -- the
   hand-rolled approach keeps the deployed bundle small.)
 - Return typed JSON responses with explicit status codes. Never leak stack
   traces. Status code conventions:
   - `200` read or update success, `201` create success.
+  - `204 No Content` delete success - no body. Used by
+    `DELETE /api/blobs/{id}` and `DELETE /api/history`.
   - `400` request-shape validation failed.
   - `401` missing or invalid auth (token expired, signature failed).
   - `403` authenticated but not allowed (e.g., not the blob owner).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,26 @@ Place new code in the correct bucket:
 ## 4. Coding Conventions
 
 ### TypeScript (frontend + functions)
-- `strict: true`, `noImplicitAny`, `noUncheckedIndexedAccess`. Never disable
+- `strict: true`, `noImplicitAny`. Never disable
   with `any` - use `unknown` + narrowing.
+- Frontend `tsconfig.json` adds `noImplicitOverride`,
+  `noPropertyAccessFromIndexSignature`, `noImplicitReturns`,
+  `noFallthroughCasesInSwitch`, plus Angular's `strictTemplates`.
+- `noUncheckedIndexedAccess` and `exactOptionalPropertyTypes` are not yet
+  on. Treat them as aspirational; do not introduce code that would break
+  if they are turned on (e.g., always guard `arr[i]` for possible
+  `undefined`).
+- Production code must have **zero** `as unknown as ...` casts. If you
+  hit a structural mismatch, change the function signature or write a
+  narrow adapter object instead. Test files may use `as unknown as X`
+  for partial framework stubs (`HttpRequest`, `Router`, `SwUpdate`,
+  `MatSnackBarRef`, etc.) -- prefer `jasmine.SpyObj<T>` or
+  `Partial<T>` intermediaries when feasible.
+- Production code must have **zero** `as any`. The single test-file
+  occurrence is grandfathered; do not add more.
+- Test-only seams on production classes use the `__<verb>ForTesting`
+  prefix (e.g., `__setJwksClientForTesting` in `api/src/shared/auth.ts`).
+  Production callers must never reference these.
 - Prefer `type` for unions/aliases, `interface` for object contracts that may be
   extended.
 - No default exports in app code (except Angular-required cases).
@@ -60,12 +78,24 @@ Place new code in the correct bucket:
 - **Standalone components** only; no `NgModule`s for new code.
 - Use **Signals** for component state; RxJS only at I/O boundaries (HTTP,
   routing, events).
+- `computed()` for derived state; `effect()` only for syncing a signal to
+  an external system (e.g., `localStorage`, `document.title`). Never use
+  `effect()` for state derivation.
+- Every `.subscribe(...)` in a component or non-singleton service must
+  be paired with `takeUntilDestroyed()` (preferred) or an explicit
+  `Subscription` cleanup in `ngOnDestroy`. Singleton (root-provided)
+  services may subscribe without cleanup since they live for the app
+  lifetime, but flag this in a code comment.
 - Use `inject()` over constructor DI for new code.
 - Components: `OnPush` change detection by default.
 - Template logic stays trivial - push branching into the component or a pipe.
 - Styles are component-scoped SCSS. Global tokens live in `src/styles/`.
 - Theming uses the `TreeHighlightColors` / theme tokens from the spec - do not
   hardcode colors in components.
+- Logging: use `LoggerService` (`src/app/core/telemetry/logger.service.ts`)
+  for any log a developer might consult. Direct `console.*` calls are
+  permitted only in `src/app/core/telemetry/` and `src/main.ts` (early-
+  boot bootstrap errors).
 
 ### Internationalization (i18n)
 - v1 ships in English only, but **all user-facing strings must be extractable**
@@ -86,16 +116,32 @@ Place new code in the correct bucket:
 
 ### Azure Functions
 - One function per folder. Keep handlers thin; put logic in `src/lib/`.
-- Validate all inputs (zod or equivalent schema validation).
+- Validate all inputs with hand-written `assert<Shape>(value: unknown): Shape`
+  guards (see `assertEnum` / `assertInt` in `api/src/shared/preferences.ts`
+  for the pattern). Throw a typed validation error and translate to
+  `400 Bad Request` at the handler edge. (We do not use zod -- the
+  hand-rolled approach keeps the deployed bundle small.)
 - Return typed JSON responses with explicit status codes. Never leak stack
-  traces.
+  traces. Status code conventions:
+  - `200` read or update success, `201` create success.
+  - `400` request-shape validation failed.
+  - `401` missing or invalid auth (token expired, signature failed).
+  - `403` authenticated but not allowed (e.g., not the blob owner).
+  - `404` resource does not exist or caller cannot see it.
+  - `409` idempotent-create conflict.
+  - `429` rate / quota exceeded.
+  - `500` server error - log full detail; respond with a generic
+    message.
 - Auth: validate Entra External ID-issued JWTs on every protected route.
 
 ### Naming
 - Files: `kebab-case.ts`. Angular: `thing.component.ts`, `thing.service.ts`,
   `thing.pipe.ts`, `thing.guard.ts`.
 - Classes: `PascalCase`. Variables/functions: `camelCase`. Constants: `UPPER_SNAKE`.
-- Test files: co-located as `*.spec.ts`.
+- Test files: co-located as `*.spec.ts`. **Exception:** the `api/`
+  workspace currently uses `*.test.ts` (Jest convention). New api/
+  test files should still use `*.test.ts` until the workspace is
+  migrated. Do not mix conventions within a workspace.
 
 ### ASCII-only repository
 - Tracked source files **must be ASCII** unless the codepoint is explicitly
@@ -134,7 +180,9 @@ Place new code in the correct bucket:
 ## 7. Definition of Done
 
 Before finishing a task:
-1. `npm run lint` passes (frontend and `api/`).
+1. `npm run lint` passes (frontend and `api/`). Lint is currently
+   `tsc --noEmit` plus `check-ascii.mjs` and `check-spec-patterns.mjs`;
+   ESLint is not yet installed.
 2. `npm test` passes (frontend and `api/`).
 3. `npm run build` (or `ng build --configuration production`) succeeds.
 4. `npm run check:ascii` passes (no new non-ASCII codepoints outside the
@@ -142,7 +190,7 @@ Before finishing a task:
 5. Only run the suites that exist - do not introduce new toolchains to satisfy
    this checklist. If a suite isn't set up yet and the task is scaffolding,
    set it up per the spec.
-6. No new TypeScript errors, ESLint errors, or console warnings introduced.
+6. No new TypeScript errors or console warnings introduced.
 7. Spec is updated if behavior or architecture changed.
 
 ## 8. Git & PR Hygiene

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,12 +7,13 @@ unless a task explicitly overrides a specific rule.
 ## 1. Source of Truth
 
 - **`DESIGN_SPEC.md` is the authoritative product & architecture spec.** Read
-  the relevant sections before making non-trivial changes. If a request
-  contradicts the spec, flag the conflict before implementing.
-- Do not silently deviate from the spec (entities, routes, SKUs, limits,
-  defaults). Before deviating, give a detailed written explanation of
-  why and ask for explicit permission. If approved, update
-  `DESIGN_SPEC.md` in the same PR as the code change.
+  the relevant sections before making non-trivial changes.
+- **Never silently deviate from the spec** (entities, routes, SKUs, limits,
+  defaults). If a request contradicts the spec, or you believe a deviation
+  is warranted, give a detailed written explanation of why and ask for
+  explicit permission before implementing.
+- If a deviation is approved, update `DESIGN_SPEC.md` in the same PR as
+  the code change.
 
 ## 2. Tech Stack (non-negotiable defaults)
 
@@ -66,8 +67,6 @@ Place new code in the correct bucket:
   may use `as unknown as X` for partial framework stubs (`HttpRequest`,
   `Router`, `SwUpdate`, `MatSnackBarRef`, etc.) -- prefer
   `jasmine.SpyObj<T>` or `Partial<T>` intermediaries when feasible.
-  Tier-2 lint rules will treat `src/testing/**` and `*.testing.ts` as
-  test code, not production.
 - Production code must have **zero** `as any`. The single test-file
   occurrence is grandfathered; do not add more.
 - Test-only seams on production classes use the `__<verb>ForTesting`
@@ -105,10 +104,10 @@ Place new code in the correct bucket:
   `src/app/features/profile/profile.component.scss` are reference
   examples.
 - Logging: use `LoggerService` (`src/app/core/telemetry/logger.service.ts`)
-  for any log a developer might consult. Direct `console.*` calls are
-  permitted only in `src/app/core/telemetry/` and `src/main.ts` (early-
-  boot bootstrap errors). This is convention-only today; a Tier-2 lint
-  rule in `check-spec-patterns.mjs` will enforce it.
+  for any log a developer might consult. Direct `console.*` calls in
+  production code are permitted only in `src/app/core/telemetry/` and
+  `src/main.ts` (early-boot bootstrap errors). Test files (`*.spec.ts`,
+  `*.test.ts`) may reference `console.*` for spies and expectations.
 
 ### Internationalization (i18n)
 - v1 ships in English only, but **all user-facing strings must be extractable**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,5 +246,8 @@ Before finishing a task:
 
 - Re-read the relevant `DESIGN_SPEC.md` section.
 - Ask a clarifying question rather than guessing on behavioral choices,
-  defaults, limits, or scope.
+  defaults, limits, or scope. **Always ask and wait for the user's
+  answer -- even if the runtime reports the user as unavailable, busy,
+  or away. Never assume an answer or proceed autonomously with a plan
+  based on a guess.**
 - Prefer the simpler, spec-aligned option over a clever alternative.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,9 @@ unless a task explicitly overrides a specific rule.
   the relevant sections before making non-trivial changes. If a request
   contradicts the spec, flag the conflict before implementing.
 - Do not silently deviate from the spec (entities, routes, SKUs, limits,
-  defaults). If a change is needed, update `DESIGN_SPEC.md` in the same PR.
+  defaults). Before deviating, give a detailed written explanation of
+  why and ask for explicit permission. If approved, update
+  `DESIGN_SPEC.md` in the same PR as the code change.
 
 ## 2. Tech Stack (non-negotiable defaults)
 
@@ -95,6 +97,13 @@ Place new code in the correct bucket:
 - Styles are component-scoped SCSS. Global tokens live in `src/styles/`.
 - Theming uses the `TreeHighlightColors` / theme tokens from the spec - do not
   hardcode colors in components.
+- When overriding Material component tokens in component SCSS, use the
+  Material 21 `--mat-<component>-*` token names (e.g.,
+  `--mat-slide-toggle-track-width`). The legacy `--mdc-<component>-*`
+  names are silently no-ops on Material 21. The slide-toggle and
+  button-toggle overrides in
+  `src/app/features/profile/profile.component.scss` are reference
+  examples.
 - Logging: use `LoggerService` (`src/app/core/telemetry/logger.service.ts`)
   for any log a developer might consult. Direct `console.*` calls are
   permitted only in `src/app/core/telemetry/` and `src/main.ts` (early-
@@ -113,6 +122,11 @@ Place new code in the correct bucket:
   a stable ID, e.g., ``$localize`:@@upload.tooLarge:File too large - max 5 MB` ``.
 - Stable ID convention: `<area>.<element>.<purpose>` in camelCase / dot
   segments (e.g., `@@tree.search.placeholder`, `@@home.empty`).
+- **Renaming visible text:** when changing the user-visible source
+  string for an existing UI element, keep the existing i18n message
+  ID stable; only the source text changes. This avoids invalidating
+  prior translations and history. Re-run `npm run extract-i18n` so
+  `messages.xlf` is regenerated with the new source.
 - Never use plain strings in templates or `console.warn`/`toast` calls when
   they are user-visible.
 - Run `npm run extract-i18n` to refresh `src/locale/messages.xlf` when you add
@@ -204,6 +218,13 @@ Before finishing a task:
 
 - Small, focused commits with imperative subject lines (e.g.,
   `Add slug collision check to BlobService`).
+- Stage files explicitly by path. **Never** run `git add -A`,
+  `git add .`, or `git add --all`. This prevents committing unrelated
+  edits, generated files, or session-state artifacts.
+- **Never** run `git rebase` or `git pull --rebase`. When branches
+  diverge, use `git pull --no-rebase` (merge), or stop and ask. The
+  "do not rewrite or force-push" rule below already prohibits the
+  destructive form; this rule prohibits the local form too.
 - Never commit secrets, `.env`, `node_modules`, build output, or editor files
   beyond what `.gitignore` already covers.
 - Do not rewrite or force-push shared branches.


### PR DESCRIPTION
## Summary

Documentation-only PR. Aligns AGENTS.md with what is actually enforced today, and codifies several conventions that were implicit in the codebase but not written down.

No code or behavior changes.

## What changed

**TypeScript section**
- Drop the unsupported `noUncheckedIndexedAccess` claim (it was never on). Document the actual flag set used by root vs. `api/`; mark the missing flags as aspirational.
- Codify the audit findings from PR #54: zero `as unknown as` in production code; tests may use it for partial framework stubs but should prefer `jasmine.SpyObj<T>` / `Partial<T>`. Zero `as any` outside the one grandfathered test occurrence in `blobs.component.spec.ts`.
- Codify the `__<verb>ForTesting` naming convention for test-only seams on production classes (e.g., `__setJwksClientForTesting`).

**Angular section**
- Distinguish `computed()` from `effect()`. `effect()` is for syncing a signal to an external system only (e.g., `localStorage`, `document.title`); never for derived state.
- Codify the `takeUntilDestroyed()` pattern for `.subscribe` in components / non-singleton services.
- Codify the no-`console.*`-outside-`core/telemetry/`-and-`main.ts` rule (current de facto state in the repo).

**Azure Functions section**
- Replace the unbacked "use zod or equivalent" claim with the actual `assertEnum` / `assertInt` hand-rolled validator pattern from `api/src/shared/preferences.ts`.
- Add an explicit HTTP status code conventions list (200/201/400/401/403/404/409/429/500) describing when each is used.

**Naming section**
- Document the `api/*.test.ts` exception (Jest convention) until that workspace is migrated to `*.spec.ts`.

**Definition of Done section**
- Drop the `ESLint errors` reference (ESLint is not installed; the only `eslint-disable-next-line` in the repo is dead code).
- Clarify what `npm run lint` actually runs: `tsc --noEmit` + `check-ascii.mjs` + `check-spec-patterns.mjs`.

## Followups (not in this PR)

A broader conventions audit identified two more tiers of work:

- **Tier 2 (lightweight automation):** extend the `check-spec-patterns.mjs` model with additional rules (no production `as unknown as`, no `as any` outside `*.spec.ts`, no `console.*` outside telemetry). Align `api/tsconfig.json` strict flags with root.
- **Tier 3 (multi-PR):** adopt ESLint + `@typescript-eslint` + `@angular-eslint`.

Let me know if you want either of those next.