### PR TITLE
Add nonprod env scaffold (VS Enterprise sub)

### DIFF
--- a/.github/workflows/cd-nonprod.yml
+++ b/.github/workflows/cd-nonprod.yml
@@ -1,0 +1,249 @@
+name: Deploy (SWA) - nonprod
+
+# ----------------------------------------------------------------------
+# Non-production SWA + Functions deploy (Visual Studio Enterprise sub).
+# Mirrors cd.yml's `workflow_dispatch` (manual) path but targets the
+# nonprod SWA (`swa-jotjson-nonprod`) under AZURE_SUBSCRIPTION_ID_NONPROD.
+#
+# Trigger: `workflow_dispatch` only. There is no `workflow_run` path -
+# nonprod does not auto-deploy on push to main (Phase 2 cd-preview.yml
+# handles PR-driven deploys; nonprod is the stable "what main looks like
+# when manually promoted" env). Future automation can be added once the
+# manual flow is proven.
+#
+# Auth (Azure): uses federated SP `gh-actions-jotjson`
+# (appId c4866b60-d20b-43f1-b81e-ca01dac6e102) via
+# `environment: nonprod` matching the federated cred
+# `repo:geevensingh/jotjson:environment:nonprod`. Role: Contributor on
+# `rg-jotjson-nonprod` only.
+#
+# Auth (SWA): uses `AZURE_STATIC_WEB_APPS_API_TOKEN_NONPROD` repo
+# secret (populated per plan step 1.8a after the first infra deploy).
+#
+# Redirect URI: `DEPLOY_REDIRECT_URI` is set to a placeholder until
+# step 1.9 pins it to the actual SWA default hostname captured from
+# the first infra deploy. The pre-deploy guard step fails if the
+# placeholder is still present, so the deploy is fail-safe.
+#
+# Entra: reuses the same `ENTRA_*` repo secrets as prod (same CIAM
+# tenant). Sign-in works on this env only after the nonprod hostname
+# is registered as a redirect URI in the Entra SPA app reg (per plan
+# step 1.7).
+#
+# App Insights: uses `APP_INSIGHTS_CONNECTION_STRING_NONPROD` repo
+# secret (different AI resource than prod; captured from the first
+# infra deploy per plan step 1.8b).
+#
+# Sourcemap upload: targets the nonprod storage account
+# `stjotjsonnonprod` (resource name follows the same hyphen-stripped
+# pattern as prod's `stjotjsondev`; the actual account name is
+# resolved via the `AZURE_STORAGE_ACCOUNT_NONPROD` secret).
+# ----------------------------------------------------------------------
+
+run-name: >-
+  [nonprod] ${{ github.event.head_commit.message || github.sha }}
+
+on:
+  workflow_dispatch: {}
+
+concurrency:
+  group: swa-deploy-nonprod
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  deploy:
+    name: Build and deploy to Azure Static Web Apps (nonprod)
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    environment: nonprod
+    steps:
+      - name: Check for deploy token
+        id: check
+        env:
+          SWA_TOKEN: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NONPROD }}
+        run: |
+          if [ -z "$SWA_TOKEN" ]; then
+            echo "::error::AZURE_STATIC_WEB_APPS_API_TOKEN_NONPROD not set - cannot deploy."
+            echo "Populate the secret per plan step 1.8a (az staticwebapp secrets list)."
+            exit 1
+          fi
+          echo "have_token=true" >> "$GITHUB_OUTPUT"
+
+      - name: Validate redirect URI is pinned
+        env:
+          DEPLOY_REDIRECT_URI: ${{ vars.NONPROD_DEPLOY_REDIRECT_URI }}
+        run: |
+          # The redirectUri must be the real SWA default hostname captured
+          # from the first infra-nonprod.yml deploy and pinned via the
+          # repo-level Variable `NONPROD_DEPLOY_REDIRECT_URI` (plan step
+          # 1.9). Until then this guard fires and the deploy fails fast.
+          if [ -z "$DEPLOY_REDIRECT_URI" ]; then
+            echo "::error::NONPROD_DEPLOY_REDIRECT_URI repo variable is unset."
+            echo "Set it to https://<nonprod-swa-hostname>/ per plan step 1.9 before triggering this workflow."
+            exit 1
+          fi
+          case "$DEPLOY_REDIRECT_URI" in
+            https://*.azurestaticapps.net/) : ;;
+            https://*/) : ;;
+            *)
+              echo "::error::NONPROD_DEPLOY_REDIRECT_URI ('$DEPLOY_REDIRECT_URI') doesn't look like a URL (must start with https:// and end with /)."
+              exit 1
+              ;;
+          esac
+
+      - uses: actions/checkout@v6
+        with:
+          submodules: true
+          lfs: false
+          # Full history so the inline `npm run build` produces a real
+          # `buildNumber`. Mirrors cd.yml's workflow_dispatch path.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: npm
+
+      - name: Install web deps
+        run: npm ci
+
+      - name: Materialize environment.ts
+        run: cp src/environments/environment.example.ts src/environments/environment.ts
+
+      - name: Bake nonprod auth config into environment.prod.ts
+        env:
+          ENTRA_SPA_CLIENT_ID: ${{ secrets.ENTRA_SPA_CLIENT_ID }}
+          ENTRA_AUTHORITY: ${{ secrets.ENTRA_AUTHORITY }}
+          ENTRA_KNOWN_AUTHORITY: ${{ secrets.ENTRA_KNOWN_AUTHORITY }}
+          ENTRA_API_SCOPE: ${{ secrets.ENTRA_API_SCOPE }}
+          APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.APP_INSIGHTS_CONNECTION_STRING_NONPROD }}
+          DEPLOY_REDIRECT_URI: ${{ vars.NONPROD_DEPLOY_REDIRECT_URI }}
+        run: |
+          # Mirrors cd.yml's parameterised bake step (with
+          # APP_INSIGHTS_CONNECTION_STRING_NONPROD substituted for the
+          # prod connection string).
+          cat > src/environments/environment.prod.ts <<'EOF'
+          import { Environment } from './environment.interface';
+
+          export const environment: Environment = {
+            production: true,
+            apiBaseUrl: '/api',
+            auth: {
+              clientId: '__ENTRA_SPA_CLIENT_ID__',
+              authority: '__ENTRA_AUTHORITY__',
+              knownAuthorities: ['__ENTRA_KNOWN_AUTHORITY__'],
+              redirectUri: '__DEPLOY_REDIRECT_URI__',
+              postLogoutRedirectUri: '__DEPLOY_REDIRECT_URI__',
+              scopes: ['__ENTRA_API_SCOPE__']
+            },
+            appInsightsConnectionString: '__APP_INSIGHTS_CONNECTION_STRING__'
+          };
+          EOF
+          sed -i 's/^          //' src/environments/environment.prod.ts
+          sed -i "s|__ENTRA_SPA_CLIENT_ID__|${ENTRA_SPA_CLIENT_ID}|g" src/environments/environment.prod.ts
+          sed -i "s|__ENTRA_AUTHORITY__|${ENTRA_AUTHORITY}|g" src/environments/environment.prod.ts
+          sed -i "s|__ENTRA_KNOWN_AUTHORITY__|${ENTRA_KNOWN_AUTHORITY}|g" src/environments/environment.prod.ts
+          sed -i "s|__ENTRA_API_SCOPE__|${ENTRA_API_SCOPE}|g" src/environments/environment.prod.ts
+          sed -i "s|__APP_INSIGHTS_CONNECTION_STRING__|${APP_INSIGHTS_CONNECTION_STRING}|g" src/environments/environment.prod.ts
+          sed -i "s|__DEPLOY_REDIRECT_URI__|${DEPLOY_REDIRECT_URI}|g" src/environments/environment.prod.ts
+          if grep -q "__ENTRA_\|__DEPLOY_REDIRECT_URI__" src/environments/environment.prod.ts; then
+            echo "::error::One or more required deploy values are missing (ENTRA_* / DEPLOY_REDIRECT_URI) - aborting deploy."
+            exit 1
+          fi
+
+      - name: Build SPA
+        run: npm run build -- --configuration=production
+
+      - name: Copy SWA config into bundle
+        run: cp staticwebapp.config.json dist/jotjson/browser/staticwebapp.config.json
+
+      - name: Sanity-check production bundle
+        run: |
+          if [ ! -f dist/jotjson/browser/index.html ]; then
+            echo "::error::dist/jotjson/browser/index.html missing"
+            exit 1
+          fi
+          if [ ! -f dist/jotjson/browser/staticwebapp.config.json ]; then
+            echo "::error::dist/jotjson/browser/staticwebapp.config.json missing"
+            exit 1
+          fi
+          if grep -r --include='*.js' '__ENTRA_\|__DEPLOY_REDIRECT_URI__' dist/jotjson/browser/; then
+            echo "::error::Production bundle contains __ENTRA_* or __DEPLOY_REDIRECT_URI__ placeholder - secret bake failed"
+            exit 1
+          fi
+
+      - name: Azure login (sourcemap upload)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
+      - name: Upload sourcemaps to Azure Blob Storage
+        env:
+          STORAGE_ACCOUNT: ${{ secrets.AZURE_STORAGE_ACCOUNT_NONPROD }}
+        run: |
+          if [ -z "$STORAGE_ACCOUNT" ]; then
+            echo "::warning::AZURE_STORAGE_ACCOUNT_NONPROD not set - skipping sourcemap upload."
+            echo "Set the secret to the nonprod storage account name (e.g. stjotjsonnonprod) to enable AI symbolication."
+            exit 0
+          fi
+          az storage blob upload-batch \
+            --source dist/jotjson/browser \
+            --destination sourcemaps \
+            --account-name "$STORAGE_ACCOUNT" \
+            --pattern '*.map' \
+            --auth-mode login \
+            --overwrite true
+      - name: Azure logout (sourcemap upload)
+        if: ${{ always() }}
+        run: az logout --username "${{ secrets.AZURE_CLIENT_ID }}" || true
+
+      - name: Install API full deps
+        working-directory: api
+        run: npm ci
+
+      - name: Build API
+        working-directory: api
+        run: npm run build
+
+      - name: Deploy to Azure Static Web Apps
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_NONPROD }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          # With skip_app_build: true the SWA action treats app_location
+          # as the prebuilt SPA output directory (per Microsoft docs).
+          # With skip_api_build: true it likewise treats api_location as
+          # a prebuilt Functions tree and uploads it as-is - no Oryx.
+          app_location: 'dist/jotjson/browser'
+          api_location: 'api'
+          skip_app_build: true
+          skip_api_build: true
+
+      - name: Summary
+        if: ${{ always() && !cancelled() }}
+        env:
+          REDIRECT_URI: ${{ vars.NONPROD_DEPLOY_REDIRECT_URI }}
+        run: |
+          if [[ "${{ job.status }}" == "success" ]]; then
+            {
+              echo "## Deployed (nonprod)"
+              echo ""
+              echo "- SWA: swa-jotjson-nonprod"
+              echo "- Redirect URI: $REDIRECT_URI"
+              echo "- Subscription: nonprod (VS Enterprise)"
+              echo "- Commit: ${{ github.sha }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Deploy failed (nonprod)"
+              echo ""
+              echo "- SWA: swa-jotjson-nonprod"
+              echo "- Commit: ${{ github.sha }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/cd-nonprod.yml
+++ b/.github/workflows/cd-nonprod.yml
@@ -78,7 +78,7 @@ jobs:
           DEPLOY_REDIRECT_URI: ${{ vars.NONPROD_DEPLOY_REDIRECT_URI }}
         run: |
           # The redirectUri must be the real SWA default hostname captured
-          # from the first infra-nonprod.yml deploy and pinned via the
+          # from the first infra-nonprod.yml deploy and set via the
           # repo-level Variable `NONPROD_DEPLOY_REDIRECT_URI` (plan step
           # 1.9). Until then this guard fires and the deploy fails fast.
           if [ -z "$DEPLOY_REDIRECT_URI" ]; then
@@ -86,11 +86,21 @@ jobs:
             echo "Set it to https://<nonprod-swa-hostname>/ per plan step 1.9 before triggering this workflow."
             exit 1
           fi
+          # Strict allowlist: only the SWA default-hostname pattern is
+          # accepted. This is intentional - a permissive catchall like
+          # `https://*/` would silently accept the prod custom domain
+          # `https://jotjson.com/` (or any other host) and bake a
+          # wrong-env redirect into the nonprod bundle. Phase 1 does
+          # not use a custom domain on nonprod (the bicepparam sets
+          # `customDomain = ''`); when/if a custom domain is added to
+          # nonprod, expand this allowlist with the specific host then,
+          # not via a wildcard.
           case "$DEPLOY_REDIRECT_URI" in
             https://*.azurestaticapps.net/) : ;;
-            https://*/) : ;;
             *)
