### PR TITLE
Add CODEOWNERS for auto-review routing (#195)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,40 @@
+# Default code owner for all paths. GitHub auto-requests review from
+# @geevensingh on every PR matching the rule below, subject to the
+# PR-author exclusion (a PR author is never auto-requested on their
+# own PR).
+#
+# Concrete behaviors:
+# - PRs opened by a bot identity (Dependabot, future Cloud Copilot
+#   coding agent, future background agents that auth as their own
+#   GitHub App or bot user, future external human contributors) get
+#   @geevensingh auto-requested. This is the motivating workflow.
+# - PRs opened by Copilot CLI or any interactive agent session that
+#   runs under `gh auth` as @geevensingh have @geevensingh as the
+#   PR author. The PR-author exclusion suppresses auto-request, so
+#   CODEOWNERS provides NO routing benefit for these PRs. (This is
+#   currently the most common pattern in this repo.)
+# - `Co-authored-by:` trailers in commit messages do NOT change the
+#   GitHub PR-author identity. An agent-opened PR with a
+#   `Co-authored-by: @geevensingh` trailer still has the agent as
+#   PR author at the GitHub-API level and still triggers
+#   auto-request.
+# - The wildcard catches every file -- including auto-generated
+#   diffs like messages.xlf and grouped Dependabot lockfile bumps.
+#
+# Syntax notes:
+# - CODEOWNERS does NOT support .gitignore-style `!` negation.
+# - CODEOWNERS DOES support a "leave ownerless" idiom: list a path
+#   on its own line with NO owners after it. Last-match-wins makes
+#   the empty-owners line clear the inherited owner for that path.
+#   See https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file
+# - Multiple owners on the same rule are space-separated on the
+#   same line (e.g. `*.spec.ts @geevensingh @second-owner`). If
+#   two owners appear on separate lines for the same path, only
+#   the LAST line's owners apply -- not the union.
+#
+# Precedence: for paths matched by multiple lines, the LAST
+# matching line wins -- not the more-specific one. Put any
+# future path-scoped carve-outs BELOW the wildcard, not above.
+# To exempt a sub-path from this wildcard, list it below with no
+# owners (see syntax notes).
+*    @geevensingh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -855,6 +855,83 @@ runtimes (e.g., Copilot Coding Agent) have different session-ID
 semantics and are out of scope for this rule until added
 explicitly.
 
+### CODEOWNERS routing
+
+`.github/CODEOWNERS` is the **routing** source for human review on
+this repo. The single wildcard rule `* @geevensingh` lists
+`@geevensingh` as the default code owner for every path; GitHub
+auto-requests review from any listed code owner on every PR
+matching the rule, subject to the **PR-author exclusion** (a PR
+author is never auto-requested on their own PR).
+
+**Asymmetric routing in this single-maintainer repo:**
+
+- **Bot-identity PRs** (Dependabot, future Cloud Copilot coding
+  agent, future background agents that auth as their own GitHub
+  App or bot user, future external human contributors) - author
+  is not `@geevensingh` -> `@geevensingh` is auto-requested.
+  Routing fires. This is the motivating workflow.
+- **Owner-authored PRs (including Copilot CLI / interactive
+  sessions running under `gh auth` as `@geevensingh`)** - author
+  is `@geevensingh` -> no auto-request -> routing does NOT fire.
+  This currently covers the majority of recent PRs.
+
+`Co-authored-by:` trailers in commit messages do **not** change
+the GitHub PR-author identity. An agent-opened PR with a
+`Co-authored-by: @geevensingh` trailer still has the agent as PR
+author at the GitHub-API level and still triggers CODEOWNERS
+auto-request.
+
+**Branch protection is unchanged by CODEOWNERS.** Classic
+protection still has `required_approving_review_count: 0` and
+`require_code_owner_reviews: false`. The merge gate against agent
+self-merge remains §8 policy ("surface blocks and wait for human
+approval"), not platform enforcement. Phase 2 (welding the gate
+to the platform via `require_code_owner_reviews: true`) is
+deliberately deferred.
+
+**No new agent-behavior rule is introduced.** Existing
+`### Auto-merge` rules below continue to govern when an agent may
+enable auto-merge - CODEOWNERS adds routing visibility, not a new
+restriction.
+
+**Tripwires that would re-open Phase 2.** Phase 2 is deferred, not
+abandoned. Re-open the discussion if any of the following occurs:
+
+- A second code owner is added (Phase 2 becomes viable because a
+  second owner can approve `@geevensingh`'s PRs without forcing
+  Admin bypass).
+- A compromised-session incident or near-miss involving Admin scope.
+- An agent, workflow, or fine-grained PAT is granted
+  `contents: write` or `pull_requests: write` on this repo beyond
+  `@geevensingh`'s interactive session. (The repo is currently
+  user-owned, not org-owned; if it is ever transferred to an org,
+  broaden this tripwire to include org-level grants.)
+- A new GitHub App or Action beyond Copilot/Mergify/Dependabot is
+  installed with write scope.
+- The `copilot_code_review` ruleset rule is disabled or deprecated
+  by GitHub.
+- The first PR opened by a non-`@geevensingh`, non-bot human
+  contributor (changes the trust profile of the repo; revisit the
+  "single maintainer" assumption that underlies Phase-1-only).
+- Any addition to CODEOWNERS beyond `@geevensingh` (especially a
+  bot/App identity or a team containing one) warrants threat-model
+  re-review - GitHub Apps can submit `APPROVE` reviews via REST,
+  and if the App identity is a code owner, that approval counts.
+
+**CODEOWNERS syntax watchouts** (relevant if anyone edits the file):
+
+- The wildcard catches every path. To exempt a sub-path, list it
+  below the wildcard with **no owners** (the empty-owners idiom is
+  supported; last-match-wins makes the empty line clear the
+  inherited owner).
+- CODEOWNERS does NOT support `.gitignore`-style `!` negation.
+- Multiple owners for the same rule must be space-separated on one
+  line. Separate lines for the same path do NOT union - only the
+  last line's owners apply.
+- Rules are read from the **base branch**, so the PR introducing a
+  CODEOWNERS change does not trigger its own routing.
+
 ### Responding to PR review feedback
 
 Review comments -- from humans **and** from bots

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,8 @@ frameworks, or cloud services without prior approval.
   feature is added, removed, or significantly altered. Keep entries
   terse - it is the public pitch doc, not engineering documentation.
 - CI (lint, test, build for both frontend and Functions) must be green.
