### PR TITLE
Tighten workflow permissions: scope id-token, drop unused pull-requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,25 +6,31 @@ on:
   pull_request:
     branches: [main]
 
-# Workflow-level permissions are the minimum every job needs:
+# Workflow-level permissions are the absolute minimum every job
+# needs:
 #   - contents: read   -- actions/checkout@v6 (every job)
-#   - checks: write    -- dorny/test-reporter@v2 publishes check runs
-#                         (api, api-integration, web-tests, smoke-e2e)
 #
 # Per-job escalations live in each job's `permissions:` block:
-#   - web        -> id-token: write (azure/login@v3 for sourcemap upload)
+#   - web             -> id-token: write (azure/login@v3 for sourcemap upload)
+#   - api             -> checks: write (dorny/test-reporter@v2)
+#   - api-integration -> checks: write (dorny/test-reporter@v2)
+#   - web-tests       -> checks: write (dorny/test-reporter@v2)
+#   - smoke-e2e       -> checks: write (dorny/test-reporter@v2)
+#   - workflows-lint  -> no escalation (actionlint only)
 #
 # Notable previous over-grants tightened:
 #   - id-token: write was workflow-level (giving every job an OIDC
 #     token they never used). Now scoped to the `web` job only, the
-#     only job that calls out to Azure. Reduces blast radius if a
-#     third-party action used by an unrelated job is compromised.
+#     only job that calls out to Azure.
+#   - checks: write was workflow-level (giving workflows-lint and
+#     other non-publishing jobs the right to mutate check runs they
+#     never create). Now scoped to the four dorny/test-reporter@v2
+#     callers only.
 #   - pull-requests: write was workflow-level but no step actually
 #     posts PR comments. dorny/test-reporter@v2 reports via check
-#     runs (checks: write), not PR comments. Removed.
+#     runs, not PR comments. Removed.
 permissions:
   contents: read
-  checks: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -38,10 +44,11 @@ jobs:
     # The web job calls azure/login@v3 (federated OIDC) for the
     # sourcemap upload step. id-token: write is granted only here so
     # other CI jobs cannot exchange a token for Azure access if a
-    # third-party action they invoke is compromised.
+    # third-party action they invoke is compromised. The web job does
+    # not publish check runs (no dorny/test-reporter usage), so
+    # checks: write is intentionally omitted.
     permissions:
       contents: read
-      checks: write
       id-token: write
     steps:
       - uses: actions/checkout@v6
@@ -287,6 +294,10 @@ jobs:
     name: API build & test
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Publishes test results via dorny/test-reporter@v2.
+    permissions:
+      contents: read
+      checks: write
     defaults:
       run:
         working-directory: api
@@ -353,6 +364,10 @@ jobs:
     name: Smoke api integration (real Cosmos)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Publishes test results via dorny/test-reporter@v2.
+    permissions:
+      contents: read
+      checks: write
     defaults:
       run:
         working-directory: api
@@ -458,6 +473,10 @@ jobs:
     name: Web unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Publishes test results via dorny/test-reporter@v2.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -498,6 +517,10 @@ jobs:
     name: Smoke e2e (anonymous, Chromium)
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # Publishes test results via dorny/test-reporter@v2.
+    permissions:
+      contents: read
+      checks: write
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,14 +6,25 @@ on:
   pull_request:
     branches: [main]
 
+# Workflow-level permissions are the minimum every job needs:
+#   - contents: read   -- actions/checkout@v6 (every job)
+#   - checks: write    -- dorny/test-reporter@v2 publishes check runs
+#                         (api, api-integration, web-tests, smoke-e2e)
+#
+# Per-job escalations live in each job's `permissions:` block:
+#   - web        -> id-token: write (azure/login@v3 for sourcemap upload)
+#
+# Notable previous over-grants tightened:
+#   - id-token: write was workflow-level (giving every job an OIDC
+#     token they never used). Now scoped to the `web` job only, the
+#     only job that calls out to Azure. Reduces blast radius if a
+#     third-party action used by an unrelated job is compromised.
+#   - pull-requests: write was workflow-level but no step actually
+#     posts PR comments. dorny/test-reporter@v2 reports via check
+#     runs (checks: write), not PR comments. Removed.
 permissions:
   contents: read
   checks: write
