### PR TITLE
Pin actionlint install in CI to v1.7.12 (#69)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,10 +513,38 @@ jobs:
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
+      # Pinned per #69. Both the install script URL and the binary
+      # version resolve to the v1.7.12 release tag (not `main` or
+      # "latest") so CI runs are reproducible against accidental
+      # upstream drift. This does NOT defend against a maliciously
+      # force-moved tag or a swapped release asset; that residual
+      # risk is tracked in #182 (Option C, sha256-verified binary).
+      #
+      # To refresh: bump ACTIONLINT_VERSION below to the new release
+      # (digits only, no `v` prefix). Dependabot does not track raw
+      # curl URLs in `run:` steps.
       - name: Install actionlint
+        env:
+          ACTIONLINT_VERSION: 1.7.12
         run: |
-          bash <(curl -fsSL https://raw.githubusercontent.com/rhysd/actionlint/main/scripts/download-actionlint.bash)
-          echo "$PWD" >> "$GITHUB_PATH"
+          set -euo pipefail
+          if [[ ! "${ACTIONLINT_VERSION}" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "ACTIONLINT_VERSION must be X.Y.Z (digits only, no 'v' prefix), got '${ACTIONLINT_VERSION}'" >&2
+            exit 1
+          fi
+          script="$(mktemp)"
+          curl -fsSL \
+            "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash" \
+            -o "${script}"
+          install_dir="${RUNNER_TEMP}/actionlint"
+          mkdir -p "${install_dir}"
+          bash "${script}" "${ACTIONLINT_VERSION}" "${install_dir}"
+          rm "${script}"
+          if ! [ -x "${install_dir}/actionlint" ]; then
+            echo "actionlint not installed at ${install_dir}/actionlint" >&2
+            exit 1
+          fi
+          echo "${install_dir}" >> "$GITHUB_PATH"
       - name: Run actionlint
         run: actionlint -color
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -533,13 +533,13 @@ jobs:
             exit 1
           fi
           script="$(mktemp)"
+          trap 'rm -f "${script}"' EXIT
           curl -fsSL \
             "https://raw.githubusercontent.com/rhysd/actionlint/v${ACTIONLINT_VERSION}/scripts/download-actionlint.bash" \
             -o "${script}"
           install_dir="${RUNNER_TEMP}/actionlint"
           mkdir -p "${install_dir}"
           bash "${script}" "${ACTIONLINT_VERSION}" "${install_dir}"
-          rm "${script}"
           if ! [ -x "${install_dir}/actionlint" ]; then
             echo "actionlint not installed at ${install_dir}/actionlint" >&2
             exit 1


### PR DESCRIPTION
Fixes #69. Follow-up tracked in #182.

## Summary

The `workflows-lint` CI job previously installed `actionlint` by
fetching `download-actionlint.bash` from `rhysd/actionlint`'s `main`
branch on every CI run, then letting the script pull the latest
release binary. Both halves were moving targets.

This PR pins both halves to the v1.7.12 release tag and hardens the
install step against silent-failure modes.

## What changed

`.github/workflows/ci.yml` -- `workflows-lint` job, `Install actionlint` step:

- Pin the script URL to the `v1.7.12` tag (was `main`).
- Pass `1.7.12` to the script as the explicit `VERSION` arg.
  Required: the script at `v1.7.12` has `version="1.7.11"` hardcoded
  as its no-arg default, so without the arg the binary half would
  still be off-by-one.
- Step-level `env: ACTIONLINT_VERSION: 1.7.12` so refresh is a
  single-value bump.
- `set -euo pipefail` + download the script to a temp file before
  executing it. `bash <(curl ...)` process substitution does NOT
  propagate the inner curl exit code, so a typo'd tag or a transient
  404 would otherwise look like a silent-success install (and the
  next step would fail with the misleading
  `actionlint: command not found`).
- Regex guard `^[0-9]+\.[0-9]+\.[0-9]+$` on `ACTIONLINT_VERSION`
  before curl. Closes the leading-`v` footgun (`v1.7.12` -> URL
  `.../vv1.7.12/...` -> silent 404 under the old shape).
- Install to `$RUNNER_TEMP/actionlint`, not `$PWD`. The script
  accepts an install DIR as its second positional. Keeps the repo
  checkout root off `$GITHUB_PATH` for subsequent steps.
- Post-install `[ -x "${install_dir}/actionlint" ]` check.

Inline YAML comment documents the refresh procedure (single-value
bump, digits only) and links to #182 for the residual-risk follow-up.

## Rubber-duck

Plan was critiqued by an adversarial review pass before approval (per
AGENTS.md §11). Material findings folded in:

- High: `bash <(curl)` swallows curl's exit code -> switched to
  download-then-execute under `set -euo pipefail`, plus post-install
  executable check.
- Medium: tag pins aren't security-grade (tags are force-moveable,
  release assets are not content-addressed) -> reframed problem
  statement as "reproducibility against accidental upstream drift,
  not protection against compromise" and filed #182 for sha256
  verification.
- Medium: `$PWD` on `$GITHUB_PATH` puts the workspace on PATH ->
  installing to `$RUNNER_TEMP/actionlint`.
- Medium: leading-`v` would silently 404 -> regex guard.
- Low: inline-comment wording referenced "two literals" when the env
  indirection means one -> tightened comment.

Considered and set aside:

- SHA-pin the script URL (deferred as a half-measure since the
  binary half is still tag-resolved; full content-addressing is
  tracked in #182).
- Deliberate-YAML-error smoke before merge (skipped: change is a
  version pin, not a linter behavior change).

## Validation

- `npm run lint:all` passes locally.
- This PR's `workflows-lint` job will exercise the change end-to-end.
  Expected log line in the install step:
  `Start downloading actionlint v1.7.12 to /home/runner/work/_temp/actionlint`
- The `Run actionlint` step continues to run `actionlint -color`
  against current workflow YAML.

## Definition of Done

- [x] `actionlint` installed via pinned reference (tag + explicit
      version arg).
- [x] Workflow no longer fetches code from a moving branch.
- [x] Install step fails loudly on transport, input, or install-location
      errors.
- [x] `npm run lint:all` green locally.
- [x] Follow-up #182 filed for Option C.
- [ ] `workflows-lint` job passes on this PR (verifying once CI runs).

## SemVer

No bump. CI-only tooling change; no user-facing behavior, no API or
schema impact.

## Telemetry

No event. CI tooling change with no runtime path.