-- At least one review approval required before merge.
+- On PRs you did not author yourself, a code-owner review is
+  auto-requested. Please respond to feedback before merging.
 
 ## Security & Privacy
 


### PR DESCRIPTION
## What

Adds `.github/CODEOWNERS` so PRs that aren't authored by `@geevensingh`
auto-request review from the maintainer. Also documents the routing
function in `AGENTS.md` §8 and fixes a pre-existing inaccuracy in
`CONTRIBUTING.md:73`.

Closes #195.

## Scope: Phase 1 only — routing, not enforcement

`.github/CODEOWNERS` provides **two distinct functions**:

1. **Routing** (file presence): GitHub auto-requests the listed code
   owner on every PR matching a rule. Fires independent of branch
   protection. This is what #195 asked for.
2. **Enforcement** (`require_code_owner_reviews: true`): the platform
   *requires* a code-owner-approved review before merge. Separate
   branch-protection setting.

This PR ships #1 only. #2 is deferred (rationale below).

## Files changed

| File | Change |
|---|---|
| `.github/CODEOWNERS` | new — wildcard `* @geevensingh` plus an extensive comment block (Cloud-vs-CLI routing distinction, Co-authored-by clarification, syntax watchouts) |
| `AGENTS.md` §8 | new `### CODEOWNERS routing` sub-heading documenting routing source, bot-vs-owner asymmetry, Phase 2 deferred + tripwire list, syntax watchouts |
| `CONTRIBUTING.md:73` | rewrites the pre-existing false claim ("At least one review approval required before merge.") with truthful routing wording |

