### PR TITLE
Extract ClipboardCopyService.copyWithToast helper

### DIFF
--- a/src/app/core/clipboard/clipboard-copy.service.spec.ts
+++ b/src/app/core/clipboard/clipboard-copy.service.spec.ts
@@ -1,4 +1,4 @@
-import { TestBed } from '@angular/core/testing';
+import { TestBed, fakeAsync, flushMicrotasks } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { ClipboardCopyService } from './clipboard-copy.service';
 
@@ -43,62 +43,71 @@ describe('ClipboardCopyService', () => {
     unsupported: 'Copy is not supported in this browser.'
   };
 
-  it('opens the unsupported snackbar when navigator.clipboard is missing', () => {
+  it('opens the unsupported snackbar and resolves false when navigator.clipboard is missing', fakeAsync(() => {
     setClipboard(undefined);
-    service.copyWithToast('hello', messages);
+    let result: boolean | undefined;
+    void service.copyWithToast('hello', messages).then((r) => (result = r));
+    flushMicrotasks();
+    expect(result).toBeFalse();
     expect(snackOpen).toHaveBeenCalledTimes(1);
     expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.unsupported);
     expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 4000 });
-  });
+  }));
 
-  it('opens the unsupported snackbar when writeText is missing on the clipboard', () => {
+  it('opens the unsupported snackbar when writeText is missing on the clipboard', fakeAsync(() => {
     setClipboard({});
-    service.copyWithToast('hello', messages);
+    let result: boolean | undefined;
+    void service.copyWithToast('hello', messages).then((r) => (result = r));
+    flushMicrotasks();
+    expect(result).toBeFalse();
     expect(snackOpen).toHaveBeenCalledTimes(1);
     expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.unsupported);
-  });
+  }));
 
-  it('writes text and opens the success snackbar when writeText resolves', async () => {
+  it('writes text, passes the Dismiss action label, and resolves true on success', fakeAsync(() => {
     const writeText = jasmine.createSpy('writeText').and.resolveTo(undefined);
     setClipboard({ writeText });
-    service.copyWithToast('hello', messages);
-    await Promise.resolve();
-    await Promise.resolve();
+    let result: boolean | undefined;
+    void service.copyWithToast('hello', messages).then((r) => (result = r));
+    flushMicrotasks();
+    expect(result).toBeTrue();
     expect(writeText).toHaveBeenCalledWith('hello');
     expect(snackOpen).toHaveBeenCalledTimes(1);
     expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.success);
+    expect(snackOpen.calls.mostRecent().args[1]).toBe('Dismiss');
     expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 3000 });
-  });
+  }));
 
-  it('opens the failure snackbar when writeText rejects', async () => {
+  it('opens the failure snackbar and resolves false when writeText rejects', fakeAsync(() => {
     const writeText = jasmine
       .createSpy('writeText')
       .and.rejectWith(new Error('denied'));
     setClipboard({ writeText });
-    service.copyWithToast('hello', messages);
-    await Promise.resolve();
-    await Promise.resolve();
+    let result: boolean | undefined;
+    void service.copyWithToast('hello', messages).then((r) => (result = r));
+    flushMicrotasks();
+    expect(result).toBeFalse();
     expect(snackOpen).toHaveBeenCalledTimes(1);
     expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.failed);
     expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 4000 });
-  });
+  }));
 
-  it('honors custom durations when provided', async () => {
+  it('honors custom durations when provided', fakeAsync(() => {
     const writeText = jasmine.createSpy('writeText').and.resolveTo(undefined);
     setClipboard({ writeText });
-    service.copyWithToast('hello', messages, {
+    void service.copyWithToast('hello', messages, {
       successDurationMs: 1234,
       failedDurationMs: 5678,
       unsupportedDurationMs: 9012
     });
-    await Promise.resolve();
-    await Promise.resolve();
+    flushMicrotasks();
     expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 1234 });
-  });
+  }));
 
-  it('honors custom unsupportedDurationMs when clipboard is missing', () => {
+  it('honors custom unsupportedDurationMs when clipboard is missing', fakeAsync(() => {
     setClipboard(undefined);
-    service.copyWithToast('hello', messages, { unsupportedDurationMs: 7777 });
+    void service.copyWithToast('hello', messages, { unsupportedDurationMs: 7777 });
+    flushMicrotasks();
     expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 7777 });
-  });
+  }));
 });

