### PR TITLE
Add merge_group trigger to ci and codeql workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,11 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # merge_group fires on the temp ref the merge queue builds
+  # (main + queued PR). Required so the 6 checks below report on
+  # the merge-group SHA the queue tests before fast-forwarding main.
+  # See AGENTS.md section 8 for the merge-queue notes.
+  merge_group:
 
 # Workflow-level permissions are the absolute minimum every job
 # needs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,11 @@ on:
     # Weekly Monday-noon-UTC scan catches drift between PR runs (e.g.,
     # transitive dependency advisories that land between pushes).
     - cron: '0 12 * * 1'
+  # merge_group fires on the temp ref the merge queue builds
+  # (main + queued PR). Required so the two Analyze checks below
+  # report on the merge-group SHA the queue tests before
+  # fast-forwarding main. See AGENTS.md section 8.
+  merge_group:
 
 permissions:
   actions: read


### PR DESCRIPTION
Adds the `merge_group` event trigger to `ci.yml` and `codeql.yml` so the 8 status checks GitHub branch protection requires on `main` also run on the temporary ref the merge queue builds (`main` + queued PR). Without this, queued PRs would stall waiting for checks that never fire on the `merge_group` event.

This PR is step 1 of a 3-part rollout to replace the manual `Update branch` loop with a sequential merge queue. After this lands:

1. PATCH the `Main ruleset` to add a `merge_queue` rule (`max_entries_to_build = max_entries_to_merge = 1` so every SHA on `main` was actually validated; squash; 60-min check timeout).
2. PUT classic branch protection on `main` to set `required_status_checks.strict = false` (mandatory - GitHub treats `strict` + merge queue as incompatible).
3. Verify end-to-end with a follow-up no-op PR and add an `AGENTS.md` section 8 note.

## Why now

PRs with auto-merge enabled stall whenever a new commit lands on `main` because `required_status_checks.strict = true` is on. Every stall needs a manual `Update branch` click. Merge queue eliminates the loop by handling freshness on a side ref.

## Why max-batch = 1 (not GitHub's default batched mode)

Batched mode validates `main + A + B + C` as one group and lands all three; the intermediate states (`main + A`, `main + A + B`) appear on `main`'s history but were never tested - breaks `git bisect` accuracy and complicates reverts. With max = 1, every SHA on `main` was actually validated. Serialization cost is irrelevant for this repo.

## Safety

This commit alone changes nothing about how PRs merge today. It only adds an event trigger; `concurrency.cancel-in-progress` continues to evaluate `false` for `merge_group` (so future queue runs are not cancelled mid-flight), and the existing `if: github.event_name == 'push' && github.ref == 'refs/heads/main'` guards on deploy steps will skip on `merge_group` (correct - the queue is pre-merge validation, not deployment).

## Verification

CI must pass on this PR (same checks as today). No new tests added; this is a workflow-config change validated by actionlint (the `Workflows lint (actionlint)` check below).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>