### PR TITLE
ci(cd): install api with --omit=dev on workflow_run path

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -282,15 +282,40 @@ jobs:
         run: az logout --username "${{ secrets.AZURE_CLIENT_ID }}" || true
 
       # ------------------------------------------------------------------
-      # Shared: install api production deps on the runner so the SWA
-      # upload (with skip_api_build: true) sees a fully-runnable
-      # Functions tree at api_location. The TS->JS compile is done in
-      # CI's `api` job (workflow_run path -> downloaded as api-dist) or
-      # by the "Build API (manual deploy)" step below (workflow_dispatch
+      # Shared: install api deps on the runner so the SWA upload (with
+      # skip_api_build: true) sees a fully-runnable Functions tree at
+      # api_location. The TS->JS compile is done in CI's `api` job
+      # (workflow_run path -> downloaded as api-dist) or by the
+      # "Build API (manual deploy)" step below (workflow_dispatch
       # path); Oryx is no longer in the deploy pipeline.
+      #
+      # The two trigger paths install differently on purpose:
+      #
+      # - workflow_run (auto on push-to-main): the api-dist artifact
+      #   carries the compiled dist/, so no tsc runs on the runner.
+      #   We install with `--omit=dev` to skip ~54 MB of typescript /
+      #   jest / @types/* that the Functions runtime never reads.
+      #
+      # - workflow_dispatch (manual redeploy): no artifact; the runner
+      #   compiles via `npm run build`, which needs typescript (a
+      #   devDep). We do a full `npm ci` and DELIBERATELY do not prune
+      #   devDeps after build. The manual path is the fast-rollback
+      #   hatch - keeping it maximally-permissive means a `gh workflow
+      #   run cd.yml` can recover from any failure mode the slim path
+      #   introduces. The ~80 MB cost on a rare manual deploy buys a
+      #   working recovery option.
+      #
+      # Use a positive `event_name == 'workflow_run'` match (not a
+      # negation): future trigger additions fail safely instead of
+      # silently falling into the slim-install branch.
       # ------------------------------------------------------------------
-      - name: Install API deps
-        if: steps.check.outputs.have_token == 'true'
+      - name: Install API production deps (workflow_run)
+        if: steps.check.outputs.have_token == 'true' && github.event_name == 'workflow_run'
+        working-directory: api
+        run: npm ci --omit=dev
+
+      - name: Install API full deps (workflow_dispatch)
+        if: steps.check.outputs.have_token == 'true' && github.event_name == 'workflow_dispatch'
         working-directory: api
         run: npm ci
 
@@ -303,6 +328,32 @@ jobs:
         if: steps.check.outputs.have_token == 'true' && github.event_name == 'workflow_dispatch'
         working-directory: api
         run: npm run build
+
+      - name: Verify devDeps were omitted (workflow_run)
+        # Guard against silent regressions: if a future npm release
+        # changes `--omit=dev` semantics, or someone moves a devDep
+        # into `dependencies`, this step fails the deploy with a clear
+        # message instead of letting the artifact balloon back
+        # unnoticed.
+        #
+        # Only check packages that are pure devDeps AND not
+        # transitively pulled by any prod dep. `@types/node` and
+        # `@types/jsonwebtoken` survive `--omit=dev` as transitive
+        # deps of `applicationinsights` and `jwks-rsa` respectively
+        # (verified via `npm ls @types/node`); they are inert .d.ts
+        # files at runtime and not worth blocking the deploy on.
+        if: steps.check.outputs.have_token == 'true' && github.event_name == 'workflow_run'
+        working-directory: api
+        run: |
+          fail=0
+          for d in typescript jest ts-jest jest-junit; do
+            if [ -d "node_modules/$d" ]; then
+              echo "::error::Expected node_modules/$d to be absent after --omit=dev, but it exists."
+              fail=1
+            fi
+          done
+          if [ "$fail" = "1" ]; then exit 1; fi
+          echo "OK: known devDeps absent from node_modules/."
 
       - name: Deploy to Azure Static Web Apps
         if: steps.check.outputs.have_token == 'true'

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -336,19 +336,27 @@ jobs:
         # message instead of letting the artifact balloon back
         # unnoticed.
         #
