### PR TITLE
chore(api): add .funcignore for trimmed Functions deploy

### DIFF
--- a/api/.funcignore
+++ b/api/.funcignore
@@ -1,0 +1,50 @@
+# Azure Functions deployment exclusion list (gitignore-style).
+#
+# Honored by `func azure functionapp publish` (Azure Functions Core
+# Tools) and by the Static Web Apps managed-Functions publish path.
+# Directory patterns are anchored with a leading `/` defensively so
+# that they only match at the api/ root, even if a parser uses
+# git-style "match anywhere" semantics. Without the leading `/`, a
+# pattern like `src/` could match `dist/src/`, which would strip the
+# compiled Functions entry points referenced by package.json `main`.
+#
+# Runtime essentials kept: host.json, package.json, package-lock.json,
+# node_modules/, dist/.
+
+# Source - compiled to /dist before deploy
+/src/
+/tsconfig.json
+/tsconfig.test.json
+*.tsbuildinfo
+
+# Tests
+/integration/
+/jest.config.js
+/jest.config.integration.js
+/test-results/
+/coverage/
+
+# One-off CI/dev helpers (not used by Functions runtime)
+/scripts/
+
+# Local dev
+/local.settings.json
+/local.settings.sample.json
+
+# Docs / repo metadata
+/README.md
+/.gitignore
+/.funcignore
+
+# IDE / editor
+/.vscode/
+/.vs/
+
+# Source maps (debug-only; small but unnecessary in production)
+**/*.js.map
+
+# Azure Functions Core Tools local state (mirrors api/.gitignore)
+/.python_packages/
+/bin/
+/obj/
+*.log

--- a/api/.funcignore
+++ b/api/.funcignore
@@ -40,8 +40,11 @@
 /.vscode/
 /.vs/
 
-# Source maps (debug-only; small but unnecessary in production)
-**/*.js.map
+# Source maps (debug-only; small but unnecessary in production).
+# Bare pattern (no leading `/`) matches at any depth, per gitignore
+# semantics, without relying on globstar `**/` support that not all
+# .funcignore parsers implement.
+*.js.map
 
 # Azure Functions Core Tools local state (mirrors api/.gitignore)
 /.python_packages/


### PR DESCRIPTION
Closes #136.

Adds `api/.funcignore` listing tracked sources, configs, scripts, and dev-only artifacts that the Azure Functions runtime does not read. The deployed tree keeps `host.json`, `package.json`, `package-lock.json`, `node_modules/`, and `dist/`.

## Why anchor every directory pattern with leading `/`

The Core Tools parser (`Azure/azure-functions-core-tools` `GitIgnoreParser.cs`) is strictly root-anchored. The Static Web Apps managed-Functions publish path uses `StaticSitesClient` (closed-source), and under git-style "match anywhere" semantics, an unanchored `src/` would match `dist/src/` and strip every compiled handler that `api/package.json` `main: ""dist/src/functions/*.js""` references - a total API outage. Leading-`/` anchoring is free defense-in-depth.

## Verification

- `npm run lint:all` green locally.
- **Post-merge** (the real check): the SWA deploy step in CD logs `Calculating the size of api artifacts: N B`. If N drops materially versus the prior CD run, `.funcignore` was honored. If not, the file is a no-op (no regression - deployed tree is unchanged from today).
- Regression smoke: curl `/api/health`, `/api/me`, `/api/blobs/...`. These exercise `dist/src/functions/*.js` which is never excluded; they cannot detect the `honored vs. no-op` distinction but they do catch any catastrophic over-exclusion.

## Out of scope

This change does not trim `api/node_modules/`, which is the dominant byte source in the deploy (`npm ci` at `cd.yml:295` installs both `dependencies` and `devDependencies`). A follow-up issue will cover `--omit=dev` (or equivalent) for the deploy install.

## SemVer

No bump. Build/CI infrastructure change.