No code, no tests, no spec semantics, no telemetry, no infra. No
`DESIGN_SPEC.md` change (its branch-protection enumeration at line
1482 is still accurate post-merge).

## Why Phase 2 (`require_code_owner_reviews: true`) is deferred

Empirically verified that **PR authors cannot approve their own PRs**
on GitHub server-side:

```
$ gh api -X POST /repos/geevensingh/jotjson/pulls/208/reviews -f event=APPROVE
HTTP 422 Unprocessable Entity
errors: ["Review Can not approve your own pull request"]
```

In this single-maintainer repo, flipping
`require_code_owner_reviews: true` would force Admin UI bypass on
every owner-authored PR. That conflicts with AGENTS.md §8's
no-bypass rule and breaks the existing auto-merge flow.

Tripwires for re-opening Phase 2 are documented in the new
AGENTS.md sub-heading (so they survive plan.md being discarded).
Headline triggers: a second code owner is added, a new contributor
opens a PR, a fine-grained PAT or App is granted `contents: write`
beyond @geevensingh's interactive session.

## PR-author exclusion makes routing asymmetric

- **Bot-identity PRs** (Dependabot, future Cloud Copilot coding
  agent, future external contributors): author ≠ @geevensingh →
  auto-request fires. **This is the motivating workflow.**
- **Copilot CLI / interactive sessions running under
  `@geevensingh`**: author == @geevensingh → auto-request
  suppressed by GitHub's PR-author exclusion → no routing benefit.
  Currently the most common pattern in this repo.

`Co-authored-by:` trailers do **not** change PR-author identity —
they're a commit-level convention, not a GitHub API field.

## Pre-merge verification

- ✅ **REST**: `gh api /repos/geevensingh/jotjson/codeowners/errors?ref=chore/add-codeowners`
  returns `{"errors": []}` — file parses cleanly.
- ⏳ **Blob view**: manual eyeball check on
  https://github.com/geevensingh/jotjson/blob/chore/add-codeowners/.github/CODEOWNERS
  — expect the "Owners" indicator with no syntax-error banner.

## Post-merge sanity check (deferred follow-up)

On the next PR opened against `main` after this merge SHA whose
author is NOT `@geevensingh` (next Dependabot bump is the cleanest
test), verify `@geevensingh` is auto-requested AND the
`(code owner)` tag appears in the review sidebar. Also observe
whether Mergify-rebase pushes into the currently-open Dependabot
PRs (#200/#201/#202) trigger CODEOWNERS evaluation — GitHub docs
are ambiguous on whether branch-update pushes re-evaluate. Findings
will be recorded in the issue closing comment.

## SemVer decision

**No bump.** Governance file addition with no product behavior,
public API, or user-visible feature change.

## Definition of Done

- [x] `.github/CODEOWNERS` committed with `* @geevensingh` plus
      comment block
- [x] `AGENTS.md` §8 `### CODEOWNERS routing` sub-heading added
- [x] `CONTRIBUTING.md:73` updated to truthful wording
- [x] `npm run lint:all` passes locally
- [x] `codeowners/errors?ref=chore/add-codeowners` returns
      `{"errors": []}`
- [ ] Manual blob-view eyeball confirms "Owners" indicator
- [ ] Merge via normal flow (no Admin bypass)
- [ ] Post-merge sanity check + Mergify-rebase observation recorded
      in #195 closing comment (no time bound)


---
**Session**
- AI-Local: `bc7c3a8f-19bb-49e4-a5ed-7faf763a6fcb`
- AI-Cloud: `03d8e46e-580c-4a18-a23d-7031b474a4c1`
