### PR TITLE
Document Phase 2 preview environments in spec + infra README

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -1523,8 +1523,10 @@ production stack.
   - Angular SPA -> Azure Static Web Apps (using the `azure/static-web-apps-deploy` action).
   - Azure Functions -> deployed as Static Web Apps managed functions (bundled with the SPA in a single deployment).
   - Per-PR preview deploys land on the **nonprod** stack (Phase 2 of
-    issue #93), not the production SWA - see Azure Infrastructure ->
-    "Non-production environment" above.
+    issue #93), not the production SWA - driven by `cd-preview.yml`,
+    one preview SWA environment + dedicated per-PR Cosmos database
+    per open PR, torn down on PR `closed`. See Azure Infrastructure
+    -> "Non-production environment" above.
 - **Infrastructure** - Bicep templates applied via a separate workflow on changes to `/infra` directory.
 - **Workflow lint** - `actionlint` runs against `.github/workflows/` in CI.
 - **Spec-pattern lint** - `scripts/check-spec-patterns.mjs` runs in CI's lint job and fails on known-fragile testing idioms (e.g. `spyOnProperty(navigator, 'clipboard', ...)` which silently passes on Windows headless Chrome but throws on the Linux runner). New rules are added as we encounter cross-platform test failures.
@@ -1561,6 +1563,7 @@ ID test tenant.
 | Browser integration | yes | Real Monaco loaded once per suite via the project's loader. Verifies the loader, the asset path, and the editor's mount + value roundtrip with a real DOM. Lives alongside frontend unit specs but is named `*.integration.spec.ts`. |
 | API integration | v1 gate (active) | Functions + shared modules against a CI-only real Cosmos DB free-tier account (1000 RU/s + 25 GB free forever; per-run unique database name; secret-presence check skips fork PRs). Catches partition-key, query-shape, and continuation-token mistakes that mocks cannot. The `vnext-preview` Linux emulator is rejected as a harness due to acknowledged flakiness. Tracked in issue #63. |
 | Smoke e2e (anonymous) | v1 gate (active) | Playwright on critical anonymous user flows in Chromium, per-PR. Catches MSAL redirect, router lazy-load, service-worker, and CSP regressions that unit + browser-integration cannot. Tracked in issue #64. |
+| Preview-env smoke | shadow (active) | Same anonymous smoke harness, but pointed at a per-PR SWA preview environment on the nonprod stack (`pr-<N>` on `swa-jotjson-nonprod`) via `PLAYWRIGHT_BASE_URL`. Catches deploy-pipeline regressions (SWA config drift, CSP, service worker, redirect rules) that the locally-served-from-`dist` anonymous smoke cannot. Driven by `.github/workflows/cd-preview.yml`; lives under shadow mode (`continue-on-error: true` on the e2e job) for ~1 week from PR #210 merge, then flipped to required. Tracked in issue #93 (Phase 2) / #179. |
 | Smoke e2e (signed-in) | deferred | Same harness as anonymous smoke, but covers blob CRUD, share lifecycle, profile round-trip, and MSAL silent-token refresh. Requires an Entra External ID test tenant + ROPC users in CI; tenant setup is currently out of scope. Tracked in issue #68. |
 | Cross-browser smoke | post-v1 | Playwright matrix on Firefox + WebKit, run nightly. Catches engine-specific issues. (WebKit on Linux is not Safari; iOS-Safari still needs manual verification.) Deferred post-v1 due to engine-flake risk and zero historical engine-specific shipped bugs. Tracked in issue #65. |
 | Accessibility smoke | v1 gate (active) | `@axe-core/playwright` invoked from each smoke flow, blocking on `serious` + `critical` impact only; pre-existing violations are allow-listed with dated review-by comments. Backs the WCAG 2.1 AA commitment in the Accessibility section (axe-green is necessary but not sufficient for WCAG-green - keyboard-only nav, screen-reader announcements, and dynamic focus order remain manual concerns). Tracked in issue #66. |

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -1524,9 +1524,16 @@ production stack.
   - Azure Functions -> deployed as Static Web Apps managed functions (bundled with the SPA in a single deployment).
   - Per-PR preview deploys land on the **nonprod** stack (Phase 2 of
     issue #93), not the production SWA - driven by `cd-preview.yml`,
-    one preview SWA environment + dedicated per-PR Cosmos database
-    per open PR, torn down on PR `closed`. See Azure Infrastructure
-    -> "Non-production environment" above.
+    one preview SWA environment + a dedicated per-PR Cosmos database
+    per open PR, both torn down on PR `closed`. The per-PR Cosmos
+    database is currently **defensive scaffolding only** (created
+    and torn down for resource isolation, but not yet wired into
+    preview Functions because `az staticwebapp appsettings set
+    --environment-name <preview>` returns Not Found for non-default
+    environments); preview Functions read whatever app settings the
+    default `production` env has. See Azure Infrastructure ->
+    "Non-production environment" above for the limitation details
+    and the three alternative paths #68 can take.
 - **Infrastructure** - Bicep templates applied via a separate workflow on changes to `/infra` directory.
 - **Workflow lint** - `actionlint` runs against `.github/workflows/` in CI.
 - **Spec-pattern lint** - `scripts/check-spec-patterns.mjs` runs in CI's lint job and fails on known-fragile testing idioms (e.g. `spyOnProperty(navigator, 'clipboard', ...)` which silently passes on Windows headless Chrome but throws on the Linux runner). New rules are added as we encounter cross-platform test failures.
@@ -1563,7 +1570,7 @@ ID test tenant.
 | Browser integration | yes | Real Monaco loaded once per suite via the project's loader. Verifies the loader, the asset path, and the editor's mount + value roundtrip with a real DOM. Lives alongside frontend unit specs but is named `*.integration.spec.ts`. |
 | API integration | v1 gate (active) | Functions + shared modules against a CI-only real Cosmos DB free-tier account (1000 RU/s + 25 GB free forever; per-run unique database name; secret-presence check skips fork PRs). Catches partition-key, query-shape, and continuation-token mistakes that mocks cannot. The `vnext-preview` Linux emulator is rejected as a harness due to acknowledged flakiness. Tracked in issue #63. |
 | Smoke e2e (anonymous) | v1 gate (active) | Playwright on critical anonymous user flows in Chromium, per-PR. Catches MSAL redirect, router lazy-load, service-worker, and CSP regressions that unit + browser-integration cannot. Tracked in issue #64. |
-| Preview-env smoke | shadow (active) | Same anonymous smoke harness, but pointed at a per-PR SWA preview environment on the nonprod stack (`pr-<N>` on `swa-jotjson-nonprod`) via `PLAYWRIGHT_BASE_URL`. Catches deploy-pipeline regressions (SWA config drift, CSP, service worker, redirect rules) that the locally-served-from-`dist` anonymous smoke cannot. Driven by `.github/workflows/cd-preview.yml`; lives under shadow mode (`continue-on-error: true` on the e2e job) for ~1 week from PR #210 merge, then flipped to required. Tracked in issue #93 (Phase 2) / #179. |
+| Preview-env smoke | shadow (active) | Same anonymous smoke harness, but pointed at a per-PR SWA preview environment on the nonprod stack (`pr-<N>` on `swa-jotjson-nonprod`) via `PLAYWRIGHT_BASE_URL`. Catches deploy-pipeline regressions (SWA config drift, CSP, service worker, redirect rules) that the locally-served-from-`dist` anonymous smoke cannot. Driven by `.github/workflows/cd-preview.yml`; lives under shadow mode (`continue-on-error: true` on the `Run Playwright tests` **step** of the `e2e-preview` job, so a red smoke does not block the build-and-deploy job's success or the PR) for ~1 week from PR #210 merge, then flipped to required. Tracked in issue #93 (Phase 2) / #179. |
 | Smoke e2e (signed-in) | deferred | Same harness as anonymous smoke, but covers blob CRUD, share lifecycle, profile round-trip, and MSAL silent-token refresh. Requires an Entra External ID test tenant + ROPC users in CI; tenant setup is currently out of scope. Tracked in issue #68. |
 | Cross-browser smoke | post-v1 | Playwright matrix on Firefox + WebKit, run nightly. Catches engine-specific issues. (WebKit on Linux is not Safari; iOS-Safari still needs manual verification.) Deferred post-v1 due to engine-flake risk and zero historical engine-specific shipped bugs. Tracked in issue #65. |
 | Accessibility smoke | v1 gate (active) | `@axe-core/playwright` invoked from each smoke flow, blocking on `serious` + `critical` impact only; pre-existing violations are allow-listed with dated review-by comments. Backs the WCAG 2.1 AA commitment in the Accessibility section (axe-green is necessary but not sufficient for WCAG-green - keyboard-only nav, screen-reader announcements, and dynamic focus order remain manual concerns). Tracked in issue #66. |

--- a/infra/README.md
+++ b/infra/README.md
@@ -375,10 +375,10 @@ plus a dedicated Cosmos database, both automatically torn down on PR
 |---|---|
 | Workflow | `.github/workflows/cd-preview.yml` |
 | Trigger | `pull_request` (`opened`, `synchronize`, `reopened`, `closed`); fork PRs skipped |
-| SWA preview env | `pr-<N>` on `swa-jotjson-nonprod` (hostname pattern: `<swa-shortname>-<N>.<region>.azurestaticapps.net`) |
+| SWA preview env | `pr-<N>` on `swa-jotjson-nonprod` (hostname pattern: roughly `<swa-default-hostname>-<N>.<region>.<dns-suffix>.azurestaticapps.net` - e.g. `calm-flower-01969880f-210.eastus2.7.azurestaticapps.net`; the `<dns-suffix>` segment can change without notice per Azure, so the canonical source is the `static_web_app_url` output of `Azure/static-web-apps-deploy@v1`, exposed as the `preview_url` job output and pasted into the sticky comment). |
 | Per-PR Cosmos DB | `jotjson-pr-<N>` on `cosmos-jotjson-nonprod` (defensive scaffolding for #68; created and torn down but **not yet wired** into preview Functions - see "Known limitations" below) |
 | Sign-in | **anonymous build only** - MSAL is initialised with inert config; sign-in is non-functional on preview URLs. #68 tracks the signed-in story. |
-| e2e | The existing anonymous smoke (`e2e/anonymous/`) is replayed against the preview URL via `PLAYWRIGHT_BASE_URL`. Shadow mode (`continue-on-error: true`) for ~1 week from #210 merge, then flipped to required. |
+| e2e | The existing anonymous smoke (`e2e/anonymous/`) is replayed against the preview URL via `PLAYWRIGHT_BASE_URL`. Shadow mode (`continue-on-error: true` on the `Run Playwright tests` **step**, not the whole job) for ~1 week from #210 merge, then flipped to required. |
 | Sticky comment | `marocchino/sticky-pull-request-comment@v2`, header `cd-preview`; updates in-place across deploy / re-deploy / teardown so each PR carries exactly one preview status comment. |
 | Concurrency | `cd-preview-pr-<N>` with `cancel-in-progress: true` - newer commits on the same PR cancel older builds. |
 

--- a/infra/README.md
+++ b/infra/README.md
@@ -364,6 +364,82 @@ az deployment group create `
 # See cd-nonprod.yml for the full env-var bake step and SWA deploy invocation.
 ```
 
+### Preview environments
+
+Per-PR preview deploys land on this same nonprod stack (Phase 2 of
+issue #93 / #179). Each open PR gets its own SWA preview environment
+plus a dedicated Cosmos database, both automatically torn down on PR
+`closed`.
+
+| Item | Value |
+|---|---|
+| Workflow | `.github/workflows/cd-preview.yml` |
+| Trigger | `pull_request` (`opened`, `synchronize`, `reopened`, `closed`); fork PRs skipped |
+| SWA preview env | `pr-<N>` on `swa-jotjson-nonprod` (hostname pattern: `<swa-shortname>-<N>.<region>.azurestaticapps.net`) |
+| Per-PR Cosmos DB | `jotjson-pr-<N>` on `cosmos-jotjson-nonprod` (defensive scaffolding for #68; created and torn down but **not yet wired** into preview Functions - see "Known limitations" below) |
+| Sign-in | **anonymous build only** - MSAL is initialised with inert config; sign-in is non-functional on preview URLs. #68 tracks the signed-in story. |
+| e2e | The existing anonymous smoke (`e2e/anonymous/`) is replayed against the preview URL via `PLAYWRIGHT_BASE_URL`. Shadow mode (`continue-on-error: true`) for ~1 week from #210 merge, then flipped to required. |
+| Sticky comment | `marocchino/sticky-pull-request-comment@v2`, header `cd-preview`; updates in-place across deploy / re-deploy / teardown so each PR carries exactly one preview status comment. |
+| Concurrency | `cd-preview-pr-<N>` with `cancel-in-progress: true` - newer commits on the same PR cancel older builds. |
+
+#### Known limitations
+
+- **No per-preview app-setting overrides via Azure CLI.**
+  `az staticwebapp appsettings set --environment-name <preview>`
+  returns `Operation returned an invalid status 'Not Found'` for any
+  environment other than the default `production`. This means the
+  per-PR Cosmos database is created but not wired into the preview
+  Functions; Functions running on a preview see whatever app settings
+  the default `production` env has. The three alternative paths for
+  signed-in / write-bearing preview coverage are documented in the
+  inline comment block at the top of `cd-preview.yml`:
+  1. Use the ARM Management API
+     (`Microsoft.Web/staticSites/builds/{env}/config/appsettings`)
+     directly via `az rest`.
+  2. Route at runtime inside the Functions code based on a header /
+     env name extracted from the SWA hostname.
+  3. Share the default Cosmos database and partition by a per-PR
+     ownerId prefix.
+  These are out of scope for Phase 2 (anonymous smoke only) and will
+  be revisited when #68 lights up.
+- **Docs-only PRs still deploy a preview** (~3 minutes). The
+  workflow deliberately omits trigger-level `paths-ignore` so the
+  `closed` event always reaches the teardown job - this prevents
+  preview-env / Cosmos-DB leaks for PRs that end up docs-only after a
+  code revert. The cost of one wasted deploy per docs-only PR is
+  preferable to silent leaks.
+- **Preview teardown is partial-failure-resilient.** SWA close and
+  Cosmos DB delete run independently (`continue-on-error: true` +
+  `if: always()`); a final summary step re-fails the job loudly if
+  either provider call failed, so a partial teardown surfaces as a
+  red workflow run rather than a silent leak.
+
+#### Useful KQL / Azure queries
+
+```kusto
+// Preview deploys in the last 7 days (Application Insights)
+requests
+| where timestamp > ago(7d)
+| where cloud_RoleName == "swa-jotjson-nonprod"
+| where customDimensions has "pr-"
+| summarize count() by tostring(customDimensions["EnvironmentName"]), bin(timestamp, 1d)
+| order by timestamp desc
+```
+
+```powershell
+# List currently-open preview SWA environments
+az staticwebapp environment list `
+  --name swa-jotjson-nonprod `
+  --resource-group rg-jotjson-nonprod `
+  --query "[?name != 'default'].{name:name, hostname:hostname, status:status}" -o table
+
+# List currently-open per-PR Cosmos databases
+az cosmosdb sql database list `
+  --account-name cosmos-jotjson-nonprod `
+  --resource-group rg-jotjson-nonprod `
+  --query "[?starts_with(name, 'jotjson-pr-')].{name:name}" -o table
+```
+
 ### Cost budget runbook
 
 Subscription-scoped budgets with notifications **cannot** be created
@@ -413,7 +489,10 @@ more entries to the `notifications` dict with distinct keys.
 ### Pointer
 
 - Workflow files: `.github/workflows/infra-nonprod.yml`,
-  `.github/workflows/cd-nonprod.yml`.
+  `.github/workflows/cd-nonprod.yml`,
+  `.github/workflows/cd-preview.yml`.
 - Bicep parameters: `infra/parameters/nonprod.bicepparam`.
 - Spec section: DESIGN_SPEC.md -> Azure Infrastructure -> "Non-production environment".
-- Tracking issue: #93 (Phase 1 in this RG; Phase 2 wires per-PR previews into this same stack).
+- Tracking issues: #93 (Phase 1 in this RG, complete); #179 (Phase 2
+  per-PR previews, in shadow mode); #68 (deferred: signed-in preview
+  coverage); #211 (follow-up: status-bar channel chip).


### PR DESCRIPTION
Docs follow-up to PR #210. Spec + infra README now reflect the per-PR preview environment behavior actually shipped in `cd-preview.yml`.

## Changes

**`DESIGN_SPEC.md`**

- New `Preview-env smoke` row in the Testing-strategy table, between the anonymous and signed-in smoke rows. Flagged as `shadow (active)` to mirror the workflow's `continue-on-error: true` posture for the first ~1 week.
- Tightened the CD-pipeline bullet to name `cd-preview.yml` and describe the per-PR resources rather than pointing only at the nonprod prose.

**`infra/README.md`**

- New `### Preview environments` subsection under the existing Non-production-environment section. Sits between `Manual deploy commands` and `Cost budget runbook`. Includes:
  - Inventory table (workflow, trigger, SWA env pattern, per-PR Cosmos DB pattern, sign-in mode, e2e harness, sticky-comment header, concurrency group).
  - **Known limitations** subsection: documents the Azure CLI `appsettings set --environment-name <preview>` Not-Found behavior + the three alternative paths for signed-in / write-bearing preview coverage (ARM Management API, runtime env-name routing, shared-DB + ownerId partition). Also notes the docs-only-PR tradeoff (we deploy ~3-min build to guarantee teardown) and the partial-failure-resilient teardown.
  - Useful KQL / `az` queries for listing live preview envs and per-PR Cosmos databases.
- Added #211 and #179 to the Pointer list at the end of the nonprod section.

## Why

Phase 2 PR 1 (#210) shipped the workflow but didn't touch the spec or infra README. Future contributors landing on those docs would otherwise miss that previews exist, where they land, and the architectural details that influenced the design (anonymous-only, paths-ignore decision, appsettings limitation).

## Validation

- `npm run lint:ascii` -> clean (447 files scanned, 0 violations).
- `npm run lint:format` -> clean.
- `npm run lint:spec-patterns` -> clean.
- `npm run lint:prod-patterns` -> clean.
- No code touched - no test impact.

## Related

- #210 (Phase 2 PR 1: the `cd-preview.yml` workflow).
- #179 (canonical preview-env tracking issue).
- #93 (Phase 1 / Phase 2 epic).
- #68 (deferred: signed-in preview coverage).
- #211 (follow-up: status-bar channel chip).
