### PR TITLE
Profile: align controls flush right against labels

### DIFF
--- a/src/app/features/profile/profile.component.html
+++ b/src/app/features/profile/profile.component.html
@@ -93,17 +93,19 @@
 
         <div class="pref-row">
           <label for="pref-font-size" i18n="@@profile.prefs.editor.fontSize">Font size</label>
-          <input
-            id="pref-font-size"
-            type="number"
-            class="pref-number"
-            [min]="fontSizeMin"
-            [max]="fontSizeMax"
-            step="1"
-            [ngModel]="editorFontSize()"
-            (ngModelChange)="onEditorFontSizeChange($event)"
-          />
-          <span class="pref-suffix" aria-hidden="true">px</span>
+          <span class="pref-control-group">
+            <input
+              id="pref-font-size"
+              type="number"
+              class="pref-number"
+              [min]="fontSizeMin"
+              [max]="fontSizeMax"
+              step="1"
+              [ngModel]="editorFontSize()"
+              (ngModelChange)="onEditorFontSizeChange($event)"
+            />
+            <span class="pref-suffix" aria-hidden="true">px</span>
+          </span>
         </div>
 
         <div class="pref-row">
@@ -120,6 +122,7 @@
 
         <div class="pref-row">
           <mat-slide-toggle
+            labelPosition="before"
             [checked]="editorWordWrap()"
             (change)="onEditorWordWrapChange($event.checked)"
           >
@@ -135,39 +138,43 @@
 
         <div class="pref-row">
           <label for="pref-tree-font-size" i18n="@@profile.prefs.tree.fontSize">Font size</label>
-          <input
-            id="pref-tree-font-size"
-            type="number"
-            class="pref-number"
-            [min]="fontSizeMin"
-            [max]="fontSizeMax"
-            step="1"
-            [ngModel]="treeFontSize()"
-            (ngModelChange)="onTreeFontSizeChange($event)"
-          />
-          <span class="pref-suffix" aria-hidden="true">px</span>
+          <span class="pref-control-group">
+            <input
+              id="pref-tree-font-size"
+              type="number"
+              class="pref-number"
+              [min]="fontSizeMin"
+              [max]="fontSizeMax"
+              step="1"
+              [ngModel]="treeFontSize()"
+              (ngModelChange)="onTreeFontSizeChange($event)"
+            />
+            <span class="pref-suffix" aria-hidden="true">px</span>
+          </span>
         </div>
 
         <div class="pref-row pref-row--slider">
           <label for="pref-expansion-depth" i18n="@@profile.prefs.tree.expansionDepth">
             Default expansion depth
           </label>
-          <mat-slider
-            class="pref-slider"
-            [min]="expansionDepthMin"
-            [max]="expansionDepthMax"
-            step="1"
-            discrete
-            showTickMarks
-          >
-            <input
-              matSliderThumb
-              id="pref-expansion-depth"
-              [ngModel]="defaultTreeExpansionDepth()"
-              (ngModelChange)="onDefaultTreeExpansionDepthChange($event)"
-            />
-          </mat-slider>
-          <span class="pref-suffix" aria-hidden="true">{{ defaultTreeExpansionDepth() }}</span>
+          <span class="pref-control-group">
+            <mat-slider
+              class="pref-slider"
+              [min]="expansionDepthMin"
+              [max]="expansionDepthMax"
+              step="1"
+              discrete
+              showTickMarks
+            >
+              <input
+                matSliderThumb
+                id="pref-expansion-depth"
+                [ngModel]="defaultTreeExpansionDepth()"
+                (ngModelChange)="onDefaultTreeExpansionDepthChange($event)"
+              />
+            </mat-slider>
+            <span class="pref-suffix" aria-hidden="true">{{ defaultTreeExpansionDepth() }}</span>
+          </span>
           <span class="pref-help" i18n="@@profile.prefs.tree.expansionDepth.help">
             How deep the tree starts expanded when a blob loads.
           </span>
@@ -175,6 +182,7 @@
 
         <div class="pref-row">
           <mat-slide-toggle
+            labelPosition="before"
             [checked]="treeShowTypeLabels()"
             (change)="onTreeShowTypeLabelsChange($event.checked)"
           >
@@ -184,6 +192,7 @@
 
         <div class="pref-row">
           <mat-slide-toggle
+            labelPosition="before"
             [checked]="treeShowDateAnnotations()"
             (change)="onTreeShowDateAnnotationsChange($event.checked)"
           >
@@ -196,6 +205,7 @@
         <div class="pref-substack">
           <div class="pref-row pref-row--indented">
             <mat-slide-toggle
+              labelPosition="before"
               [checked]="treeAssumeUtcForIsoDateTime()"
               [disabled]="!treeShowDateAnnotations()"
               (change)="onTreeAssumeUtcForIsoDateTimeChange($event.checked)"
@@ -208,6 +218,7 @@
 
           <div class="pref-row pref-row--indented">
             <mat-slide-toggle