--- a/src/app/core/clipboard/clipboard-copy.service.spec.ts
+++ b/src/app/core/clipboard/clipboard-copy.service.spec.ts
@@ -30,10 +30,10 @@ describe('ClipboardCopyService', () => {
     if (originalDescriptor) {
       Object.defineProperty(navigator, 'clipboard', originalDescriptor);
     } else {
-      Object.defineProperty(navigator, 'clipboard', {
-        configurable: true,
-        value: undefined
-      });
+      // navigator.clipboard lives on Navigator.prototype in real Chrome; if
+      // there was no own-property before this spec, restore that state by
+      // deleting the override rather than masking the prototype with undefined.
+      delete (navigator as unknown as { clipboard?: Clipboard }).clipboard;
     }
   });
 

--- a/src/app/core/clipboard/clipboard-copy.service.spec.ts
+++ b/src/app/core/clipboard/clipboard-copy.service.spec.ts
@@ -1,0 +1,104 @@
+import { TestBed } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { ClipboardCopyService } from './clipboard-copy.service';
+
+describe('ClipboardCopyService', () => {
+  let service: ClipboardCopyService;
+  let snackOpen: jasmine.Spy;
+  let originalDescriptor: PropertyDescriptor | undefined;
+
+  function setClipboard(value: { writeText?: jasmine.Spy } | undefined): void {
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value
+    });
+  }
+
+  beforeEach(() => {
+    originalDescriptor = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    snackOpen = jasmine.createSpy('open');
+    TestBed.configureTestingModule({
+      providers: [
+        ClipboardCopyService,
+        { provide: MatSnackBar, useValue: { open: snackOpen } }
+      ]
+    });
+    service = TestBed.inject(ClipboardCopyService);
+  });
+
+  afterEach(() => {
+    if (originalDescriptor) {
+      Object.defineProperty(navigator, 'clipboard', originalDescriptor);
+    } else {
+      Object.defineProperty(navigator, 'clipboard', {
+        configurable: true,
+        value: undefined
+      });
+    }
+  });
+
+  const messages = {
+    success: 'Copied!',
+    failed: 'Could not copy.',
+    unsupported: 'Copy is not supported in this browser.'
+  };
+
+  it('opens the unsupported snackbar when navigator.clipboard is missing', () => {
+    setClipboard(undefined);
+    service.copyWithToast('hello', messages);
+    expect(snackOpen).toHaveBeenCalledTimes(1);
+    expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.unsupported);
+    expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 4000 });
+  });
+
+  it('opens the unsupported snackbar when writeText is missing on the clipboard', () => {
+    setClipboard({});
+    service.copyWithToast('hello', messages);
+    expect(snackOpen).toHaveBeenCalledTimes(1);
+    expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.unsupported);
+  });
+
+  it('writes text and opens the success snackbar when writeText resolves', async () => {
+    const writeText = jasmine.createSpy('writeText').and.resolveTo(undefined);
+    setClipboard({ writeText });
+    service.copyWithToast('hello', messages);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(writeText).toHaveBeenCalledWith('hello');
+    expect(snackOpen).toHaveBeenCalledTimes(1);
+    expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.success);
+    expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 3000 });
+  });
+
+  it('opens the failure snackbar when writeText rejects', async () => {
+    const writeText = jasmine
+      .createSpy('writeText')
+      .and.rejectWith(new Error('denied'));
+    setClipboard({ writeText });
+    service.copyWithToast('hello', messages);
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(snackOpen).toHaveBeenCalledTimes(1);
+    expect(snackOpen.calls.mostRecent().args[0]).toBe(messages.failed);
+    expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 4000 });
+  });
+
+  it('honors custom durations when provided', async () => {
+    const writeText = jasmine.createSpy('writeText').and.resolveTo(undefined);
+    setClipboard({ writeText });
+    service.copyWithToast('hello', messages, {
+      successDurationMs: 1234,
+      failedDurationMs: 5678,
+      unsupportedDurationMs: 9012
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 1234 });
+  });
+
+  it('honors custom unsupportedDurationMs when clipboard is missing', () => {
+    setClipboard(undefined);
+    service.copyWithToast('hello', messages, { unsupportedDurationMs: 7777 });
+    expect(snackOpen.calls.mostRecent().args[2]).toEqual({ duration: 7777 });
+  });
+});