-  pull-requests: write
-  # Required for federated OIDC login (azure/login@v3) in the
-  # sourcemap-upload step. Only the web job uses it; other jobs
-  # do not call out to Azure.
-  id-token: write
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
@@ -24,6 +35,14 @@ jobs:
     name: Web build & type-check
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # The web job calls azure/login@v3 (federated OIDC) for the
+    # sourcemap upload step. id-token: write is granted only here so
+    # other CI jobs cannot exchange a token for Azure access if a
+    # third-party action they invoke is compromised.
+    permissions:
+      contents: read
+      checks: write
+      id-token: write
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -59,9 +59,18 @@ on:
       - '.github/workflows/infra.yml'
   workflow_dispatch: {}
 
+# Workflow-level permissions are the minimum every job needs:
+#   - contents: read   -- actions/checkout@v6 (every job)
+#
+# Per-job escalations live in each job's `permissions:` block:
+#   - validate -> id-token: write (azure/login@v3 for what-if)
+#   - deploy   -> id-token: write (azure/login@v3 for deployment)
+#
+# `build` (Bicep build only, no Azure call) intentionally has no
+# id-token: write. Reduces blast radius if a third-party action used
+# during build is compromised.
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   build:
@@ -85,6 +94,9 @@ jobs:
     needs: build
     if: github.event_name != 'pull_request'
     timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - name: Azure login (OIDC)
@@ -127,6 +139,9 @@ jobs:
     runs-on: ubuntu-latest
     environment: dev
     timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v6
       - uses: azure/login@v3


### PR DESCRIPTION
Audit-driven hardening of three over-grants in workflow permissions blocks. All changes follow the principle of granting elevated permissions only at the job level where they are actually used.

## Findings addressed

**A. `ci.yml`: workflow-level `id-token: write` -> `web` job only**
The workflow-level grant gave every CI job (web, api, api-integration, workflows-lint, web-tests, smoke-e2e) a federated identity token they could exchange for Azure access. Only the `web` job actually calls `azure/login@v3` (sourcemap upload). The pre-existing comment already noted 'Only the web job uses it' -- the permission was just never tightened to match. **Five jobs lose access to a credential they never needed**, reducing blast radius if any third-party action used by an unrelated job is compromised.

**B. `ci.yml`: drop `pull-requests: write`**
No step in ci.yml posts PR comments. The only PR-status-related action is `dorny/test-reporter@v2`, which per its README only requires `checks: write` (creates check runs, not PR comments). `pull-requests: write` was vestigial.

**C. `infra.yml`: workflow-level `id-token: write` -> `validate` + `deploy` jobs only**
The `build` job (Bicep build, no Azure call) doesn't need it. Same blast-radius reduction as A.

## What did not change

- `cd.yml` -- single-job workflow, all permissions used. No change.
- `codeql.yml` -- standard CodeQL action requirements. No change.
- `dependency-review.yml` -- the action posts PR comments on failure (`pull-requests: write` actually used). No change.

## Verification

- `npm run check:ascii`: clean.
- `prettier --write` applied.
- No functional changes -- the workflows produce the same outputs in the same conditions; only the metadata that grants permissions to the GITHUB_TOKEN is tightened.
- If something silently relied on `pull-requests: write` in `ci.yml` (Finding B is the most uncertain), CI on this PR will surface it via a permission-denied error in the test-reporter step. Easy to revert just that one-liner.

## Risk

- **A and C**: very low. Comment-confirmed and code-confirmed that the demoted permission was unused at those job sites.
- **B**: low. dorny/test-reporter v2 README documents `checks: write` only. If the action has undocumented PR-comment behavior, the test-reporter step will fail visibly.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>