+              labelPosition="before"
               [checked]="treeAssumeUtcForIsoDateOnly()"
               [disabled]="!treeShowDateAnnotations()"
               (change)="onTreeAssumeUtcForIsoDateOnlyChange($event.checked)"
@@ -349,27 +360,29 @@
                     }
                   }
                 </label>
-                <input
-                  type="color"
-                  class="pref-color"
-                  [id]="field.inputId(theme)"
-                  [value]="treeHighlightColors()[theme][field.key]"
-                  (input)="
-                    onHighlightColorChange(
-                      theme,
-                      field.key,
-                      $any($event.target).value
-                    )
-                  "
-                />
-                <span
-                  class="pref-color-swatch"
-                  [style.background]="treeHighlightColors()[theme][field.key]"
-                  aria-hidden="true"
-                ></span>
-                <code class="pref-color-hex">{{
-                  treeHighlightColors()[theme][field.key]
-                }}</code>
+                <span class="pref-control-group">
+                  <input
+                    type="color"
+                    class="pref-color"
+                    [id]="field.inputId(theme)"
+                    [value]="treeHighlightColors()[theme][field.key]"
+                    (input)="
+                      onHighlightColorChange(
+                        theme,
+                        field.key,
+                        $any($event.target).value
+                      )
+                    "
+                  />
+                  <span
+                    class="pref-color-swatch"
+                    [style.background]="treeHighlightColors()[theme][field.key]"
+                    aria-hidden="true"
+                  ></span>
+                  <code class="pref-color-hex">{{
+                    treeHighlightColors()[theme][field.key]
+                  }}</code>
+                </span>
               </div>
             }
           </div>
@@ -407,6 +420,7 @@
 
         <div class="pref-row">
           <mat-slide-toggle
+            labelPosition="before"
             [checked]="searchCaseSensitive()"
             (change)="onSearchCaseSensitiveChange($event.checked)"
           >
@@ -416,6 +430,7 @@
 
         <div class="pref-row">
           <mat-slide-toggle
+            labelPosition="before"
             [checked]="searchRegexMode()"
             (change)="onSearchRegexModeChange($event.checked)"
           >

