### PR TITLE
Fix stale dorny/test-reporter @v2 references in ci.yml comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ on:
 #
 # Per-job escalations live in each job's `permissions:` block:
 #   - web             -> id-token: write (azure/login@v3 for sourcemap upload)
-#   - api             -> checks: write (dorny/test-reporter@v2)
-#   - api-integration -> checks: write (dorny/test-reporter@v2)
-#   - web-tests       -> checks: write (dorny/test-reporter@v2)
-#   - smoke-e2e       -> checks: write (dorny/test-reporter@v2)
+#   - api             -> checks: write (dorny/test-reporter@v3)
+#   - api-integration -> checks: write (dorny/test-reporter@v3)
+#   - web-tests       -> checks: write (dorny/test-reporter@v3)
+#   - smoke-e2e       -> checks: write (dorny/test-reporter@v3)
 #   - workflows-lint  -> no escalation (actionlint only)
 #
 # Notable previous over-grants tightened:
@@ -326,7 +326,7 @@ jobs:
     name: API build & test
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Publishes test results via dorny/test-reporter@v2.
+    # Publishes test results via dorny/test-reporter@v3.
     permissions:
       contents: read
       checks: write
@@ -410,7 +410,7 @@ jobs:
     name: Smoke api integration (real Cosmos)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Publishes test results via dorny/test-reporter@v2.
+    # Publishes test results via dorny/test-reporter@v3.
     permissions:
       contents: read
       checks: write
@@ -561,7 +561,7 @@ jobs:
     name: Web unit tests
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Publishes test results via dorny/test-reporter@v2.
+    # Publishes test results via dorny/test-reporter@v3.
     permissions:
       contents: read
       checks: write
@@ -619,7 +619,7 @@ jobs:
     name: Smoke e2e (anonymous, Chromium)
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    # Publishes test results via dorny/test-reporter@v2.
+    # Publishes test results via dorny/test-reporter@v3.
     permissions:
       contents: read
       checks: write


### PR DESCRIPTION
Comment-only cleanup of `ci.yml`.

The four test-publishing jobs (`api`, `api-integration`, `web-tests`, `smoke-e2e`) were upgraded to `dorny/test-reporter@v3` in a prior change, but eight comment lines still referenced `@v2`:

- The four-line summary block in the workflow header (the `permissions:` rationale).
- The per-job `# Publishes test results via dorny/test-reporter@v2.` comment in each of the four jobs.

No behavior change -- the action `uses:` lines were already `@v3`; only stale comments are touched. `npm run lint:all` passes.

No SemVer bump (comment-only change, doesn't affect product behavior).