--- a/src/app/core/clipboard/clipboard-copy.service.ts
+++ b/src/app/core/clipboard/clipboard-copy.service.ts
@@ -1,0 +1,72 @@
+import { Injectable, inject } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+
+/**
+ * Resolved (already-localized) snackbar messages for the three outcomes of
+ * a clipboard write. Callers must evaluate `$localize` tagged template
+ * literals at the call site so the i18n extractor can find them.
+ */
+export interface CopyToastMessages {
+  /** Shown after `clipboard.writeText` resolves. */
+  success: string;
+  /** Shown after `clipboard.writeText` rejects. */
+  failed: string;
+  /** Shown when `navigator.clipboard?.writeText` is unavailable. */
+  unsupported: string;
+}
+
+/**
+ * Optional duration overrides (milliseconds) for each outcome.
+ * Defaults match the original inlined copy/share-link behavior.
+ */
+export interface CopyToastDurations {
+  successDurationMs?: number;
+  failedDurationMs?: number;
+  unsupportedDurationMs?: number;
+}
+
+const DEFAULT_SUCCESS_MS = 3000;
+const DEFAULT_FAILED_MS = 4000;
+const DEFAULT_UNSUPPORTED_MS = 4000;
+
+/**
+ * Write-side companion to `ClipboardPollingService`. Centralizes the
+ * "copy text and tell the user how it went" pattern so call sites do
+ * not duplicate the unsupported / success / failed snackbar plumbing.
+ *
+ * Callers pass already-localized messages because Angular's i18n
+ * extractor only finds `$localize` tagged template literals at lexical
+ * positions; the helper cannot accept ID strings and resolve them.
+ */
+@Injectable({ providedIn: 'root' })
+export class ClipboardCopyService {
+  private readonly snack = inject(MatSnackBar);
+
+  copyWithToast(
+    text: string,
+    messages: CopyToastMessages,
+    durations: CopyToastDurations = {}
+  ): void {
+    const dismiss = $localize`:@@common.dismiss:Dismiss`;
+    const successMs = durations.successDurationMs ?? DEFAULT_SUCCESS_MS;
+    const failedMs = durations.failedDurationMs ?? DEFAULT_FAILED_MS;
+    const unsupportedMs =
+      durations.unsupportedDurationMs ?? DEFAULT_UNSUPPORTED_MS;
+
+    const clipboard = navigator.clipboard;
+    // clipboard is undefined on HTTP / file:// (insecure contexts) and in
+    // older browsers; writeText may also be missing on partial polyfills.
+    if (!clipboard?.writeText) {
+      this.snack.open(messages.unsupported, dismiss, { duration: unsupportedMs });
+      return;
+    }
+    clipboard.writeText(text).then(
+      () => {
+        this.snack.open(messages.success, dismiss, { duration: successMs });
+      },
+      () => {
+        this.snack.open(messages.failed, dismiss, { duration: failedMs });
+      }
+    );
+  }
+}