-              echo "::error::NONPROD_DEPLOY_REDIRECT_URI ('$DEPLOY_REDIRECT_URI') doesn't look like a URL (must start with https:// and end with /)."
+              echo "::error::NONPROD_DEPLOY_REDIRECT_URI ('$DEPLOY_REDIRECT_URI') is not an allowed nonprod hostname."
+              echo "Allowed pattern: https://<name>.azurestaticapps.net/"
+              echo "If you need to add a custom domain for nonprod, expand the allowlist in this file rather than loosening the pattern."
               exit 1
               ;;
           esac

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -194,9 +194,17 @@ jobs:
           ENTRA_KNOWN_AUTHORITY: ${{ secrets.ENTRA_KNOWN_AUTHORITY }}
           ENTRA_API_SCOPE: ${{ secrets.ENTRA_API_SCOPE }}
           APP_INSIGHTS_CONNECTION_STRING: ${{ secrets.APP_INSIGHTS_CONNECTION_STRING }}
+          # MSAL only allows one redirectUri in its config. For prod
+          # this workflow stays at https://jotjson.com/ (the canonical
+          # custom domain). Sibling workflows (cd-nonprod.yml) override
+          # DEPLOY_REDIRECT_URI to point at their own SWA hostname.
+          DEPLOY_REDIRECT_URI: 'https://jotjson.com/'
         run: |
           # Duplicates ci.yml's bake step. See "Build topology" comment at
           # the top of this file for why this duplication exists.
