### PR TITLE
Wire Mergify CI Insights uploads to all four test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,21 @@ jobs:
           npx tsc --pretty false --noEmit
           echo "::remove-matcher owner=tsc-jotjson::"
       - name: Run tests
+        id: run-api-tests
         run: npm test
+      - name: Mergify CI Upload (api unit)
+        if: steps.run-api-tests.outcome == 'success' || steps.run-api-tests.outcome == 'failure'
+        continue-on-error: true
+        uses: mergifyio/gha-mergify-ci@v17
+        with:
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: api/test-results/api/junit.xml
+          test_step_outcome: ${{ steps.run-api-tests.outcome }}
+      - name: Mergify CI Upload - failure notice (api unit)
+        if: failure() && steps.run-api-tests.outcome != 'skipped'
+        run: |
+          echo "::warning::Mergify CI upload may have failed for api unit. Check MERGIFY_TOKEN secret and dashboard."
+          echo "Mergify CI upload may have failed for api unit. Check MERGIFY_TOKEN secret and dashboard." >> "$GITHUB_STEP_SUMMARY"
       - name: Upload api JUnit
         if: always()
         uses: actions/upload-artifact@v7
@@ -417,6 +431,7 @@ jobs:
             echo "enabled=true" >> "$GITHUB_OUTPUT"
           fi
       - name: Run integration tests
+        id: run-api-integration
         if: steps.cosmos-preflight.outputs.enabled == 'true'
         env:
           COSMOS_ENDPOINT: ${{ secrets.COSMOS_CI_ENDPOINT }}
@@ -426,6 +441,19 @@ jobs:
           # workflow rerun (run_id is reused; run_attempt increments).
           COSMOS_BLOBS_CONTAINER: blobs-${{ github.run_id }}-${{ github.run_attempt }}
         run: npm run test:integration
+      - name: Mergify CI Upload (api integration)
+        if: (steps.run-api-integration.outcome == 'success' || steps.run-api-integration.outcome == 'failure') && steps.cosmos-preflight.outputs.enabled == 'true'
+        continue-on-error: true
+        uses: mergifyio/gha-mergify-ci@v17
+        with:
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: api/test-results/api-integration/junit.xml
+          test_step_outcome: ${{ steps.run-api-integration.outcome }}
+      - name: Mergify CI Upload - failure notice (api integration)
+        if: failure() && steps.run-api-integration.outcome != 'skipped' && steps.cosmos-preflight.outputs.enabled == 'true'
+        run: |
+          echo "::warning::Mergify CI upload may have failed for api integration. Check MERGIFY_TOKEN secret and dashboard."
+          echo "Mergify CI upload may have failed for api integration. Check MERGIFY_TOKEN secret and dashboard." >> "$GITHUB_STEP_SUMMARY"
       - name: Cleanup integration container (backstop)
         # `if: always()` covers Jest hard-crashes that bypass
         # globalTeardown. Setup-time orphan cleanup at the next run
@@ -503,7 +531,21 @@ jobs:
       - name: Materialize environment.ts
         run: cp src/environments/environment.example.ts src/environments/environment.ts
       - name: Run tests with coverage
+        id: run-web-tests
         run: npm run test:ci
+      - name: Mergify CI Upload (web unit)
+        if: steps.run-web-tests.outcome == 'success' || steps.run-web-tests.outcome == 'failure'
+        continue-on-error: true
+        uses: mergifyio/gha-mergify-ci@v17
+        with:
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: test-results/web/junit.xml
+          test_step_outcome: ${{ steps.run-web-tests.outcome }}
+      - name: Mergify CI Upload - failure notice (web unit)
+        if: failure() && steps.run-web-tests.outcome != 'skipped'
+        run: |
+          echo "::warning::Mergify CI upload may have failed for web unit. Check MERGIFY_TOKEN secret and dashboard."
+          echo "Mergify CI upload may have failed for web unit. Check MERGIFY_TOKEN secret and dashboard." >> "$GITHUB_STEP_SUMMARY"
       - name: Upload coverage
         if: always()
         uses: actions/upload-artifact@v7
@@ -567,7 +609,21 @@ jobs:
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
       - name: Run smoke e2e
+        id: run-e2e-tests
         run: npm run test:e2e