-        # Only check packages that are pure devDeps AND not
-        # transitively pulled by any prod dep. `@types/node` and
-        # `@types/jsonwebtoken` survive `--omit=dev` as transitive
-        # deps of `applicationinsights` and `jwks-rsa` respectively
-        # (verified via `npm ls @types/node`); they are inert .d.ts
-        # files at runtime and not worth blocking the deploy on.
+        # `npm ls <pkg> --all --parseable` walks the full installed
+        # tree (including nested `node_modules/<dep>/node_modules/`
+        # entries that npm may emit when resolving version conflicts),
+        # so a top-level `[ -d node_modules/$d ]` check would miss
+        # those. The parseable output is empty when the package is
+        # absent.
+        #
+        # The check list is intentionally limited to the highest-
+        # impact pure devDeps from `api/package.json`. `@types/node`
+        # and `@types/jsonwebtoken` are deliberately excluded: they
+        # survive `--omit=dev` as transitive deps of
+        # `applicationinsights` and `jwks-rsa` respectively (verified
+        # via `npm ls @types/node`), are inert .d.ts files at runtime,
+        # and not worth blocking the deploy on.
         if: steps.check.outputs.have_token == 'true' && github.event_name == 'workflow_run'
         working-directory: api
         run: |
           fail=0
-          for d in typescript jest ts-jest jest-junit; do
-            if [ -d "node_modules/$d" ]; then
-              echo "::error::Expected node_modules/$d to be absent after --omit=dev, but it exists."
+          for d in typescript jest ts-jest jest-junit "@types/jest"; do
+            if [ -n "$(npm ls "$d" --all --parseable 2>/dev/null)" ]; then
+              echo "::error::Expected $d to be absent from node_modules after --omit=dev, but npm reports it installed."
               fail=1
             fi
           done


### PR DESCRIPTION
Closes #164.

## What

Branches the CD workflow's API install step on trigger so the auto-deploy path skips ~54 MB of devDeps while the manual-redeploy path stays maximally-permissive.

| Path | Install | Build | Prune | Verify | Result |
|---|---|---|---|---|---|
| `workflow_run` (auto push-to-main) | `npm ci --omit=dev` | (skipped - uses api-dist artifact) | n/a | yes | slim |
| `workflow_dispatch` (manual) | `npm ci` (full) | `npm run build` | none | n/a | full (safety hatch) |

Local size measurement on this branch's lockfile: `api/node_modules` **180.5 MB -> 126.6 MB (-54 MB, -30%)**.

## Why keep the manual path full

The manual `workflow_dispatch` is the fast-rollback hatch. If `--omit=dev` ever breaks production - because npm changes `--omit` semantics, or a future package author moves a runtime require behind a peerOptional we missed - `gh workflow run cd.yml` reinstalls everything and recovers. The ~80 MB cost on a rare manual deploy is paid in exchange for that working recovery option. Pruning on both paths would eliminate the hatch.

## Why a positive `event_name == 'workflow_run'` match

Negation (`!= 'workflow_dispatch'`) would silently catch any future trigger addition (`workflow_call`, `schedule`) and run them with the slim install regardless of whether they actually downloaded a prebuilt `dist/`. Positive match fails safely instead.

## Verify step

A new `Verify devDeps were omitted` step on the workflow_run path fails the deploy with a clear `::error::` annotation if any of `typescript`, `jest`, `ts-jest`, or `jest-junit` survive `--omit=dev`. This catches:
- npm release changing `--omit` semantics
- Someone moving a devDep into `dependencies` accidentally
- Lockfile drift introducing a new peerOptional path

`@types/node` and `@types/jsonwebtoken` are deliberately not in the check list: they survive `--omit=dev` as transitive deps of `applicationinsights` and `jwks-rsa` respectively (verified via `npm ls @types/node`), are inert .d.ts files at runtime, and not worth blocking the deploy on.

## Production-import audit

Every non-test `api/src/**/*.ts` file imports only `@azure/cosmos`, `@azure/functions`, `applicationinsights`, `jsonc-parser`, `jsonwebtoken`, `jwks-rsa`, or Node builtins (`crypto`). All in `dependencies`. `@azure/identity` is lazy-`require`d at `cosmos.ts:65-66` (deliberately structured to dodge Jest's ESM transform; see comment at the top of that file) AND is transitive via `applicationinsights`. Both keep it installed under `--omit=dev`.

## Verification

- `npm run lint:all` green locally.
- Local sim: `npm ci --omit=dev` in `api/` -> 126.6 MB tree; all 7 prod deps `require()`able from a Node REPL.
- **Post-merge**: read the SWA deploy step output for the `Calculating the size of api artifacts: N B` log line and compare to the previous CD run; expected drop is tens of MB. Smoke `/api/health`, `/api/me`, `/api/blobs/<existing>`.

## SemVer

No bump. Build/CI infrastructure.

## Out of scope

- Verifying that PR #163's `.funcignore` is actually honored by the SWA upload path (orthogonal; this change's byte drop is independent).
- `actions/setup-node` cache-dependency-path correction (currently keyed only on root `package-lock.json`; cold-misses api installs every run).