+          # ci.yml's bake stays hard-coded to https://jotjson.com/ because
+          # ci.yml only runs on push-to-main and only ever produces the
+          # prod artifact; only this manual path needs to retarget.
           cat > src/environments/environment.prod.ts <<'EOF'
           import { Environment } from './environment.interface';
 
@@ -207,8 +215,8 @@ jobs:
               clientId: '__ENTRA_SPA_CLIENT_ID__',
               authority: '__ENTRA_AUTHORITY__',
               knownAuthorities: ['__ENTRA_KNOWN_AUTHORITY__'],
-              redirectUri: 'https://jotjson.com/',
-              postLogoutRedirectUri: 'https://jotjson.com/',
+              redirectUri: '__DEPLOY_REDIRECT_URI__',
+              postLogoutRedirectUri: '__DEPLOY_REDIRECT_URI__',
               scopes: ['__ENTRA_API_SCOPE__']
             },
             appInsightsConnectionString: '__APP_INSIGHTS_CONNECTION_STRING__'
@@ -220,8 +228,9 @@ jobs:
           sed -i "s|__ENTRA_KNOWN_AUTHORITY__|${ENTRA_KNOWN_AUTHORITY}|g" src/environments/environment.prod.ts
           sed -i "s|__ENTRA_API_SCOPE__|${ENTRA_API_SCOPE}|g" src/environments/environment.prod.ts
           sed -i "s|__APP_INSIGHTS_CONNECTION_STRING__|${APP_INSIGHTS_CONNECTION_STRING}|g" src/environments/environment.prod.ts
