### PR TITLE
Rename CodeQL workflow to codeql-advanced.yml with display name "CodeQL (Advanced)"

### DIFF
--- a/.github/workflows/codeql-advanced.yml
+++ b/.github/workflows/codeql-advanced.yml
@@ -1,4 +1,4 @@
-name: "CodeQL"
+name: "CodeQL (Advanced)"
 
 # CodeQL Advanced Setup: replaces the auto-managed Default Setup so we
 # can use .github/codeql/codeql-config.yml to scope paths and exclude


### PR DESCRIPTION
## What

Rename the active CodeQL workflow to disambiguate it from the historical
`dynamic/github-code-scanning/codeql` tombstone in the Actions UI:

1. `git mv .github/workflows/codeql.yml .github/workflows/codeql-advanced.yml`
   — disambiguates the workflow URL slug and any future status-badge URL.
2. Display `name:` changes from `CodeQL` -> `CodeQL (Advanced)` — matches GitHub's
   own Advanced-Security-UI terminology (`Advanced setup` vs. `Default setup`)
   and disambiguates the Actions-list heading.

Single file changed, 1 insertion / 1 deletion (98% rename similarity).

## Why

The repo has had two `CodeQL`-named workflows in `Actions -> All workflows` since
2026-05-08: this active Advanced-Setup workflow and a historical Default-Setup
tombstone (`dynamic/github-code-scanning/codeql`) that was auto-disabled when
this file landed. Only one workflow fires, but the duplicate display name is
confusing when scanning the Actions list or filtering runs by name.

## Verified safe

- **Branch protection**: required-check contexts `Analyze (actions)` and
  `Analyze (javascript-typescript)` reference the **job** `name:`
  (`Analyze (${{ matrix.language }})`), not the workflow `name:`. Unchanged.
- **CodeQL alert continuity**: SARIF `category` is
  `/language:${{ matrix.language }}`, so existing dismissed alerts (#1, #6
  per `codeql-config.yml` rationale) survive the rename.
- **`workflow_run` / `workflow_call` consumers**: none. `cd.yml` consumes
  `workflow_run` from `CI` only.
- **Status badges**: no SVG badge URLs anywhere in the repo (verified by grep).
- **Concurrency group**: changes from `codeql-CodeQL-<ref>` to
  `codeql-CodeQL (Advanced)-<ref>`. Worst case if a scheduled run is in-flight
  at merge: one extra run completes (different group, no cancel).
  `cancel-in-progress` is gated on `pull_request` events only, so cross-name
  cancellation isn't expected for push/schedule anyway.

## Rubber-duck (AGENTS.md §11)

Plan went through `deep-review:skeptic` before authorization. Skeptic verdict:
**proceed-with-modifications, no blockers found**. Material findings adopted:
expanded scope from display-name-only to file-rename-plus-display-name; branched
off `origin/main` rather than the in-flight `feat/perf-measurement-suite` branch;
acknowledged convention drift vs. `Deploy (SWA)` / `Infra (Bicep)` (parens
denote tool in those; here parens denote setup tier — accepted because the
GitHub-UI parallel is the load-bearing semantic).

## SemVer / Telemetry / Mockup

- **SemVer**: no bump (CI display-name only).
- **Telemetry**: none.
- **Mockup**: N/A (no user-facing UI surface).

---
**Session**
- AI-Local: `74fde239-21af-4be8-9527-f04a7f265d50`
- AI-Cloud: (not present; CLI runtime without a cloud session id)