--- a/src/app/core/clipboard/clipboard-copy.service.ts
+++ b/src/app/core/clipboard/clipboard-copy.service.ts
@@ -42,11 +42,18 @@ const DEFAULT_UNSUPPORTED_MS = 4000;
 export class ClipboardCopyService {
   private readonly snack = inject(MatSnackBar);
 
-  copyWithToast(
+  /**
+   * Copies `text` to the clipboard and opens a snackbar describing the
+   * outcome. Resolves to `true` when the write succeeded, `false` when the
+   * environment is unsupported or `writeText` rejected. Most callers can
+   * `void` the return value; the boolean exists so future callers can chain
+   * follow-up UI on success without re-plumbing the API.
+   */
+  async copyWithToast(
     text: string,
     messages: CopyToastMessages,
     durations: CopyToastDurations = {}
-  ): void {
+  ): Promise<boolean> {
     const dismiss = $localize`:@@common.dismiss:Dismiss`;
     const successMs = durations.successDurationMs ?? DEFAULT_SUCCESS_MS;
     const failedMs = durations.failedDurationMs ?? DEFAULT_FAILED_MS;
@@ -58,15 +65,15 @@ export class ClipboardCopyService {
     // older browsers; writeText may also be missing on partial polyfills.
     if (!clipboard?.writeText) {
       this.snack.open(messages.unsupported, dismiss, { duration: unsupportedMs });
-      return;
+      return false;
     }
-    clipboard.writeText(text).then(
-      () => {
-        this.snack.open(messages.success, dismiss, { duration: successMs });
-      },
-      () => {
-        this.snack.open(messages.failed, dismiss, { duration: failedMs });
-      }
-    );
+    try {
+      await clipboard.writeText(text);
+      this.snack.open(messages.success, dismiss, { duration: successMs });
+      return true;
+    } catch {
+      this.snack.open(messages.failed, dismiss, { duration: failedMs });
+      return false;
+    }
   }
 }

--- a/src/app/features/blobs/blobs.component.spec.ts
+++ b/src/app/features/blobs/blobs.component.spec.ts
@@ -193,6 +193,19 @@ describe('BlobsComponent', () => {
     expect(message).toBe('Failed to copy link');
   });
 
+  it('copyLink toasts the unsupported message when navigator.clipboard is missing', async () => {
+    const { fixture, snack } = setup();
+    Object.defineProperty(navigator, 'clipboard', {
+      value: undefined,
+      configurable: true
+    });
+    spyOn(console, 'warn');
+    await fixture.componentInstance.copyLink(blob({ slug: 'no-perm' }));
+    expect(snack.open).toHaveBeenCalled();
+    const message = (snack.open.calls.mostRecent().args as unknown[])[0];
+    expect(message).toBe('Copy is not supported in this browser.');
+  });
+
   it('displayTitle falls back to "Untitled" for blank titles', () => {
     const { fixture } = setup();
     expect(fixture.componentInstance.displayTitle(blob({ title: undefined }))).toBe(

--- a/src/app/features/blobs/blobs.component.ts
+++ b/src/app/features/blobs/blobs.component.ts
@@ -14,6 +14,7 @@ import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { firstValueFrom } from 'rxjs';
 import { BlobService } from '../../core/api/blob.service';
+import { ClipboardCopyService } from '../../core/clipboard/clipboard-copy.service';
 import type { JsonBlob } from '../../core/api/models';
 import { LoggerService } from '../../core/telemetry/logger.service';
 import { SeoService } from '../../core/seo/seo.service';
@@ -42,6 +43,7 @@ type LoadState = 'loading' | 'ready' | 'error';
 })
 export class BlobsComponent implements OnInit {
   private readonly blobs = inject(BlobService);
+  private readonly clipboardCopy = inject(ClipboardCopyService);
   private readonly dialog = inject(MatDialog);
   private readonly snack = inject(MatSnackBar);
   private readonly router = inject(Router);
@@ -109,21 +111,13 @@ export class BlobsComponent implements OnInit {
 
   async copyLink(blob: JsonBlob): Promise<void> {
     const url = `${window.location.origin}/s/${blob.slug}`;
-    try {
-      await navigator.clipboard?.writeText(url);
-      this.snack.open(
-        $localize`:@@blobs.copyLink.success:Link copied to clipboard`,
-        $localize`:@@common.dismiss:Dismiss`,
-        { duration: 3000 }
-      );
-    } catch (err) {
+    const copied = await this.clipboardCopy.copyWithToast(url, {
+      success: $localize`:@@blobs.copyLink.success:Link copied to clipboard`,
+      failed: $localize`:@@blobs.copyLink.failed:Failed to copy link`,
+      unsupported: $localize`:@@blobs.copyLink.unsupported:Copy is not supported in this browser.`
+    });
+    if (!copied) {
       this.logger.warn('blobs.copyLink.failed');
-      void err;
-      this.snack.open(
-        $localize`:@@blobs.copyLink.failed:Failed to copy link`,
-        $localize`:@@common.dismiss:Dismiss`,
-        { duration: 4000 }
-      );
     }
   }
 

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -527,7 +527,7 @@ export class HomeComponent {
     const blob = this.loadedBlob();
     if (!blob) return;
     const url = `${window.location.origin}/s/${blob.slug}`;
-    this.clipboardCopy.copyWithToast(url, {
+    void this.clipboardCopy.copyWithToast(url, {
       success: $localize`:@@share.copyLink.success:Share link copied to clipboard.`,
       failed: $localize`:@@share.copyLink.failed:Failed to copy share link.`,
       unsupported: $localize`:@@share.copyLink.unsupported:Copy is not supported in this browser.`

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -53,6 +53,7 @@ import {
   ToolbarComponent
 } from '../../shared/components/toolbar/toolbar.component';
 import { StatusBarComponent } from './status-bar/status-bar.component';
+import { ClipboardCopyService } from '../../core/clipboard/clipboard-copy.service';
 import { ClipboardPollingService } from '../../core/clipboard/clipboard-polling.service';
 import { ClipboardBannerComponent } from './clipboard-banner/clipboard-banner.component';
 
@@ -88,6 +89,7 @@ export class HomeComponent {
   private readonly dialog = inject(MatDialog);
   private readonly snack = inject(MatSnackBar);
   private readonly clipboard = inject(ClipboardPollingService);
+  private readonly clipboardCopy = inject(ClipboardCopyService);
   private readonly logger = inject(LoggerService);
 
   /**
@@ -525,32 +527,11 @@ export class HomeComponent {
     const blob = this.loadedBlob();
     if (!blob) return;
     const url = `${window.location.origin}/s/${blob.slug}`;
-    const clipboard = navigator.clipboard;
-    const dismiss = $localize`:@@common.dismiss:Dismiss`;
-    if (!clipboard?.writeText) {
-      this.snack.open(
-        $localize`:@@share.copyLink.unsupported:Copy is not supported in this browser.`,
-        dismiss,
-        { duration: 4000 }
-      );
-      return;
-    }
-    clipboard.writeText(url).then(
-      () => {
-        this.snack.open(
-          $localize`:@@share.copyLink.success:Share link copied to clipboard.`,
-          dismiss,
-          { duration: 3000 }
-        );
-      },
-      () => {
-        this.snack.open(
-          $localize`:@@share.copyLink.failed:Failed to copy share link.`,
-          dismiss,
-          { duration: 4000 }
-        );
-      }
-    );
+    this.clipboardCopy.copyWithToast(url, {
+      success: $localize`:@@share.copyLink.success:Share link copied to clipboard.`,
+      failed: $localize`:@@share.copyLink.failed:Failed to copy share link.`,
+      unsupported: $localize`:@@share.copyLink.unsupported:Copy is not supported in this browser.`
+    });
   }
 
   async onTogglePublic(): Promise<void> {

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -13,9 +13,9 @@ import {
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { MatMenuModule } from '@angular/material/menu';
-import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTreeModule, MatTreeNestedDataSource } from '@angular/material/tree';
 import { NestedTreeControl } from '@angular/cdk/tree';
+import { ClipboardCopyService } from '../../../core/clipboard/clipboard-copy.service';
 import { PreferencesService } from '../../../core/preferences/preferences.service';
 import { persistedStringSignal } from '../../../core/preferences/persisted-signal';
 import { JsonParserService } from '../../../core/json/json-parser.service';
@@ -117,7 +117,7 @@ export class JsonTreeComponent {
   private readonly prefs = inject(PreferencesService);
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly snack = inject(MatSnackBar);
+  private readonly clipboardCopy = inject(ClipboardCopyService);
   private readonly jsonParser = inject(JsonParserService);
 
   readonly value = input<unknown>(undefined);
@@ -697,38 +697,15 @@ export class JsonTreeComponent {
   }
 
   copyPath(node: TreeNode): void {
-    const dismiss = $localize`:@@common.dismiss:Dismiss`;
-    const clipboard = navigator.clipboard;
-    // clipboard is undefined on HTTP / file:// (insecure contexts) and in older browsers
-    if (!clipboard?.writeText) {
-      this.snack.open(
-        $localize`:@@tree.copyPath.unsupported:Copy is not supported in this browser.`,
-        dismiss,
-        { duration: 4000 }
-      );
-      return;
-    }
-    clipboard.writeText(
-      this.jsonParser.formatPathForClipboard(
-        node.pathString,
-        this.prefs.prefs().treePathRoot
-      )
-    ).then(
-      () => {
-        this.snack.open(
-          $localize`:@@tree.copyPath.success:Path copied to clipboard.`,
-          dismiss,
-          { duration: 3000 }
-        );
-      },
-      () => {
-        this.snack.open(
-          $localize`:@@tree.copyPath.failed:Failed to copy path.`,
-          dismiss,
-          { duration: 4000 }
-        );
-      }
+    const path = this.jsonParser.formatPathForClipboard(
+      node.pathString,
+      this.prefs.prefs().treePathRoot
     );
+    this.clipboardCopy.copyWithToast(path, {
+      success: $localize`:@@tree.copyPath.success:Path copied to clipboard.`,
+      failed: $localize`:@@tree.copyPath.failed:Failed to copy path.`,
+      unsupported: $localize`:@@tree.copyPath.unsupported:Copy is not supported in this browser.`
+    });
   }
 
   renderLeaf(value: unknown, type: JsonValueType): string {

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -701,7 +701,7 @@ export class JsonTreeComponent {
       node.pathString,
       this.prefs.prefs().treePathRoot
     );
-    this.clipboardCopy.copyWithToast(path, {
+    void this.clipboardCopy.copyWithToast(path, {
       success: $localize`:@@tree.copyPath.success:Path copied to clipboard.`,
       failed: $localize`:@@tree.copyPath.failed:Failed to copy path.`,
       unsupported: $localize`:@@tree.copyPath.unsupported:Copy is not supported in this browser.`

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -2,34 +2,23 @@
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
   <file source-language="en-US" datatype="plaintext" original="ng2.template">
     <body>
-      <trans-unit id="quota.autoDeleted.toast" datatype="html">
-        <source>Deleted oldest blob &quot;<x id="name" equiv-text="name"/>&quot; to stay within your 100-blob limit.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/core/quota/quota-notification.service.ts</context>
-          <context context-type="linenumber">29</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="common.dismiss" datatype="html">
         <source>Dismiss</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/core/clipboard/clipboard-copy.service.ts</context>
+          <context context-type="linenumber">57</context>
+        </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/core/quota/quota-notification.service.ts</context>
           <context context-type="linenumber">30</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">116</context>
+          <context context-type="linenumber">144</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">124</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">150</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">158</context>
+          <context context-type="linenumber">152</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
@@ -45,27 +34,26 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">529</context>
+          <context context-type="linenumber">551</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">570</context>
+          <context context-type="linenumber">557</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">576</context>
+          <context context-type="linenumber">591</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">610</context>
+          <context context-type="linenumber">600</context>
         </context-group>
+      </trans-unit>
+      <trans-unit id="quota.autoDeleted.toast" datatype="html">
+        <source>Deleted oldest blob &quot;<x id="name" equiv-text="name"/>&quot; to stay within your 100-blob limit.</source>
         <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">619</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">700</context>
+          <context context-type="sourcefile">src/app/core/quota/quota-notification.service.ts</context>
+          <context context-type="linenumber">29</context>
         </context-group>
       </trans-unit>
       <trans-unit id="quota.firstTime.title" datatype="html">
@@ -233,42 +221,42 @@
         <source>Failed to load your saved blobs.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">79</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.untitled" datatype="html">
         <source>Untitled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">89</context>
+          <context context-type="linenumber">91</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.justNow" datatype="html">
         <source>just now</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">97</context>
+          <context context-type="linenumber">99</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.minutesAgo" datatype="html">
         <source><x id="count" equiv-text="minutes"/> min ago</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">98</context>
+          <context context-type="linenumber">100</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.hoursAgo" datatype="html">
         <source><x id="count" equiv-text="hours"/> h ago</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">100</context>
+          <context context-type="linenumber">102</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.daysAgo" datatype="html">
         <source><x id="count" equiv-text="days"/> d ago</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">102</context>
+          <context context-type="linenumber">104</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.copyLink.success" datatype="html">
@@ -282,39 +270,46 @@
         <source>Failed to copy link</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">123</context>
+          <context context-type="linenumber">116</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="blobs.copyLink.unsupported" datatype="html">
+        <source>Copy is not supported in this browser.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.delete.title" datatype="html">
         <source>Delete this blob?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">133</context>
+          <context context-type="linenumber">127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.delete.message" datatype="html">
         <source>&quot;<x id="name" equiv-text="label"/>&quot; will be permanently deleted. This cannot be undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">134</context>
+          <context context-type="linenumber">128</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.confirm" datatype="html">
         <source>Delete</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">135</context>
+          <context context-type="linenumber">129</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">592</context>
+          <context context-type="linenumber">573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.cancel" datatype="html">
         <source>Cancel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">130</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
@@ -322,29 +317,29 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">593</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.success" datatype="html">
         <source>Blob deleted.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">149</context>
+          <context context-type="linenumber">143</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">609</context>
+          <context context-type="linenumber">590</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.failed" datatype="html">
         <source>Failed to delete blob.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">157</context>
+          <context context-type="linenumber">151</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">618</context>
+          <context context-type="linenumber">599</context>
         </context-group>
       </trans-unit>
       <trans-unit id="formattingRules.title" datatype="html">
@@ -586,98 +581,98 @@
         <source>JotJSON - JSON viewer, formatter, and tree explorer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">156</context>
+          <context context-type="linenumber">158</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.title.untitled" datatype="html">
         <source>Untitled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">233</context>
+          <context context-type="linenumber">235</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.quotaExceeded" datatype="html">
         <source>Blob limit reached - delete one from your saved blobs to save a new blob.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">455</context>
+          <context context-type="linenumber">457</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.signIn" datatype="html">
         <source>Please sign in to save</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">473</context>
+          <context context-type="linenumber">475</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.forbidden" datatype="html">
         <source>You do not own this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">476</context>
+          <context context-type="linenumber">478</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.generic" datatype="html">
         <source>Could not save - please try again</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">478</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="share.copyLink.unsupported" datatype="html">
-        <source>Copy is not supported in this browser.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">532</context>
+          <context context-type="linenumber">480</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.success" datatype="html">
         <source>Share link copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">541</context>
+          <context context-type="linenumber">531</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.failed" datatype="html">
         <source>Failed to copy share link.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">548</context>
+          <context context-type="linenumber">532</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="share.copyLink.unsupported" datatype="html">
+        <source>Copy is not supported in this browser.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">533</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.public" datatype="html">
         <source>Blob is now public.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">568</context>
+          <context context-type="linenumber">549</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.private" datatype="html">
         <source>Blob is now private.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">569</context>
+          <context context-type="linenumber">550</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.failed" datatype="html">
         <source>Failed to update visibility.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">575</context>
+          <context context-type="linenumber">556</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.title" datatype="html">
         <source>Delete this blob?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">590</context>
+          <context context-type="linenumber">571</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.message" datatype="html">
         <source>&quot;<x id="name" equiv-text="label"/>&quot; will be permanently deleted. This cannot be undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">591</context>
+          <context context-type="linenumber">572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="status.chars.aria" datatype="html">
@@ -1774,25 +1769,25 @@
           <context context-type="linenumber">300</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="tree.copyPath.unsupported" datatype="html">
-        <source>Copy is not supported in this browser.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">705</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="tree.copyPath.success" datatype="html">
         <source>Path copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">719</context>
+          <context context-type="linenumber">705</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.copyPath.failed" datatype="html">
         <source>Failed to copy path.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">726</context>
+          <context context-type="linenumber">706</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.copyPath.unsupported" datatype="html">
+        <source>Copy is not supported in this browser.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">707</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paste.aria" datatype="html">


### PR DESCRIPTION
Centralizes the duplicated clipboard-write + snackbar pattern shared by `json-tree`'s `copyPath` and `home`'s `onCopyShareLink` into a single core service.

## Changes
- **New:** `src/app/core/clipboard/clipboard-copy.service.ts` -- `ClipboardCopyService.copyWithToast(text, messages, durations?)`. Messages bag is `{ success, failed, unsupported }`; durations default to 3000/4000/4000 ms.
- **New:** matching spec with 6 unit tests (unsupported / writeText-missing / success / failure / custom durations).
- **Modified:** `json-tree.component.ts` -- `copyPath` collapsed from ~33 lines to ~10. `MatSnackBar` no longer injected here (it had no other usages).
- **Modified:** `home.component.ts` -- `onCopyShareLink` collapsed from ~30 lines to ~9. `MatSnackBar` retained (7 other usages).

## i18n
Callers pass already-resolved `` strings so the extractor still sees them at the original lexical positions. All existing IDs (`@@tree.copyPath.*`, `@@share.copyLink.*`, `@@common.dismiss`) are preserved verbatim -- no xlf changes.

## No behavior change
- Same snackbar durations, action label, clipboard fallback paths.
- Existing call-site specs (7 in json-tree, 3 in home) continue to pass as integration tests through the new service.

## Validation
- `npm run lint` -- pass
- `npm run test:ci` -- 632 pass / 2 skipped (was 626; +6 new ClipboardCopyService tests)
- `npm run build` -- pass
- `npm run check:ascii` -- pass

Closes #55