### PR TITLE
Unify tree/editor scrollbars with Monaco style (#31)

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -673,6 +673,7 @@ SPA-originated calls in production.
   - Primary: Teal/Cyan accent (#00BCD4 family).
   - Background: Dark (#1E1E1E) / Light (#FAFAFA).
   - JSON types color-coded: strings=green (`#6a8759`), numbers=orange (`#ff9800`), booleans=blue (`#2196f3`), null=gray (`#9e9e9e`), arrays=purple (`#9c27b0`), objects=teal (`#009688`). Exact values live in `src/styles/_variables.scss`.
+  - **Scrollbars**: non-Monaco scrollable surfaces (e.g., the JSON tree pane, the editor's inline error list) use the themed `--scrollbar-thumb` / `--scrollbar-thumb-hover` / `--scrollbar-track` tokens defined in `src/styles/_theme.scss`, applied via the `themed-scrollbar` mixin in `src/styles/_scrollbars.scss`. The styling matches Monaco's overlay scrollbar (thin, no arrow buttons, semi-transparent thumb that strengthens on hover) so the editor and tree look visually unified.
 - **Logo:** "JotJSON" wordmark - "Jot" in regular weight, "JSON" in bold, with a `{ }` icon element.
 - **Responsive breakpoints:** Mobile (< 768px), Tablet (768-1024px), Desktop (> 1024px).
 

--- a/src/app/shared/components/json-editor/json-editor.component.scss
+++ b/src/app/shared/components/json-editor/json-editor.component.scss
@@ -1,4 +1,5 @@
 @use '../../../../styles/variables' as v;
+@use '../../../../styles/scrollbars' as sb;
 
 :host {
   display: flex;
@@ -45,6 +46,8 @@
   font-size: 12.5px;
   max-height: 90px;
   overflow: auto;
+
+  @include sb.themed-scrollbar;
 
   li {
     padding: 2px 0;

--- a/src/app/shared/components/json-tree/json-tree.component.scss
+++ b/src/app/shared/components/json-tree/json-tree.component.scss
@@ -1,4 +1,5 @@
 @use '../../../../styles/variables' as v;
+@use '../../../../styles/scrollbars' as sb;
 
 :host {
   display: flex;
@@ -103,6 +104,8 @@
   font-family: v.$font-mono;
   font-size: var(--tree-font-size, 13px);
   line-height: 1.55;
+
+  @include sb.themed-scrollbar;
 }
 
 .tree-empty {

--- a/src/styles/_scrollbars.scss
+++ b/src/styles/_scrollbars.scss
@@ -1,0 +1,45 @@
+// Themed scrollbar mixin used by non-Monaco scrollable surfaces so they
+// visually match Monaco's overlay scrollbar (thin, no arrow buttons,
+// semi-transparent thumb that strengthens on hover). Tokens come from
+// _theme.scss (--scrollbar-thumb / --scrollbar-thumb-hover / --scrollbar-track)
+// and follow the active dark/light/system theme.
+
+@mixin themed-scrollbar {
+  // Firefox
+  scrollbar-width: thin;
+  scrollbar-color: var(--scrollbar-thumb) var(--scrollbar-track);
+
+  // WebKit / Blink (Chromium, Edge, Safari)
+  &::-webkit-scrollbar {
+    width: 10px;
+    height: 10px;
+  }
+
+  &::-webkit-scrollbar-track {
+    background: var(--scrollbar-track);
+  }
+
+  &::-webkit-scrollbar-thumb {
+    background: var(--scrollbar-thumb);
+    border-radius: 5px;
+    // padding-box clip + transparent border gives the thumb an inset look
+    // by reserving 2px of "space" on each side, matching Monaco's slim slider.
+    border: 2px solid transparent;
+    background-clip: padding-box;
+  }
+
+  &::-webkit-scrollbar-thumb:hover {
+    background: var(--scrollbar-thumb-hover);
+    background-clip: padding-box;
+  }
+
+  &::-webkit-scrollbar-corner {
+    background: transparent;
+  }
+
+  // Monaco's scrollbar has no arrow buttons; suppress Chromium's defaults
+  // so the tree and editor stay visually unified.
+  &::-webkit-scrollbar-button {
+    display: none;
+  }
+}

--- a/src/styles/_theme.scss
+++ b/src/styles/_theme.scss
@@ -15,6 +15,10 @@
   --highlight-matching: #{$highlight-matching-dark};
   --highlight-ancestor: #{$highlight-ancestor-dark};
   --highlight-search: #{$highlight-search-dark};
+
+  --scrollbar-thumb: #{rgba(121, 121, 121, 0.4)};
+  --scrollbar-thumb-hover: #{rgba(100, 100, 100, 0.7)};
+  --scrollbar-track: transparent;
 }
 
 .theme-light {
@@ -25,6 +29,10 @@
   --highlight-matching: #{$highlight-matching-light};
   --highlight-ancestor: #{$highlight-ancestor-light};
   --highlight-search: #{$highlight-search-light};
+
+  --scrollbar-thumb: #{rgba(100, 100, 100, 0.4)};
+  --scrollbar-thumb-hover: #{rgba(100, 100, 100, 0.7)};
+  --scrollbar-track: transparent;
 }
 
 @media (prefers-color-scheme: light) {
@@ -36,5 +44,9 @@
     --highlight-matching: #{$highlight-matching-light};
     --highlight-ancestor: #{$highlight-ancestor-light};
     --highlight-search: #{$highlight-search-light};
+
+    --scrollbar-thumb: #{rgba(100, 100, 100, 0.4)};
+    --scrollbar-thumb-hover: #{rgba(100, 100, 100, 0.7)};
+    --scrollbar-track: transparent;
   }
 }


### PR DESCRIPTION
Closes #31.

## What

Non-Monaco scroll containers (the JSON tree pane and the editor's inline error list) used the browser's native scrollbar, which on Windows looks visibly chunkier and arrow-button-laden next to Monaco's slim overlay scrollbar.

This PR adds shared theme tokens and a SCSS mixin so those surfaces match Monaco.

## Changes

- `src/styles/_theme.scss`: new `--scrollbar-thumb` / `--scrollbar-thumb-hover` / `--scrollbar-track` tokens for dark / light / system themes (values match Monaco's `scrollbarSlider` defaults).
- `src/styles/_scrollbars.scss` (new): `themed-scrollbar` mixin covering Firefox (`scrollbar-width: thin` + `scrollbar-color`) and WebKit/Blink (`::-webkit-scrollbar*` rules incl. arrow-button suppression).
- `json-tree.component.scss`: applied to `.tree-body`.
- `json-editor.component.scss`: applied to `.editor-errors`.
- `DESIGN_SPEC.md`: bullet under UI/UX Guidelines documenting the tokens.

## Why these are the only two

Grep for `overflow:auto` / `overflow:scroll` across `src/` returns just those two containers. Monaco renders its own scrollbar inside the editor and is unchanged.

## Decisions

- **Style**: match Monaco closely - thin (10px), no arrows, semi-transparent thumb that gets opaque on hover, transparent track, `background-clip: padding-box` for the inset look.
- **Scope**: explicit selectors only, no global `*` rules.
- **Arrows**: omitted intentionally - Monaco's scrollbar has no arrow buttons (by design; not configurable), so suppressing them on the tree side gives true visual unity.

## Manual verification

- [ ] Home page in dark theme: tree and editor scrollbars look identical (thin thumb, no arrows).
- [ ] Toggle to light theme: same.
- [ ] Toggle to system theme on a system in light mode: same.
- [ ] Trigger editor errors (paste invalid JSON until the error list overflows): scrollbar there matches.

## Tests

Pure CSS change - no logic, no new specs. `npm run lint` clean (TSC + ASCII + spec-pattern checks).