### PR TITLE
Parameterize playwright.config.ts via PLAYWRIGHT_BASE_URL

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -85,6 +85,20 @@ If you already have a build server on port 4173, Playwright reuses
 it locally (`reuseExistingServer: !CI`). On CI it always starts a
 fresh server.
 
+### Targeting a deployed environment
+
+Set `PLAYWRIGHT_BASE_URL` to skip the local build/serve and run the
+suite against a deployed environment instead:
+
+```
+PLAYWRIGHT_BASE_URL=https://<host>.azurestaticapps.net/ npm run test:e2e
+```
+
+This is how Phase 1's manual verification against the `nonprod` SWA
+runs, and how `cd-preview.yml` (per-PR previews) will exercise the
+same suite against each PR's preview URL. Whitespace-only values are
+ignored; non-`http(s)` URLs fail config load.
+
 ## Debugging failures
 
 On failure, Playwright writes:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,8 @@ import { defineConfig, devices } from '@playwright/test';
  * `https://<host>.azurestaticapps.net/`) to skip the local build/serve and
  * target an already-deployed environment instead. Used by Phase 1's manual
  * verification against `nonprod` and by Phase 2's per-PR preview smoke.
+ * Empty or whitespace-only values are treated as unset; the value must
+ * be an absolute http(s) URL or config load fails fast.
  *
  * Determinism guardrails (per zero-flake-tolerance norm):
  * - retries: 0 - any flake is a P0 bug, not absorbed by retries.
@@ -23,7 +25,20 @@ import { defineConfig, devices } from '@playwright/test';
  *
  * See e2e/README.md for how to add a spec, run locally, and debug failures.
  */
-const previewBaseUrl = process.env['PLAYWRIGHT_BASE_URL']?.replace(/\/$/, '');
+function readPreviewBaseUrl(): string | undefined {
+  const raw = process.env['PLAYWRIGHT_BASE_URL']?.trim();
+  if (!raw) {
+    return undefined;
+  }
+  if (!/^https?:\/\//i.test(raw)) {
+    throw new Error(
+      `PLAYWRIGHT_BASE_URL must be an absolute http(s) URL, got: ${JSON.stringify(raw)}`,
+    );
+  }
+  return raw.replace(/\/$/, '');
+}
+
+const previewBaseUrl = readPreviewBaseUrl();
 
 export default defineConfig({
   testDir: './e2e',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -3,9 +3,14 @@ import { defineConfig, devices } from '@playwright/test';
 /**
  * Playwright configuration for JotJSON's anonymous-flow smoke e2e suite.
  *
- * Runs Chromium-only against an anonymous-config production-built bundle.
- * The webServer command builds the SPA and serves it with `serve --single`
- * so SPA fallback routing works for nested routes like `/profile`.
+ * Default: builds the SPA and serves it locally with `serve --single` so
+ * SPA fallback routing works for nested routes like `/profile`, then runs
+ * Chromium against `http://localhost:4173`.
+ *
+ * Deployed-URL override: set `PLAYWRIGHT_BASE_URL` (e.g.
+ * `https://<host>.azurestaticapps.net/`) to skip the local build/serve and
+ * target an already-deployed environment instead. Used by Phase 1's manual
+ * verification against `nonprod` and by Phase 2's per-PR preview smoke.
  *
  * Determinism guardrails (per zero-flake-tolerance norm):
  * - retries: 0 - any flake is a P0 bug, not absorbed by retries.
@@ -18,6 +23,8 @@ import { defineConfig, devices } from '@playwright/test';
  *
  * See e2e/README.md for how to add a spec, run locally, and debug failures.
  */
+const previewBaseUrl = process.env['PLAYWRIGHT_BASE_URL']?.replace(/\/$/, '');
+
 export default defineConfig({
   testDir: './e2e',
   fullyParallel: false,
@@ -36,7 +43,7 @@ export default defineConfig({
     timeout: 10_000,
   },
   use: {
-    baseURL: 'http://localhost:4173',
+    baseURL: previewBaseUrl ?? 'http://localhost:4173',
     actionTimeout: 10_000,
     navigationTimeout: 30_000,
     reducedMotion: 'reduce',
@@ -50,12 +57,17 @@ export default defineConfig({
       use: { ...devices['Desktop Chrome'] },
     },
   ],
-  webServer: {
-    command: 'npm run build && npx serve --single dist/jotjson/browser -l 4173',
-    url: 'http://localhost:4173',
-    reuseExistingServer: !process.env['CI'],
-    timeout: 180_000,
-    stdout: 'pipe',
-    stderr: 'pipe',
-  },
+  // When PLAYWRIGHT_BASE_URL is set we are targeting a deployed environment
+  // (nonprod, preview env, etc.) and must NOT spin up a local serve - doing
+  // so would race against the build cache and possibly serve stale assets.
+  webServer: previewBaseUrl
+    ? undefined
+    : {
+        command: 'npm run build && npx serve --single dist/jotjson/browser -l 4173',
+        url: 'http://localhost:4173',
+        reuseExistingServer: !process.env['CI'],
+        timeout: 180_000,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      },
 });


### PR DESCRIPTION
## Why

Step 2.3 of the non-prod env plan, pulled forward into Phase 1 so step 1.12 (anonymous e2e against the deployed nonprod URL) can run end-to-end this phase.

## What

Allow `playwright.config.ts` to honor a `PLAYWRIGHT_BASE_URL` env var:

- **Unset (default)**: existing behavior - build the SPA and serve it locally with `serve --single` on `http://localhost:4173`. The current CI `e2e` job is unaffected (it never sets the variable).
- **Set**: skip `webServer` entirely and run Chromium against the given URL.

A trailing slash on the env value is stripped so callers can pass either form.

## Verification

- `npm run lint:all` - clean (tsc root + spec, ASCII, spec/prod patterns, CSP hashes, SWA config, lockfile, prettier, reduced-motion, api tsc).
- `npx playwright test --list` - 2 tests with the variable unset, 2 tests with it set to the nonprod URL (config loads both paths).
- `PLAYWRIGHT_BASE_URL=https://calm-flower-01969880f.7.azurestaticapps.net/ npm run test:e2e` - **both anonymous specs pass against the deployed nonprod SWA in 15.4s** (this doubles as Phase 1 step 1.12 validation).

## SemVer

No app code change. **No bump.**

## Plan reference

Phase 2 step 2.3 from the non-prod env plan (`C:\Users\geevens\.copilot\session-state\957ef979-c5cd-4d97-ab41-32be791be43d\plan.md`). Pulled forward to unblock Phase 1 step 1.12.