### PR TITLE
Add Mergify auto-update for behind PRs; revert dead merge_group triggers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,6 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
-  # merge_group fires on the temp ref the merge queue builds
-  # (main + queued PR). Required so the 6 checks below report on
-  # the merge-group SHA the queue tests before fast-forwarding main.
-  # See AGENTS.md section 8 for the merge-queue notes.
-  merge_group:
 
 # Workflow-level permissions are the absolute minimum every job
 # needs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,11 +14,6 @@ on:
     # Weekly Monday-noon-UTC scan catches drift between PR runs (e.g.,
     # transitive dependency advisories that land between pushes).
     - cron: '0 12 * * 1'
-  # merge_group fires on the temp ref the merge queue builds
-  # (main + queued PR). Required so the two Analyze checks below
-  # report on the merge-group SHA the queue tests before
-  # fast-forwarding main. See AGENTS.md section 8.
-  merge_group:
 
 permissions:
   actions: read

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,9 @@
+pull_request_rules:
+  - name: Keep PR branches up to date with main
+    conditions:
+      - base=main
+      - -conflict
+      - -closed
+      - -draft
+    actions:
+      update:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -731,6 +731,16 @@ Before finishing a task:
   thread, request review, wait for CI), and stop. Do not propose
   `--admin` as an option in `ask_user`. The user can clear the block
   themselves through the GitHub UI; agents do not.
+- **Auto-update of PR branches.** `main` is protected with `strict: true`
+  on classic branch protection (require branches to be up to date before
+  merge). A Mergify GitHub App install, configured by `.mergify.yml` at
+  the repo root, auto-pushes a merge of `main` into the PR head whenever
+  an open non-draft, non-conflicting PR targeting `main` is behind. This
+  fires the PR's normal `pull_request: synchronize` event, re-runs CI,
+  and lets GitHub's native auto-merge land the PR when green. Net
+  effect: enabling auto-merge once is sufficient -- no manual "Update
+  branch" click is needed when `main` advances. Rollback is uninstalling
+  the Mergify app + deleting `.mergify.yml`.
 - When a commit is authored with AI assistance, include:
 
   ```


### PR DESCRIPTION
## Problem

PRs with auto-merge enabled stall whenever a new commit lands on `main` because the classic branch protection rule requires PR branches to be up to date before merge (`required_status_checks.strict = true`). Each stall requires a manual `Update branch` click before auto-merge resumes.

GitHub's native merge queue would solve this, but it is empirically unavailable on this account: it does not appear in classic protection UI, rulesets UI, or REST API. PR #173 added `merge_group:` triggers preemptively; with no queue ever materializing, those triggers became dead code.

## Approach

Install **Mergify** (free for public OSS repos) as a GitHub App scoped only to this repo. A small `.mergify.yml` rule tells Mergify to auto-update any open non-draft, non-conflicting PR targeting `main` whenever it falls behind. Mergify acts via its installation token (which DOES trigger downstream CI, unlike `GITHUB_TOKEN`), so the resulting `pull_request: synchronize` event re-runs CI and GitHub's native auto-merge lands the PR when green.

The `strict: true` freshness guarantee is preserved (every merged commit was CI-validated against the exact `main` SHA it landed on). The manual click is eliminated.

## Changes

1. **`.mergify.yml` (new)** -- 9 lines. Single `update` rule.
2. **`ci.yml` / `codeql.yml`** -- revert the `merge_group:` triggers + their now-misleading comment blocks added in PR #173.
3. **`AGENTS.md` ?8** -- one-paragraph note describing the new auto-update behavior so contributors and agents are not surprised by `mergify[bot]` activity.

## Gating step (separate from this PR)

The repo owner installs the Mergify GitHub App at https://mergify.com, scoped only to `geevensingh/jotjson`. The app is dormant until `.mergify.yml` lands on `main`, so it is safe to install before this PR merges.

## Verification plan

After this PR merges:

1. Open a no-op PR; enable auto-merge.
2. Open a second no-op PR; merge it (advances `main`).
3. Within ~30 seconds, Mergify should push a merge commit onto PR #1's head branch (`mergify[bot]` appears in PR timeline).
4. PR #1's CI re-runs and goes green.
5. Native auto-merge lands PR #1 with zero manual clicks.

## Rollback

Independently reversible:
- Disable Mergify entirely: uninstall the app (instant).
- Disable the rule but keep the app: delete `.mergify.yml`.
- Restore the dead `merge_group:` triggers: `git revert` this PR's workflow changes (no real reason to).

## SemVer bump

None. Config + ops only; no user-facing product change.
