### PR TITLE
Park jwks-rsa at v3.x; codify branch-protection bypass ban

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -71,8 +71,17 @@ updates:
     # @types/node tracks the Node runtime major. We are pinned to Node 24
     # (.nvmrc, engines.node, setup-node steps in CI/CD), so block major
     # bumps for @types/node. Revisit when we move to the next LTS.
+    #
+    # jwks-rsa v4 upgrades to jose v6, which is ESM-only (no CJS dist).
+    # Jest's vm.Script-based runtime cannot parse `export` syntax, so any
+    # test suite that transitively imports api/src/shared/auth.ts fails to
+    # parse. Block major bumps until either Jest stabilizes require(esm)
+    # without --experimental-vm-modules, or jose republishes a CJS build.
+    # See api/src/shared/auth.ts for the parking-rationale comment.
     ignore:
       - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+      - dependency-name: 'jwks-rsa'
         update-types: ['version-update:semver-major']
     groups:
       azure-sdk:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,9 +20,15 @@ updates:
     commit-message:
       prefix: deps(web)
       include: scope
-    # @types/node tracks the Node runtime major. We are pinned to Node 24
-    # (.nvmrc, engines.node, setup-node steps in CI/CD), so block major
-    # bumps for @types/node. Revisit when we move to the next LTS.
+    # @types/node tracks the Node major we develop and test against. Local
+    # dev, CI, and Functions Core Tools all use Node 24 (.nvmrc,
+    # engines.node, setup-node steps). The deployed Static Web Apps
+    # managed-Functions runtime is capped at node:22 by the platform
+    # (see staticwebapp.config.json -> platform.apiRuntime), but Node 22's
+    # stdlib is a strict subset of Node 24's for what we consume, so
+    # compiling against the newer @types/node is intentional. Block major
+    # bumps for @types/node so we don't jump ahead of our local Node 24.
+    # Revisit when we move to the next LTS (or SWA raises the ceiling).
     ignore:
       - dependency-name: '@types/node'
         update-types: ['version-update:semver-major']
@@ -68,9 +74,15 @@ updates:
     commit-message:
       prefix: deps(api)
       include: scope
-    # @types/node tracks the Node runtime major. We are pinned to Node 24
-    # (.nvmrc, engines.node, setup-node steps in CI/CD), so block major
-    # bumps for @types/node. Revisit when we move to the next LTS.
+    # @types/node tracks the Node major we develop and test against. Local
+    # dev, CI, and Functions Core Tools all use Node 24 (.nvmrc,
+    # engines.node, setup-node steps). The deployed Static Web Apps
+    # managed-Functions runtime is capped at node:22 by the platform
+    # (see staticwebapp.config.json -> platform.apiRuntime), but Node 22's
+    # stdlib is a strict subset of Node 24's for what we consume, so
+    # compiling against the newer @types/node is intentional. Block major
+    # bumps for @types/node so we don't jump ahead of our local Node 24.
+    # Revisit when we move to the next LTS (or SWA raises the ceiling).
     #
     # jwks-rsa v4 upgrades to jose v6, which is ESM-only (no CJS dist).
     # Jest's vm.Script-based runtime cannot parse `export` syntax, so any

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -717,7 +717,7 @@ Before finishing a task:
   - When CI is "obviously" green and the only block is an unresolved
     review thread or missing approver.
   - When the user is unavailable and the PR has been sitting.
-  - When you have local user approval to merge — that is not the same
+  - When you have local user approval to merge -- that is not the same
     as approval to **bypass policy**. The policy exists for the human
     workflow gates (review, conversation resolution, required checks);
     user-of-the-moment consent does not waive those gates.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -708,6 +708,26 @@ Before finishing a task:
 - Never commit secrets, `.env`, `node_modules`, build output, or editor files
   beyond what `.gitignore` already covers.
 - Do not rewrite or force-push shared branches.