-          if grep -q "__ENTRA_" src/environments/environment.prod.ts; then
-            echo "::error::One or more ENTRA_* secrets are missing - aborting deploy."
+          sed -i "s|__DEPLOY_REDIRECT_URI__|${DEPLOY_REDIRECT_URI}|g" src/environments/environment.prod.ts
+          if grep -q "__ENTRA_\|__DEPLOY_REDIRECT_URI__" src/environments/environment.prod.ts; then
+            echo "::error::One or more required deploy values are missing (ENTRA_* / DEPLOY_REDIRECT_URI) - aborting deploy."
             exit 1
           fi
 

--- a/.github/workflows/infra-nonprod.yml
+++ b/.github/workflows/infra-nonprod.yml
@@ -1,0 +1,148 @@
+name: Infra (Bicep) - nonprod
+
+# ----------------------------------------------------------------------
+# Non-production environment deploy (Visual Studio Enterprise sub).
+# Mirrors infra.yml but targets `rg-jotjson-nonprod` under
+# AZURE_SUBSCRIPTION_ID_NONPROD with `nonprod.bicepparam`.
+#
+# Trigger: `workflow_dispatch` only.
+# Future: add `push: main` path-filter on `nonprod.bicepparam` and this
+# workflow file once the env is stable.
+#
+# Auth: uses the same federated SP as prod (`gh-actions-jotjson`,
+# appId c4866b60-d20b-43f1-b81e-ca01dac6e102). The job declares
+# `environment: nonprod`, which matches the federated credential
+# `repo:geevensingh/jotjson:environment:nonprod` (added out-of-band
+# per plan step 1.5). Role assignment is Contributor on the
+# `rg-jotjson-nonprod` resource group only (NOT subscription scope).
+#
+# Entra: real values come from the same `ENTRA_*` repo secrets used
+# by prod's infra.yml (same CIAM tenant). No new Entra secrets.
+# ----------------------------------------------------------------------
+
+run-name: >-
+  [nonprod] ${{ github.event.head_commit.message || github.sha }}
+
+on:
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Bicep build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build main.bicep
+        run: az bicep build --file infra/main.bicep
+      - name: Validate nonprod.bicepparam
+        run: az bicep build-params --file infra/parameters/nonprod.bicepparam
+
+  validate:
+    name: Bicep what-if
+    runs-on: ubuntu-latest
+    needs: build
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      id-token: write
+    environment: nonprod
+    steps:
+      - uses: actions/checkout@v6
+      - name: Azure login (OIDC)
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
+      - name: Ensure resource group exists
+        run: |
+          az group create \
+            --name rg-jotjson-nonprod \
+            --location ${{ vars.AZURE_LOCATION || 'eastus2' }}
+      - name: What-if
+        env:
+          ENTRA_TENANT_ID: ${{ secrets.ENTRA_TENANT_ID }}
+          ENTRA_AUTHORITY: ${{ secrets.ENTRA_AUTHORITY }}
+          ENTRA_SPA_CLIENT_ID: ${{ secrets.ENTRA_SPA_CLIENT_ID }}
+          ENTRA_API_CLIENT_ID: ${{ secrets.ENTRA_API_CLIENT_ID }}
+          ENTRA_API_AUDIENCE: ${{ secrets.ENTRA_API_AUDIENCE }}
+        run: |
+          az deployment group what-if \
+            --resource-group rg-jotjson-nonprod \
+            --template-file infra/main.bicep \
+            --parameters infra/parameters/nonprod.bicepparam \
+            --parameters \
+              entraTenantId="${ENTRA_TENANT_ID}" \
+              entraAuthority="${ENTRA_AUTHORITY}" \
+              entraSpaClientId="${ENTRA_SPA_CLIENT_ID}" \
+              entraApiClientId="${ENTRA_API_CLIENT_ID}" \
+              entraApiAudience="${ENTRA_API_AUDIENCE}"
+
+  deploy:
+    name: Deploy
+    needs: [build, validate]
+    concurrency:
+      group: infra-deploy-nonprod
+      cancel-in-progress: false
+    runs-on: ubuntu-latest
+    environment: nonprod
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID_NONPROD }}
+      - name: Ensure resource group exists
+        run: |
+          az group create \
+            --name rg-jotjson-nonprod \
+            --location ${{ vars.AZURE_LOCATION || 'eastus2' }}
+      - name: Deploy Bicep
+        env:
+          ENTRA_TENANT_ID: ${{ secrets.ENTRA_TENANT_ID }}
+          ENTRA_AUTHORITY: ${{ secrets.ENTRA_AUTHORITY }}
+          ENTRA_SPA_CLIENT_ID: ${{ secrets.ENTRA_SPA_CLIENT_ID }}
+          ENTRA_API_CLIENT_ID: ${{ secrets.ENTRA_API_CLIENT_ID }}
+          ENTRA_API_AUDIENCE: ${{ secrets.ENTRA_API_AUDIENCE }}
+        run: |
+          az deployment group create \
+            --resource-group rg-jotjson-nonprod \
+            --template-file infra/main.bicep \
+            --parameters infra/parameters/nonprod.bicepparam \
+            --parameters \
+              entraTenantId="${ENTRA_TENANT_ID}" \
+              entraAuthority="${ENTRA_AUTHORITY}" \
+              entraSpaClientId="${ENTRA_SPA_CLIENT_ID}" \
+              entraApiClientId="${ENTRA_API_CLIENT_ID}" \
+              entraApiAudience="${ENTRA_API_AUDIENCE}"
+      - name: Summary
+        if: ${{ always() && !cancelled() }}
+        run: |
+          if [[ "${{ job.status }}" == "success" ]]; then
+            {
+              echo "## Deployed"
+              echo ""
+              echo "- Resource group: rg-jotjson-nonprod"
+              echo "- Subscription: nonprod (VS Enterprise)"
+              echo "- Commit: ${{ github.sha }}"
+              echo "- Trigger: ${{ github.event_name }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          else
+            {
+              echo "## Deploy failed"
+              echo ""
+              echo "- Resource group: rg-jotjson-nonprod"
+              echo "- Subscription: nonprod (VS Enterprise)"
+              echo "- Commit: ${{ github.sha }}"
+              echo "- Trigger: ${{ github.event_name }}"
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -1,7 +1,7 @@
 targetScope = 'resourceGroup'
 
-@description('Environment short name: dev, stg, prod.')
-@allowed(['dev', 'stg', 'prod'])
+@description('Environment short name: dev, stg, prod, nonprod.')
+@allowed(['dev', 'stg', 'prod', 'nonprod'])
 param environmentName string = 'dev'
 
 @description('Azure region for all resources.')

--- a/infra/parameters/nonprod.bicepparam
+++ b/infra/parameters/nonprod.bicepparam
@@ -1,0 +1,35 @@
+using '../main.bicep'
+
+// Non-production environment in the Visual Studio Enterprise subscription
+// (`5698b024-0e2d-4d8b-8db5-fd401ed0ba4a`), funded by the VS subscriber
+// $150/mo credit. Mirrors `dev` (which is currently prod) in shape so
+// Phase 2 preview environments and future signed-in smoke (#68) have an
+// independent target. Per the VS subscriber agreement this env is
+// dev/test-only -- it must NOT serve real users.
+// See plan: M1 non-prod environment plan.
+
+param environmentName = 'nonprod'
+param appName = 'jotjson'
+
+// Required for SWA preview environments (`deployment_environment`).
+param staticWebAppSku = 'Standard'
+
+// No custom domain in non-prod; use the default *.azurestaticapps.net
+// hostname assigned by the Static Web App resource. Apex binding flows
+// (custom domain, DNS zone) are prod-only.
+param customDomain = ''
+param dnsZoneName = ''
+
+// Entra External ID. Real values come from GH secrets via `-p` overrides
+// in `infra-nonprod.yml` (same secrets as prod -- same CIAM tenant).
+// Keep these empty in the committed param file; JWT validation is
+// disabled until the overrides are passed.
+param entraTenantId = ''
+param entraAuthority = ''
+param entraSpaClientId = ''
+param entraApiClientId = ''
+param entraApiAudience = ''
+
+// Operational alerts receiver. Same address as prod -- the alerting
+// surface is unified across environments by design (see issue #94).
+param notificationEmail = 'jotjsonadmin@gmail.com'


### PR DESCRIPTION
Phase 1 PR #1 of the [nonprod-environment plan](https://github.com/geevensingh/jotjson/issues/93) (subsumes #93). Adds the code scaffold needed to deploy a parallel SWA + Cosmos + Storage + App Insights stack into the Visual Studio Enterprise subscription, separate from production.

**No deploy happens from this PR alone.** The first nonprod deploy is gated on out-of-band Azure prep (steps 1.5-1.9 of the plan): federated cred, RG, role assignments, GH secrets, and the `NONPROD_DEPLOY_REDIRECT_URI` repo Variable. Those steps land after this PR merges.

## Why

The VS Enterprise subscription has \/mo in Azure credits that can fund **non-production** work but cannot move to the JotJson Subscription (where prod runs). This unlocks per-PR previews (#179), signed-in smoke (#68), nightly cross-browser smoke (#65), visual regression (#67), and dedicated-CPU perf testing — all of which need a deployed-but-not-prod environment to land on.

## What's in this PR

- `infra/main.bicep`: extend `@allowed` with `'nonprod'` (one-line change).
- `infra/parameters/nonprod.bicepparam`: mirrors `dev.bicepparam` with:
  - `environmentName = 'nonprod'`
  - `staticWebAppSku = 'Standard'` (preview envs need it)
  - `dnsZoneName = ''` (no custom DNS)
  - All `entra*` params empty (real values come via `-p` overrides at deploy time, matching prod's pattern)
- `.github/workflows/cd.yml`: parameterise the inline `environment.prod.ts` bake's `redirectUri`/`postLogoutRedirectUri` via `DEPLOY_REDIRECT_URI` env var (defaults to `https://jotjson.com/` for the prod path — behavior unchanged). `ci.yml`'s duplicate bake stays hard-coded; it only ever produces the prod artifact.
- `.github/workflows/infra-nonprod.yml`: new `workflow_dispatch`-only workflow targeting `rg-jotjson-nonprod` under `AZURE_SUBSCRIPTION_ID_NONPROD` with `nonprod.bicepparam` and the same `ENTRA_*` `-p` overrides as prod.
- `.github/workflows/cd-nonprod.yml`: new `workflow_dispatch`-only workflow mirroring `cd.yml`'s manual path with nonprod secrets (`AZURE_STATIC_WEB_APPS_API_TOKEN_NONPROD`, `APP_INSIGHTS_CONNECTION_STRING_NONPROD`, `AZURE_STORAGE_ACCOUNT_NONPROD`). Reads `DEPLOY_REDIRECT_URI` from the **repo Variable** `NONPROD_DEPLOY_REDIRECT_URI` so the hostname can be set/updated without a commit. A guard step fails fast if it's unset or malformed.

## Decisions locked in (from plan)

| Question | Decision |
| --- | --- |
| Env-name | `nonprod` (extend `@allowed` list by one value) |
| Cosmos mode | Serverless, matching prod. Free tier is incompatible with serverless. |
| CIAM redirect URI | Single fixed URI `https://<nonprod-hostname>/` registered explicitly on the existing prod SPA app registration. Wildcards rejected (Entra External ID does not support them). |
| Federated identity | Existing SP `gh-actions-jotjson`; add federated cred for `environment:nonprod` and Contributor on `rg-jotjson-nonprod` only (least-privilege; do not match prod's subscription-scope grant). |
| Budget | \/mo on VS sub, email `jotjsonadmin@gmail.com` |

## Verification

- [x] `npm run lint:all` (full chain: tsc x2, ascii, spec patterns, prod patterns, csp hashes, swa config, lockfile, prettier, reduced-motion, api tsc x2)
- [x] `npm run build:prod`
- [x] `npm --prefix api test` (452/452 pass)
- [x] `npm test` (frontend Karma, 2408 pass, 3 skipped)

## SemVer

No bump. CI/CD-only infrastructure change.

## Schema evolution

N/A. No Cosmos document shape changes. The nonprod Cosmos account is a fresh account with the same containers/partition keys as prod.

## Follow-ups (post-merge)

Out-of-band Azure prep + first deploy + verification chain (plan steps 1.5-1.15). I'll drive these once this lands.

## Plan

Session plan file: `~/.copilot/session-state/957ef979-c5cd-4d97-ab41-32be791be43d/plan.md` (not committed; canonical home is the PR/issue conversation).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