+      - name: Mergify CI Upload (e2e)
+        if: steps.run-e2e-tests.outcome == 'success' || steps.run-e2e-tests.outcome == 'failure'
+        continue-on-error: true
+        uses: mergifyio/gha-mergify-ci@v17
+        with:
+          token: ${{ secrets.MERGIFY_TOKEN }}
+          report_path: test-results/e2e/junit.xml
+          test_step_outcome: ${{ steps.run-e2e-tests.outcome }}
+      - name: Mergify CI Upload - failure notice (e2e)
+        if: failure() && steps.run-e2e-tests.outcome != 'skipped'
+        run: |
+          echo "::warning::Mergify CI upload may have failed for e2e. Check MERGIFY_TOKEN secret and dashboard."
+          echo "Mergify CI upload may have failed for e2e. Check MERGIFY_TOKEN secret and dashboard." >> "$GITHUB_STEP_SUMMARY"
       - name: Upload Playwright report
         if: failure()
         uses: actions/upload-artifact@v7

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -510,6 +510,38 @@ Set `JOTJSON_DEV_AUTH_BYPASS=true` in `api/local.settings.json` (under
 - Test names describe behavior: `it('returns 404 when blob slug is unknown')`.
 - Run the full lint + test + build suite before declaring completion (see §7).
 
+### CI Insights (Mergify)
+
+After each test job, CI uploads the suite's JUnit XML to Mergify CI Insights
+via `mergifyio/gha-mergify-ci@v17`. Wired suites: **api unit**, **api
+integration**, **web unit** (Karma), **e2e** (Playwright). Dashboards live
+at `https://dashboard.mergify.com/ci-insights/jobs`. JUnit artifacts and
+`dorny/test-reporter` PR check-runs are unchanged and remain the canonical
+in-repo signal; Mergify is an additive cross-PR view for flake and
+duration trends.
+
+- **Auto-Retry and Quarantine are explicitly disabled** per §11's
+  zero-tolerance for silent retries on `main`. The four test steps must
+  **not** carry `continue-on-error: true` (which would let Mergify
+  override the runner's success/failure conclusion). Only the
+  `Mergify CI Upload (*)` steps themselves carry `continue-on-error: true`,
+  so a Mergify outage or expired token doesn't fail CI.
+- **Token visibility**: each upload is followed by a `Mergify CI Upload -
+  failure notice (*)` step that writes a `::warning::` annotation and a
+  `$GITHUB_STEP_SUMMARY` line when the upload fails. This surfaces
+  token/permission breakage on the run page; otherwise a stale dashboard
+  is the only signal.
+- **Conditional firing**: uploads use `if: steps.<id>.outcome ==
+  'success' || ... 'failure'` (not `if: success() || failure()`), so the
+  upload runs only when the test step actually executed. This prevents
+  an `npm ci` failure from triggering an upload of a non-existent JUnit
+  file.
+- **Rollback**: delete the four `Mergify CI Upload (*)` steps and the
+  four `Mergify CI Upload - failure notice (*)` steps from
+  `.github/workflows/ci.yml`, remove the four `id:` attributes from
+  the test steps, and revoke the `MERGIFY_TOKEN` repository secret.
+  JUnit artifact uploads and `dorny/test-reporter` are unaffected.
+
 ### Fast inner loop
 
 For incremental work, prefer the fast inner loop over the full


### PR DESCRIPTION
## What

Wire Mergify CI Insights uploads to all four test jobs in CI:

- **api unit** -> `api/test-results/api/junit.xml`
- **api integration** -> `api/test-results/api-integration/junit.xml` (cosmos-preflight gated)
- **web unit** (Karma) -> `test-results/web/junit.xml`
- **e2e** (Playwright) -> `test-results/e2e/junit.xml`

Each test step now carries an `id:`; each upload step uses `mergifyio/gha-mergify-ci@v17` with `test_step_outcome` so flake stats reflect the runner's real conclusion. A follow-up failure-notice step surfaces token/permission breakage via `::warning::` + `GITHUB_STEP_SUMMARY`.

## Why

User-facing flake/duration trends across PRs. JUnit artifacts and dorny/test-reporter PR check-runs stay as the canonical in-repo signal; CI Insights is additive.

## Guardrails (per AGENTS.md s11 zero-tolerance for silent retries)

- Auto-Retry and Quarantine remain **disabled**. Test steps have no `continue-on-error: true`.
- Only the Mergify upload steps use `continue-on-error: true`, so a Mergify outage or expired `MERGIFY_TOKEN` cannot break CI.
- `if: steps.<id>.outcome == 'success' || 'failure'` (NOT `success() || failure()`) so we never try to upload after an earlier setup step failed.

## DoD

- [x] `npm run lint:all` green locally
- [x] No new branch-protection contexts (steps live inside existing required jobs)
- [x] AGENTS.md s5 documents wiring + rollback
- [ ] CI green on this PR (workflows-lint validates the YAML)
- [ ] Mergify dashboard ingests data post-merge (verify)

## Rollback

Delete the eight `Mergify CI Upload*` steps, drop the four `id:` fields, revoke `MERGIFY_TOKEN`. JUnit artifacts and dorny/test-reporter unaffected.