+- **NEVER bypass branch protection.** Do not use `gh pr merge --admin`,
+  `--force`, or any other flag/UI/API path that bypasses required
+  reviews, required status checks, or unresolved review-thread blocks.
+  This rule has zero exceptions, including:
+  - When the user owns the repo and `--admin` would technically work.
+  - When the change "looks trivial" (a comment-only edit, a typo fix).
+  - When CI is "obviously" green and the only block is an unresolved
+    review thread or missing approver.
+  - When the user is unavailable and the PR has been sitting.
+  - When you have local user approval to merge — that is not the same
+    as approval to **bypass policy**. The policy exists for the human
+    workflow gates (review, conversation resolution, required checks);
+    user-of-the-moment consent does not waive those gates.
+
+  If a PR is blocked, surface the block in plain language (which gate
+  is failing, e.g., "1 unresolved review thread", "review required",
+  "1 of 10 checks pending"), explain how it can be cleared (resolve
+  thread, request review, wait for CI), and stop. Do not propose
+  `--admin` as an option in `ask_user`. The user can clear the block
+  themselves through the GitHub UI; agents do not.
 - When a commit is authored with AI assistance, include:
 
   ```

--- a/api/src/shared/auth.ts
+++ b/api/src/shared/auth.ts
@@ -15,6 +15,12 @@
 import type { HttpRequest } from '@azure/functions';
 import * as jwt from 'jsonwebtoken';
 import type { GetPublicKeyOrSecret, JwtPayload } from 'jsonwebtoken';
+// Pinned to jwks-rsa v3.x. v4 upgrades to jose v6, which is ESM-only
+// (no CJS dist). Jest's vm.Script runtime cannot parse `export` syntax,
+// so any test suite that transitively imports this module fails to
+// parse. Revisit when Jest stabilizes require(esm) without
+// --experimental-vm-modules, or jose republishes a CJS build. The major
+// is blocked from Dependabot in .github/dependabot.yml.
 import jwksClient from 'jwks-rsa';
 import { trackEvent } from './telemetry';
 


### PR DESCRIPTION
## Summary

Two related guardrails landing together:

### 1. Park jwks-rsa at v3.x

PR #77 demonstrates that `jwks-rsa@4` cannot be adopted: it upgrades to `jose@6`, which is ESM-only (no CJS dist). Jest's `vm.Script` runtime cannot parse `export` syntax, so 5 of 12 api test suites fail to parse with:

```
SyntaxError: Unexpected token 'export'
api/node_modules/jose/dist/webapi/index.js:1
```

The v4 release notes call this out explicitly, referencing https://github.com/auth0/node-jwks-rsa/issues/493.

Changes:

- `.github/dependabot.yml`: add `ignore` rule for `jwks-rsa` major bumps in the api workspace, with a block-comment explaining why and the revisit trigger.
- `api/src/shared/auth.ts`: add an inline comment at the import documenting the parking rationale.

Patch/minor bumps for `jwks-rsa` v3.x and `jose` v5.x continue to flow through the existing groups, so security updates within the v3.x line are unaffected. `jwks-rsa` v3.2.2 was released Jan 2026 and is actively maintained.

### 2. Codify ban on branch-protection bypass

Mid-session, the user stated: never use `gh pr merge --admin`, `--force`, or any branch-protection bypass — even when they own the repo, even on trivial changes. Codified under AGENTS.md §8 with explicit zero-exceptions language. Same family of "never rewrite shared-branch state" rules as the existing rebase/force-push bans.

### 3. Comment clarification (review feedback)

Tightened the `@types/node` Dependabot comment to acknowledge the dev/CI/local Node 24 vs deployed SWA Node 22 split, with a pointer to `staticwebapp.config.json` -> `platform.apiRuntime`. Applied to both the `/` and `/api` workspace blocks.

## Revisit when (jwks-rsa)

Either: Jest stabilizes `require(esm)` without `--experimental-vm-modules`, or `jose` republishes a CJS build.

## SemVer

No bump - no user-visible change. Closes #77.