### PR TITLE
docs(spec): retire PR-by-default readiness item; document branch protection

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -1478,12 +1478,13 @@ key fallback can be removed. Local `func start` also uses `COSMOS_KEY`.
 - **Infrastructure** - Bicep templates applied via a separate workflow on changes to `/infra` directory.
 - **Workflow lint** - `actionlint` runs against `.github/workflows/` in CI.
 - **Spec-pattern lint** - `scripts/check-spec-patterns.mjs` runs in CI's lint job and fails on known-fragile testing idioms (e.g. `spyOnProperty(navigator, 'clipboard', ...)` which silently passes on Windows headless Chrome but throws on the Linux runner). New rules are added as we encounter cross-platform test failures.
+- **Branch protection on `main`** - required PR with green required status checks (web build, api build, workflow lint, web unit tests, anonymous smoke e2e, api integration, CodeQL), `required_linear_history: true`, `allow_force_pushes: false`, and `required_conversation_resolution: true`. PRs are the only sanctioned path to `main`; the bypass ban is codified in `AGENTS.md` §8.
 
 ### Pre-v1 readiness review
 
-Items to revisit before declaring v1 complete (deliberately deferred so they do not slow current development velocity):
+Items revisited before declaring v1 complete (deliberately deferred so they did not slow current development velocity). **All items in this section are now done**; enforcement of the PR-by-default policy lives in branch protection on `main` and in `AGENTS.md` §8 ("NEVER bypass branch protection").
 
-- **PR-by-default for code changes.** Today, code changes can land directly on `main`. Decide whether v1 should require code changes to land via a PR with green CI before merging, with CD/workflow hotfixes remaining as the only sanctioned direct-to-`main` path. Rationale for deferring now: keeps iteration velocity high; CI on `push: main` still runs, just after merge.
+- ~~**PR-by-default for code changes.** Code changes must land via a PR with green CI before merging; CD/workflow hotfixes remain as the only sanctioned direct-to-`main` path.~~ (done - enforced by branch protection: `required_pull_request_reviews`, required status checks, `required_linear_history: true`, `allow_force_pushes: false`; bypass ban codified in `AGENTS.md` §8.)
 - ~~**Bundle size budget.** `angular.json` `maximumWarning` / `maximumError` were temporarily relaxed; tighten before launch.~~ (done)
 
 ---


### PR DESCRIPTION
Retires the PR-by-default item in DESIGN_SPEC.md sec.Pre-v1 readiness review now that branch protection on main operationally enforces it (and AGENTS.md sec.8 codifies the bypass ban via PR #155).

## Audit summary (from this session)

Verified what's actually pending for v1 vs. what's done-but-undocumented. Findings:

**Genuinely pending v1 items (untouched here):**
- #100 - highlight flyout keyboard a11y (priority:high)
- #134 - SWA-config smoke decision (priority:high)
- #95 - tree virtualization NFR (priority:medium)
- #96 - stacked comments collapse bug (priority:medium)

**Done but stale in spec:**
- PR-by-default - this PR fixes it.

Everything else surveyed (M7o, #108/#125/#146, #128-#133 v1 follow-ups, telemetry expansion, etc.) is already correctly documented as post-v1 / out-of-scope / follow-up.

## Changes

1. DESIGN_SPEC.md sec.Pre-v1 readiness review (line ~1483) - strikethrough the PR-by-default bullet with (done) tag matching the bundle-size bullet on the next line; preamble updated to note all items are done; points readers at branch protection + AGENTS.md sec.8 for the policy's enforcement home.
2. DESIGN_SPEC.md sec.CI/CD - one-line note documenting branch protection on main (required PR, required status checks, no force push, linear history).

## SemVer bump
No bump (doc-only).

## Verification
`npm run lint` passes (tsc, ASCII gate, spec-pattern, prod-pattern, CSP hashes, lockfile, prettier).
