### PR TITLE
Add dependency-review-action as PR check

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,49 @@
+name: "Dependency Review"
+
+# Runs the GitHub-official dependency-review-action on every PR
+# targeting main. Diffs the dependency manifests + lockfiles against
+# the base branch and fails the check if any newly-introduced
+# dependency has a known vulnerability at moderate severity or above.
+#
+# Pairs with branch protection on main: when this check is added to
+# required_status_checks (deferred until we have observed clean runs
+# on real PRs), it gates merges on dependency safety, complementing
+# Dependabot's post-merge alerting with pre-merge prevention.
+#
+# Configuration choices documented inline below; see the audit
+# session notes for full rationale.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  # Required so the action can post the failure-summary comment on
+  # the PR. Read-only fall-through for everything else.
+  pull-requests: write
+
+concurrency:
+  group: dependency-review-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+        with:
+          # 'moderate' would have caught most of the Dependabot alerts
+          # closed in the audit (several were medium severity).
+          # 'high' lets mediums through; 'low' is noisy for transitive
+          # deps we cannot always upgrade quickly.
+          fail-on-severity: moderate
+          # Keeps clean PRs uncluttered. On failure, the action posts
+          # an inline summary explaining which dependency was blocked
+          # and why.
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
Adds GitHub's official dependency-review-action as a per-PR check that diffs the dependency graph against the base branch and fails on newly-introduced moderate-or-above CVEs. Pairs with the branch protection on main that requires PR + CI green before merge.

## Configuration

- ``fail-on-severity: moderate`` — would have caught most of the Dependabot alerts closed in the audit session that preceded this PR (several were medium severity); ``high`` would let mediums through; ``low`` is noisy for transitive deps we cannot always upgrade quickly.
- ``comment-summary-in-pr: on-failure`` — keeps clean PRs uncluttered; failures post an inline summary explaining which dep was blocked.
- ``pull_request`` trigger only (not push) — branch protection now requires PRs, so push runs would be wasted.
- ``@v4`` major-version tag (not SHA) — matches the existing repo convention for ``actions/checkout@v6``, ``azure/login@v3``, etc. SHA-pinning posture is a separate decision.
- License-checking deferred — needs a curated allow/deny list; one-line config tweak when ready.

## Branch protection

This check is intentionally **not** added to ``required_status_checks`` on ``main`` in this PR. After observing 1-2 clean runs on real PRs, follow-up will add ``Dependency review`` to the required contexts. Avoids blocking all merges on a transient action/API issue before we have confidence.

## Verification

- ``npm run check:ascii``: clean
- ``prettier --check .github/workflows/dependency-review.yml``: clean
- This PR's own diff is just the new workflow file (zero new deps), so the dependency-review job will pass trivially as a smoke test.

## Out of scope

- License compliance (deferred — needs allow-list).
- SHA-pinning of the dependency-review-action itself (deferred — separate posture decision for all third-party actions).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>