### PR TITLE
Extract scheduleStaticSplashRemoval; fix flaky AppComponent spec (#170)

### DIFF
--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -8,6 +8,7 @@ import { LoggerService } from './core/telemetry/logger.service';
 import { RouteTracker } from './core/telemetry/route-tracker';
 import { AppUpdateService } from './core/update/app-update.service';
 import { DocumentDropController } from './core/upload/document-drop-controller.service';
+import * as staticSplashRemoval from './static-splash-removal';
 
 function waitForDoubleAnimationFrame(): Promise<void> {
   return new Promise<void>((resolve) => {
@@ -15,60 +16,6 @@ function waitForDoubleAnimationFrame(): Promise<void> {
       requestAnimationFrame(() => resolve());
     });
   });
-}
-
-interface RafController {
-  step: () => Promise<void>;
-  pendingCount: () => number;
-  waitForPending: (n: number, timeoutMs?: number) => Promise<void>;
-  restore: () => void;
-}
-
-// Replaces the real `window.requestAnimationFrame` with a manual queue
-// so tests can step rAF turns deterministically. AppComponent's static-
-// splash removal hook is `afterNextRender(() => rAF(() => rAF(remove)))`,
-// and the previous tests that timed real rAFs were intermittently flaky
-// in CI because Angular's afterNextRender outer rAF could land in the
-// same animation frame as the test's own rAF. The shim isolates the
-// two nested rAFs from any framework-side scheduling.
-//
-// Note: the shim does NOT control `afterNextRender` itself - that is
-// scheduled through Angular's after-render manager, not rAF. Use
-// `waitForPending(1)` after `whenStable()` to wait for the outer rAF
-// to land in the controlled queue before stepping.
-function installControlledRaf(): RafController {
-  const queue: FrameRequestCallback[] = [];
-  const original = window.requestAnimationFrame;
-  window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-    queue.push(cb);
-    return queue.length;
-  }) as typeof window.requestAnimationFrame;
-  return {
-    step: async () => {
-      const cb = queue.shift();
-      if (cb) {
-        cb(performance.now());
-      }
-      // Microtask flush so any work scheduled inside the callback
-      // settles before the next assertion.
-      await Promise.resolve();
-    },
-    pendingCount: () => queue.length,
-    waitForPending: async (n, timeoutMs = 1000) => {
-      const start = Date.now();
-      while (queue.length < n) {
-        if (Date.now() - start > timeoutMs) {
-          throw new Error(
-            `timed out waiting for ${n} pending rAF callback(s); have ${queue.length}`,
-          );
-        }
-        await new Promise((resolve) => setTimeout(resolve, 1));
-      }
-    },
-    restore: () => {
-      window.requestAnimationFrame = original;
-    },
-  };
 }
 
 describe('AppComponent', () => {
@@ -226,50 +173,52 @@ describe('AppComponent', () => {
       return splash;
     }
 
-    it('removes #jot-static-splash after exactly two rAF turns (paint barrier)', async () => {
-      // This merged spec replaces the previous double-rAF + single-rAF
-      // sentinel pair. The intent of the sentinel ("guard against the
-      // removal hook regressing to single-rAF") is preserved as the
-      // intermediate `after 1 rAF the splash is still present`
-      // assertion + queue-count check below.
-      //
-      // Determinism: we install a controlled-rAF shim BEFORE creating
-      // the fixture so AppComponent's two nested rAFs are captured by
-      // the shim, then poll the queue to wait for Angular's
-      // afterNextRender to fire and queue the outer rAF.
-      const splash = setUpStaticSplash();
-      const raf = installControlledRaf();
-      let fixture: ReturnType<typeof TestBed.createComponent<AppComponent>> | undefined;
+    it("invokes scheduleStaticSplashRemoval exactly once from AppComponent's afterNextRender hook", async () => {
+      // Structural assertion: AppComponent must call the extracted
+      // helper exactly once per lifecycle. This catches regressions
+      // where someone removes the hook entirely or accidentally
+      // converts `afterNextRender` to `afterRender` (which fires on
+      // every change-detection cycle) without exercising real rAFs.
+      // The double-rAF / paint-barrier semantics are covered by
+      // static-splash-removal.spec.ts in isolation, free of
+      // cross-spec rAF bleed (see #170).
+      const spy = jasmine.createSpy<() => void>('scheduleStaticSplashRemoval');
+      staticSplashRemoval.__setScheduleStaticSplashRemovalImplForTesting(spy);
       try {
-        fixture = TestBed.createComponent(AppComponent);
+        const fixture = TestBed.createComponent(AppComponent);
         fixture.detectChanges();
         await fixture.whenStable();
+        // Flush one macrotask so any after-render callbacks scheduled
+        // by Angular's render manager have had a chance to fire.
+        // Mirrors the web-vitals init spy test above.
+        await new Promise<void>((resolve) => setTimeout(resolve, 0));
 
-        // afterNextRender runs through Angular's after-render manager,
-        // not rAF. Wait for it to fire and queue the outer rAF in the
-        // controlled queue before stepping.
-        await raf.waitForPending(1);
-        expect(raf.pendingCount()).toBe(1);
-
-        // Step 1: outer rAF runs and queues the inner rAF.
-        await raf.step();
-        expect(document.getElementById('jot-static-splash'))
-          .withContext('after 1 rAF the splash is still present (sentinel)')
-          .toBe(splash);
-        expect(raf.pendingCount())
-          .withContext('inner rAF must be queued after outer rAF runs')
-          .toBe(1);
-
-        // Step 2: inner rAF removes the splash.
-        await raf.step();
-        expect(document.getElementById('jot-static-splash'))
-          .withContext('after 2 rAFs the splash is removed')
-          .toBeNull();
-        expect(raf.pendingCount()).withContext('no further rAFs should be queued').toBe(0);
+        expect(spy).toHaveBeenCalledTimes(1);
       } finally {
-        fixture?.destroy();
-        raf.restore();
+        staticSplashRemoval.__resetScheduleStaticSplashRemovalImplForTesting();
       }
+    });
+
+    it('removes #jot-static-splash via the real scheduler after Angular renders (happy-path smoke)', async () => {
+      // Smoke test for the end-to-end wiring with the REAL
+      // scheduleStaticSplashRemoval impl. No rAF shim is installed, so
+      // all rAFs run on the native browser queue and this spec is
+      // immune to the cross-spec rAF bleed that motivated the
+      // isolated-spec extraction (#170). The assertion depends only
+      // on the splash being absent at the end, which is robust to
+      // foreign rAF interleavings: any foreign rAF callback that ran
+      // would either be unrelated (no-op for our assertion) or would
+      // itself remove the splash early (still satisfies the
+      // assertion).
+      const splash = setUpStaticSplash();
+      expect(document.getElementById('jot-static-splash')).toBe(splash);
+
+      const fixture = TestBed.createComponent(AppComponent);
+      fixture.detectChanges();
+      await fixture.whenStable();
+      await waitForDoubleAnimationFrame();
+
+      expect(document.getElementById('jot-static-splash')).toBeNull();
     });
 
     it('does not throw when #jot-static-splash is absent (e.g. shell.html serve path)', async () => {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -9,6 +9,7 @@ import { AppUpdateService } from './core/update/app-update.service';
 import { DocumentDropController } from './core/upload/document-drop-controller.service';
 import { LoadingSplashComponent } from './shared/components/loading-splash/loading-splash.component';
 import { RouteProgressBarComponent } from './shared/components/route-progress-bar/route-progress-bar.component';
+import { scheduleStaticSplashRemoval } from './static-splash-removal';
 
 @Component({
   selector: 'app-root',
@@ -79,20 +80,21 @@ export class AppComponent implements OnInit {
   // remove it explicitly once Angular has taken over.
   //
   // `afterNextRender` is browser-only (no-op during SSR), runs after
-  // Angular's render phases, and the inner double-rAF defers the
-  // removal one full paint past Angular's first commit. This matches
-  // the canonical paint-barrier idiom used by HomeComponent and
-  // JsonTreeComponent: a single rAF can fire on the same tick as the
-  // pending paint, leaving a flash gap; double-rAF guarantees the
-  // browser has actually painted the Angular splash before the
-  // static splash is detached, so the visual handoff is seamless
-  // (both render the identical `.jot-splash` markup).
+  // Angular's render phases, and the inner double-rAF (inside
+  // `scheduleStaticSplashRemoval`) defers the removal one full paint
+  // past Angular's first commit. This matches the canonical
+  // paint-barrier idiom used by HomeComponent and JsonTreeComponent:
+  // a single rAF can fire on the same tick as the pending paint,
+  // leaving a flash gap; double-rAF guarantees the browser has
+  // actually painted the Angular splash before the static splash is
+  // detached, so the visual handoff is seamless (both render the
+  // identical `.jot-splash` markup).
+  //
+  // The body lives in `./static-splash-removal.ts` so the double-rAF
+  // behavior can be unit-tested in isolation, free of cross-spec rAF
+  // bleed (see #170 and `static-splash-removal.spec.ts`).
   private readonly _removeStaticSplash = afterNextRender(() => {
-    requestAnimationFrame(() => {
-      requestAnimationFrame(() => {
-        document.getElementById('jot-static-splash')?.remove();
-      });
-    });
+    scheduleStaticSplashRemoval();
   });
 
   ngOnInit(): void {

--- a/src/app/static-splash-removal.spec.ts
+++ b/src/app/static-splash-removal.spec.ts
@@ -1,0 +1,128 @@
+// Isolated spec for `scheduleStaticSplashRemoval`. See #170.
+//
+// SAFETY INVARIANT - DO NOT REMOVE: this spec is safe from cross-spec
+// rAF bleed only because it never yields to the task queue between
+// installing the controlled-rAF shim and the final assertion.
+// Concretely:
+//
+//   - `scheduleStaticSplashRemoval()` is called SYNCHRONOUSLY (no
+//     `await fixture.whenStable()`, no `TestBed` fixture, no DI).
+//   - `step()` ends with `await Promise.resolve()` (a microtask
+//     only - no task boundary).
+//   - No `setTimeout`, no `setInterval`, no `waitForPending`-style
+//     poll, no `fixture.whenStable()`, no `requestIdleCallback` is
+//     used anywhere in this file.
+//
+// Because nothing yields to the macrotask queue, the browser cannot
+// fire foreign native `requestAnimationFrame` callbacks queued by
+// prior specs in the same Karma session between our assertions.
+// Adding ANY task-yielding wait (`setTimeout`, `whenStable`,
+// `waitForPending`, etc.) between shim install and the final
+// assertion reopens the cross-spec rAF bleed window and reintroduces
+// the flake this fix was written to eliminate.
+//
+// If you find yourself wanting to add a task-yielding wait here,
+// stop. Either the test belongs in `app.component.spec.ts` (where
+// the bleed is structurally tolerated via the spy seam), or it
+// belongs in a separate, larger refactor that audits the entire
+// Karma suite for foreign rAF emitters.
+
+import { scheduleStaticSplashRemoval } from './static-splash-removal';
+
+interface RafController {
+  step: () => Promise<void>;
+  pendingCount: () => number;
+  restore: () => void;
+}
+
+function installControlledRaf(): RafController {
+  const queue: FrameRequestCallback[] = [];
+  const original = window.requestAnimationFrame;
+  window.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+    queue.push(cb);
+    return queue.length;
+  }) as typeof window.requestAnimationFrame;
+  return {
+    step: async () => {
+      const cb = queue.shift();
+      if (cb) {
+        cb(performance.now());
+      }
+      // Microtask flush only - intentionally no task boundary. See
+      // SAFETY INVARIANT at top of file.
+      await Promise.resolve();
+    },
+    pendingCount: () => queue.length,
+    restore: () => {
+      window.requestAnimationFrame = original;
+    },
+  };
+}
+
+function setUpStaticSplash(): HTMLDivElement {
+  const splash = document.createElement('div');
+  splash.id = 'jot-static-splash';
+  splash.className = 'jot-splash';
+  splash.setAttribute('role', 'status');
+  splash.setAttribute('aria-live', 'polite');
+  document.body.appendChild(splash);
+  return splash;
+}
+
+describe('scheduleStaticSplashRemoval', () => {
+  afterEach(() => {
+    // Belt-and-suspenders cleanup: if a test left the splash in the
+    // DOM (e.g., it threw before the second step), remove it so it
+    // does not bleed into subsequent specs.
+    document.getElementById('jot-static-splash')?.remove();
+  });
+
+  it('removes #jot-static-splash after exactly two rAF turns (paint barrier)', async () => {
+    const splash = setUpStaticSplash();
+    const raf = installControlledRaf();
+    try {
+      scheduleStaticSplashRemoval();
+
+      // After the synchronous call, exactly one rAF must be queued
+      // (the outer one). The shim install is guaranteed to be in
+      // place because it ran synchronously before the call.
+      expect(raf.pendingCount())
+        .withContext('one outer rAF queued by scheduleStaticSplashRemoval')
+        .toBe(1);
+
+      // Step 1: outer rAF runs and queues the inner rAF. The splash
+      // must still be present (sentinel: catches regressions to a
+      // single-rAF implementation).
+      await raf.step();
+      expect(document.getElementById('jot-static-splash'))
+        .withContext('after 1 rAF the splash is still present')
+        .toBe(splash);
+      expect(raf.pendingCount()).withContext('inner rAF queued after outer ran').toBe(1);
+
+      // Step 2: inner rAF removes the splash.
+      await raf.step();
+      expect(document.getElementById('jot-static-splash'))
+        .withContext('after 2 rAFs the splash is removed')
+        .toBeNull();
+      expect(raf.pendingCount()).withContext('queue drained').toBe(0);
+    } finally {
+      raf.restore();
+    }
+  });
+
+  it('does not throw when #jot-static-splash is absent', async () => {
+    // Mirrors the shell.html / hot-reload path where no static splash
+    // ever existed. Optional chaining must make the removal a no-op.
+    expect(document.getElementById('jot-static-splash')).toBeNull();
+    const raf = installControlledRaf();
+    try {
+      scheduleStaticSplashRemoval();
+      await raf.step();
+      await raf.step();
+      expect(document.getElementById('jot-static-splash')).toBeNull();
+      expect(raf.pendingCount()).toBe(0);
+    } finally {
+      raf.restore();
+    }
+  });
+});

--- a/src/app/static-splash-removal.ts
+++ b/src/app/static-splash-removal.ts
@@ -1,0 +1,44 @@
+/**
+ * Removes the pre-bootstrap static splash (`#jot-static-splash` in
+ * `src/index.html`) after the Angular splash has painted on top of it.
+ *
+ * The double-`requestAnimationFrame` defers the removal one full paint
+ * past Angular's first commit. A single rAF can fire on the same tick as
+ * the pending paint, leaving a flash gap; double-rAF guarantees the
+ * browser has actually painted the Angular splash before the static
+ * splash is detached, so the visual handoff is seamless (both render the
+ * identical `.jot-splash` markup).
+ *
+ * Extracted into its own module so the double-rAF behavior can be tested
+ * in isolation, without a `TestBed` fixture in the same Karma session
+ * queuing cross-spec rAFs into a controlled rAF shim. See #170 and
+ * `static-splash-removal.spec.ts` for the bleed-isolation rationale.
+ *
+ * The module uses the `__<verb>ForTesting` seam convention documented in
+ * `AGENTS.md` §4 so callers (AppComponent) can be unit-tested via a spy
+ * without depending on `spyOn(module, ...)` semantics, which do not work
+ * with Angular's esbuild builder (ESM live bindings bypass the namespace
+ * object). Mirrors the pattern in `core/telemetry/web-vitals.ts`.
+ */
+
+const realScheduleStaticSplashRemoval = (): void => {
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      document.getElementById('jot-static-splash')?.remove();
+    });
+  });
+};
+
+let scheduleStaticSplashRemovalImpl: () => void = realScheduleStaticSplashRemoval;
+
+export function __setScheduleStaticSplashRemovalImplForTesting(impl: () => void): void {
+  scheduleStaticSplashRemovalImpl = impl;
+}
+
+export function __resetScheduleStaticSplashRemovalImplForTesting(): void {
+  scheduleStaticSplashRemovalImpl = realScheduleStaticSplashRemoval;
+}
+
+export function scheduleStaticSplashRemoval(): void {
+  scheduleStaticSplashRemovalImpl();
+}


### PR DESCRIPTION
Closes #170.

## Diagnosis (revised after two rubber-duck passes)

The failing spec asserts `expect(raf.pendingCount()).toBe(1)` immediately after `await raf.waitForPending(1)`. The original "race between waitForPending and the assertion" hypothesis was wrong — there is no `await` between those two lines.

**Actual cause: cross-spec rAF bleed.**

1. A prior AppComponent fixture in the same Karma session queues a real `requestAnimationFrame` from its `afterNextRender` hook on the **native** queue.
2. The prior spec completes in under one animation frame (~16ms), leaving the outer rAF still pending on the native queue.
3. The splash spec then installs its controlled-rAF shim and starts polling the queue.
4. While polling (the poll yields to the macrotask queue via `setTimeout(_, 1)`), the browser fires the prior spec's pending outer rAF. Its body calls `requestAnimationFrame(inner)` which now resolves through the shim.
5. Queue jumps from 1 to 2; the assertion fails.

Order-dependent (Jasmine `random: true`, no seed pinning in `karma.conf.js:20-23`), so it presents as ~30–50% under CI load — consistent with two consecutive CI failures followed by a later spontaneous pass on the same SHA.

## Fix: Option B from #170, revised

### 1. Extract the double-rAF body into a new module

`src/app/static-splash-removal.ts` uses the `__<verb>ForTesting` indirection pattern documented in `AGENTS.md` §4 and used by `web-vitals.ts` / `monaco-loader.ts`. ESM live bindings under Angular's esbuild builder make `spyOn(module, fn)` silently no-op (which would have **reintroduced the bleed source** in the spec file); the `let impl` seam routes the call through a mutable binding so a test spy actually intercepts.

### 2. New isolated spec, free of cross-spec rAF bleed

`src/app/static-splash-removal.spec.ts` exercises the double-rAF behavior synchronously — no `TestBed`, no DI, no `whenStable`, no `setTimeout` waits. A `SAFETY INVARIANT - DO NOT REMOVE` comment at the top warns future contributors that adding any task-yielding wait (`setTimeout`, `whenStable`, `waitForPending`, etc.) between shim install and the final assertion reopens the bleed window.

### 3. Delete the failing spec + orphan helper

Drop the `removes #jot-static-splash after exactly two rAF turns` spec (the bleed-vulnerable one) and the now-orphaned `installControlledRaf` helper + `RafController` interface from `app.component.spec.ts`.

### 4. Add a spy assertion

The new isolated spec covers the double-rAF mechanics, but on its own it would let a regression that removes the `afterNextRender` hook entirely (or swaps it to `afterRender`) ship green. The spy assertion in `app.component.spec.ts` plugs that gap by asserting `scheduleStaticSplashRemoval` is invoked exactly once from `AppComponent`'s `afterNextRender` lifecycle.

### 5. Add a happy-path smoke spec

The real scheduler + native rAFs (no shim, no queue-count assertion). Bleed-tolerant by construction: the assertion depends only on `getElementById('jot-static-splash')` being null at the end, which is robust to foreign rAF interleavings. Catches regressions like `afterNextRender` → `ngOnInit` (loses paint barrier) that the spy alone would miss.

## Verification

- `npm run lint:all` — clean
- `npm test` (frontend, 2410 specs) — clean
- `npm --prefix api test` (452 specs) — clean
- `npm run build` — clean
- **50x focused isolated-spec loop: 49/50 PASS, 0 assertion failures.** The single failure was a Karma harness `Disconnected, because no message in 30000 ms` / `Executed 0 of 0 DISCONNECTED` Chrome Headless startup race (the browser disconnected before any test ran), unrelated to the test design.

## SemVer

No bump. Test refactor + behaviorally-identical 5-line production hoist.

## Follow-up

The `afterNextRender + double-rAF` paint-barrier pattern exists at four other production sites (`home.component.ts:661`, `home.component.ts:1579`, `json-tree.component.ts:1143`, and now this one). Each has its own ad-hoc test approach and each is exposed to the same cross-spec rAF-bleed class. Will file a follow-up tech-debt issue to consolidate into a shared `scheduleAfterPaint(cb)` utility with one canonical isolated test. Out of scope for this PR.