--- a/src/app/features/profile/profile.component.scss
+++ b/src/app/features/profile/profile.component.scss
@@ -106,9 +106,18 @@ dl {
 
   label,
   > span:first-child {
-    flex: 0 0 auto;
-    min-width: 12rem;
+    flex: 0 1 auto;
+    min-width: 0;
     color: var(--mat-sys-on-surface, inherit);
+  }
+
+  > label + *,
+  > span:first-child + * {
+    margin-left: auto;
+  }
+
+  > mat-slide-toggle:first-child {
+    width: 100%;
   }
 
   &--indented { padding-left: 0.25rem; }
@@ -118,6 +127,19 @@ dl {
     min-width: 12rem;
     max-width: 22rem;
   }
+}
+
+.pref-control-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+// stylelint-disable-next-line selector-pseudo-element-no-unknown
+.pref-row mat-slide-toggle:first-child ::ng-deep .mdc-form-field {
+  width: 100%;
+  justify-content: space-between;
 }
 
 .pref-substack {
@@ -160,13 +182,8 @@ dl {
 
 .pref-help {
   flex: 1 1 100%;
-  margin-left: 12rem;
   color: var(--mat-sys-on-surface-variant, #9aa0a6);
   font-size: 0.8125rem;
-
-  @media (max-width: 540px) {
-    margin-left: 0;
-  }
 }
 
 // ---------------------------------------------------------------
@@ -275,10 +292,6 @@ dl {
 
 .highlight-row {
   margin: 0.35rem 0;
-
-  label {
-    min-width: 11rem;
-  }
 }
 
 .pref-color {

--- a/src/app/features/profile/profile.component.scss
+++ b/src/app/features/profile/profile.component.scss
@@ -116,6 +116,11 @@ dl {
     margin-left: auto;
   }
 
+  > .pref-hint {
+    flex: 1 1 100%;
+    min-width: 0;
+  }
+
   > mat-slide-toggle:first-child {
     width: 100%;
   }

--- a/src/app/features/profile/profile.component.spec.ts
+++ b/src/app/features/profile/profile.component.spec.ts
@@ -521,10 +521,10 @@ describe('ProfileComponent', () => {
         root.querySelectorAll('.pref-row mat-slide-toggle')
       );
       for (const toggle of toggles) {
-        const hasLabelPosBefore = toggle.getAttribute('labelPosition') === 'before';
+        const hasLabelPositionBefore = toggle.getAttribute('labelPosition') === 'before';
         const prevSibling = toggle.previousElementSibling;
         const hasExternalLabel = prevSibling?.tagName === 'LABEL';
-        expect(hasLabelPosBefore || hasExternalLabel).toBe(true);
+        expect(hasLabelPositionBefore || hasExternalLabel).toBe(true);
       }
       expect(toggles.length).toBeGreaterThan(0);
     });

--- a/src/app/features/profile/profile.component.spec.ts
+++ b/src/app/features/profile/profile.component.spec.ts
@@ -507,6 +507,50 @@ describe('ProfileComponent', () => {
       expect(prefs.prefs().defaultRuleSetIds).toBe(before);
     });
   });
+
+  describe('flush-right layout', () => {
+    const signedIn = {
+      user: { id: 'oid-1', displayName: 'Ada', email: 'ada@example.com' },
+      isConfigured: true
+    };
+
+    it('places every settings slide-toggle with its label before the thumb', async () => {
+      const { fixture } = await create(signedIn);
+      const root = fixture.nativeElement as HTMLElement;
+      const toggles = Array.from(
+        root.querySelectorAll('.pref-row mat-slide-toggle')
+      );
+      for (const toggle of toggles) {
+        const hasLabelPosBefore = toggle.getAttribute('labelPosition') === 'before';
+        const prevSibling = toggle.previousElementSibling;
+        const hasExternalLabel = prevSibling?.tagName === 'LABEL';
+        expect(hasLabelPosBefore || hasExternalLabel).toBe(true);
+      }
+      expect(toggles.length).toBeGreaterThan(0);
+    });
+
+    it('wraps multi-piece controls in a pref-control-group', async () => {
+      const { fixture } = await create(signedIn);
+      const root = fixture.nativeElement as HTMLElement;
+
+      const fontSize = root.querySelector('#pref-font-size');
+      const fontSizeWrap = fontSize?.closest('.pref-control-group');
+      expect(fontSizeWrap).toBeTruthy();
+      expect(fontSizeWrap?.querySelector('.pref-suffix')?.textContent).toContain('px');
+
+      const treeFontSize = root.querySelector('#pref-tree-font-size');
+      expect(treeFontSize?.closest('.pref-control-group')).toBeTruthy();
+    });
+
+    it('groups slider with its value suffix', async () => {
+      const { fixture } = await create(signedIn);
+      const root = fixture.nativeElement as HTMLElement;
+      const slider = root.querySelector('mat-slider');
+      const wrap = slider?.closest('.pref-control-group');
+      expect(wrap).toBeTruthy();
+      expect(wrap?.querySelector('.pref-suffix')).toBeTruthy();
+    });
+  });
 });
 
 function makeRuleSet(partial: { id: string; name: string }): FormattingRuleSet {


### PR DESCRIPTION
Phase 1 of profile-page cleanup: make every settings row label-left / control-flush-right so the controls form a clean vertical line regardless of label length.

## What changed

- `.pref-row` no longer pins the label at `min-width: 12rem`. The first non-label child gets `margin-left: auto`, so it floats to the right edge.
- 7 `mat-slide-toggle`s gain `labelPosition="before"`, putting the inner `<span>` text on the **left** of the thumb. A scoped `::ng-deep .mdc-form-field` rule stretches the toggle to row width and space-betweens label/thumb. The recently-viewed row already had a separate `<label>`, so it just rides the new `margin-left: auto` rule.
- Multi-piece controls (font-size + `px`, slider + value, color input + swatch + hex) are wrapped in a new `<span class="pref-control-group">` so the cluster floats right as one unit.
- `.pref-help` drops its `margin-left: 12rem` magic number tied to the old label gutter; help text now wraps full-width below the row.
- 3 structural specs cover toggle label position, multi-piece control wrappers, and slider grouping.

## Mock-up

Before:

\\\
| Theme            [Dark        v]                       |
| Font size        [ 14] px                              |
| (o) Word wrap                                          |
| Default expansion depth [=====O======] 4   How deep... |
\\\

After:

\\\
| Theme                                  [Dark        v] |
| Font size                                   [ 14]  px  |
| Word wrap                                          (o) |
| Default expansion depth         [=====O======]    4    |
|   How deep the tree starts expanded...                 |
\\\

## Notes for review

- The expansion-depth slider has `max-width: 22rem`, so on the 880px-max card you may see a small gap between the short label and the slider. Kept for visual consistency; one-line change to flip if it looks bad.
- `::ng-deep` for the slide-toggle inner form-field is consistent with existing `::ng-deep` use in `profile.component.scss` and elsewhere -- not introducing a new pattern.
- Long labels on narrow viewports will wrap-and-stack-control via the existing `flex-wrap: wrap`, just triggered earlier than before. Verified at ~360px.
- No content / i18n string changes; `extract-i18n` not re-run.
- Component CSS bundle hits 6.15 kB (warning at 6 kB, error at 8 kB) -- existing budget unchanged, build is green.

## Phase-2 ideas (not in this PR)

If "less cluttered" still bites after this lands:
- Subtle row dividers / drop heavy group dividers
- Help text -> info-icon tooltip so rows stop expanding
- Collapsible groups (Material expansion panels)
- Sticky sub-nav between the Appearance / Editor / Tree / Highlights / Search / Storage groups
- Migrate number/select inputs to `mat-form-field` for visual parity with toggles

## Validation

- `npm run lint` (tsc + ascii + spec-patterns) -- pass
- `npm run test:ci` -- 758 SUCCESS, 2 skipped (pre-existing Monaco-load skips)
- `npm run build` -- pass with the 6.15 kB component-style warning above

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>