### PR TITLE
Add deployed-headers smoke spec (e2e/preview) for cd-preview env (#220)

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -18,14 +18,36 @@ cannot:
 
 ## What this suite is NOT for
 
-- **SWA-applied response headers** (CSP, X-Frame-Options) - those live
-  in `staticwebapp.config.json` and only take effect on a deployed SWA
-  host. Validating them needs a separate post-deploy smoke layer.
+- **SWA-applied response headers** (CSP, X-Frame-Options, HSTS, etc.) -
+  those live in `staticwebapp.config.json` and only take effect on a
+  deployed SWA host. Source-level coverage lives in
+  `scripts/check-swa-config.mjs` (`lint:swa-config` gate); end-to-end
+  deployed-response coverage lives in
+  [`e2e/preview/security-headers.spec.ts`](./preview/security-headers.spec.ts)
+  and runs only when `PLAYWRIGHT_BASE_URL` is set (cd-preview's
+  `e2e-preview` job).
 - **Real MSAL config behavior** - the e2e bundle is built against
   `environment.example.ts` (anonymous), not the secret-baked
   `environment.prod.ts`. Signed-in coverage is tracked in issue #68.
 - **Cross-browser** (Firefox, WebKit) - issue #65, post-v1.
 - **Visual regression** - issue #67, post-v1.
+
+## Folders
+
+This suite is split into two top-level folders. Both are auto-
+discovered by `playwright.config.ts`'s `testDir: './e2e'`.
+
+- **`e2e/anonymous/`** - app-behavior specs that pass against either
+  the local `dist/` serve or a deployed SWA host. The default `npm run
+  test:e2e` and the CI `e2e` job run these against the local serve;
+  cd-preview's `e2e-preview` job re-runs them against the per-PR
+  preview URL.
+- **`e2e/preview/`** - deploy-behavior specs that only make sense
+  against a deployed SWA host (e.g., asserting SWA-applied response
+  headers reach the browser). Specs here skip at module load when
+  `PLAYWRIGHT_BASE_URL` is unset, so the CI `e2e` job stays green
+  without them and cd-preview's `e2e-preview` job picks them up
+  automatically. See [`e2e/preview/README.md`](./preview/README.md).
 
 ## Anonymous routes only
 

--- a/e2e/preview/README.md
+++ b/e2e/preview/README.md
@@ -1,0 +1,50 @@
+# JotJSON e2e - preview-env specs
+
+This directory holds Playwright specs that **only make sense against a
+deployed environment** (a real Azure Static Web Apps host, typically the
+per-PR preview env on `swa-jotjson-nonprod`). They are skipped when the
+suite is run against the local `dist/` serve.
+
+## What lives here
+
+- **`security-headers.spec.ts`** - asserts that the SWA-applied response
+  headers from `staticwebapp.config.json` `globalHeaders` reach the
+  browser on a request to `/`. Catches deploy-pipeline regressions
+  (config drift, AFD stripping, CDN edge rewrites) that the
+  `lint:swa-config` gate cannot catch by reading the source file alone.
+
+## Why a separate folder
+
+The `e2e/anonymous/` smoke specs validate **app behavior** - Monaco
+mount, tree render, draft persistence, accessibility - and run against
+both the local `dist/` serve and (in cd-preview) a deployed preview
+URL. They pass either way.
+
+The specs here validate **deploy behavior** - bytes the SWA platform
+adds to responses, which only exist on a deployed host. Running them
+against `localhost:4173` would always fail (or, worse, silently pass
+against a `serve --single`-shaped response that does not include
+`globalHeaders`). The skip-on-local-serve guard at the top of each
+spec keeps the `e2e` CI job green when `PLAYWRIGHT_BASE_URL` is unset.
+
+## Adding a spec here
+
+1. Confirm the assertion only makes sense against a deployed SWA host.
+   App-behavior specs belong in `e2e/anonymous/`.
+2. Skip at module load when `PLAYWRIGHT_BASE_URL` is unset (see
+   `security-headers.spec.ts` for the pattern). Specs in this folder
+   must never fail when the suite runs against the local serve.
+3. Keep the assertion narrow - one HTTP request per spec where
+   feasible. cd-preview's `e2e-preview` job runs serially after the
+   anonymous smoke; every spec here adds to total CI wall-time.
+
+## Where these specs run
+
+- **CI `e2e` job** (`ci.yml`, every push/PR): `PLAYWRIGHT_BASE_URL`
+  unset; specs in this folder skip cleanly.
+- **`cd-preview.yml` `e2e-preview` job** (per-PR preview deploys):
+  `PLAYWRIGHT_BASE_URL=<preview-url>` set; specs in this folder run
+  against the deployed preview environment.
+
+See the top-level [`e2e/README.md`](../README.md) for the broader
+suite layout, zero-flake norm, and CI integration overview.

--- a/e2e/preview/security-headers.spec.ts
+++ b/e2e/preview/security-headers.spec.ts
@@ -1,0 +1,75 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Deployed-only spec: validates that the SWA-applied response headers
+ * declared in `staticwebapp.config.json` `globalHeaders` actually reach
+ * the browser on a request to `/`.
+ *
+ * The repo has a `lint:swa-config` gate (`scripts/check-swa-config.mjs`)
+ * that asserts the source config file declares each required header
+ * with the expected value. That gate runs on every CI build but it can
+ * only read the source file -- it cannot prove the SWA deploy pipeline,
+ * Azure Front Door, or any CDN edge in between is not stripping or
+ * rewriting headers on the way to the browser. This spec closes that
+ * end-to-end gap by inspecting a real HTTP response from a deployed
+ * preview environment.
+ *
+ * Skipped when `PLAYWRIGHT_BASE_URL` is unset (i.e. CI `e2e` job or any
+ * local `npm run test:e2e` against the locally-served `dist/`). The
+ * local `serve --single` does not apply `globalHeaders`, so running
+ * this spec there would always fail or, worse, silently false-pass
+ * against a different header set.
+ *
+ * If a header is added to or removed from `staticwebapp.config.json`,
+ * three places must be kept in sync:
+ *   1. `staticwebapp.config.json` `globalHeaders` (the source).
+ *   2. `scripts/check-swa-config.mjs` `checkGlobalHeaders()` (source lint).
+ *   3. This spec (deployed-response check).
+ */
+
+const baseUrl = process.env['PLAYWRIGHT_BASE_URL']?.trim();
+
+test.describe('Deployed SWA globalHeaders reach the browser', () => {
+  test.skip(
+    !baseUrl,
+    'security-headers.spec.ts requires PLAYWRIGHT_BASE_URL to point at a ' +
+      'deployed SWA host. Skipping when targeting the local dist/ serve, ' +
+      'which does not apply globalHeaders.',
+  );
+
+  test('GET / response carries all 7 SWA globalHeaders', async ({ request }) => {
+    const response = await request.get('/');
+    expect(response.status()).toBe(200);
+
+    const headers = response.headers();
+
+    expect(headers['x-content-type-options'], 'X-Content-Type-Options').toBe('nosniff');
+    expect(headers['x-frame-options'], 'X-Frame-Options').toBe('SAMEORIGIN');
+    expect(headers['x-xss-protection'], 'X-XSS-Protection').toBe('0');
+    expect(headers['referrer-policy'], 'Referrer-Policy').toBe('strict-origin-when-cross-origin');
+
+    const hsts = headers['strict-transport-security'];
+    expect(hsts, 'Strict-Transport-Security present').toBeTruthy();
+    const maxAgeMatch = /(?:^|;|\s)\s*max-age\s*=\s*(\d+)/i.exec(hsts ?? '');
+    expect(maxAgeMatch, 'Strict-Transport-Security has max-age=...').not.toBeNull();
+    expect(
+      Number(maxAgeMatch?.[1]),
+      'Strict-Transport-Security max-age >= 1 year',
+    ).toBeGreaterThanOrEqual(31_536_000);
+    expect(
+      /(?:^|;|\s)\s*includeSubDomains\b/i.test(hsts ?? ''),
+      'Strict-Transport-Security has includeSubDomains',
+    ).toBe(true);
+
+    const permissionsPolicy = headers['permissions-policy'];
+    expect(permissionsPolicy, 'Permissions-Policy present').toBeTruthy();
+    expect(permissionsPolicy, 'Permissions-Policy declares clipboard-read').toMatch(
+      /\bclipboard-read\s*=/,
+    );
+    expect(permissionsPolicy, 'Permissions-Policy declares clipboard-write').toMatch(
+      /\bclipboard-write\s*=/,
+    );
+
+    expect(headers['content-security-policy'], 'Content-Security-Policy present').toBeTruthy();
+  });
+});

--- a/scripts/check-swa-config.mjs
+++ b/scripts/check-swa-config.mjs
@@ -201,6 +201,17 @@ export function routeMatchesPath(routePattern, path) {
 // Assertion blocks (pure, each returns string[] of errors)
 // ---------------------------------------------------------------------------
 
+// NOTE: When adding, removing, or renaming a header in
+// `staticwebapp.config.json` `globalHeaders`, three places must be kept in
+// sync (per Phase 2 cleanup #220):
+//   1. `staticwebapp.config.json` `globalHeaders` (the source of truth).
+//   2. `checkGlobalHeaders()` below (this source-level lint).
+//   3. `e2e/preview/security-headers.spec.ts` (deployed-response check
+//      against an Azure SWA preview host; runs only when
+//      `PLAYWRIGHT_BASE_URL` is set).
+// The source lint asserts the config file declares the header; the
+// deployed-response spec proves no platform/edge layer strips or
+// rewrites it between SWA and the browser. Both gates are needed.
 export function checkGlobalHeaders(config) {
   const errors = [];
   const headers = config?.globalHeaders ?? {};


### PR DESCRIPTION
# PR β: deployed-headers smoke spec for `cd-preview` env

Adds a deploy-behavior Playwright spec to close the source-vs-deployed gap on SWA `globalHeaders`. This is **PR β** of the two-PR Phase 2 cleanup tracked in #220.

## What this adds

- **`e2e/preview/security-headers.spec.ts`** — asserts the 7 SWA `globalHeaders` from `staticwebapp.config.json` reach the browser on a request to `/` (X-Content-Type-Options, X-Frame-Options, X-XSS-Protection, Strict-Transport-Security, Referrer-Policy, Permissions-Policy, Content-Security-Policy).
- **`e2e/preview/README.md`** — folder purpose statement (deploy-behavior vs `e2e/anonymous/` app-behavior); skip-on-local-serve pattern; CI integration.
- **`scripts/check-swa-config.mjs`** — NOTE comment near `checkGlobalHeaders()` documenting the three-place sync rule (source config + source lint + this spec). Per architect Round 2 finding A3 (eliminates the forward-reference window).
- **`e2e/README.md`** —
  - Replaces the stale "SWA-applied response headers... needs a separate post-deploy smoke layer" bullet with a pointer to the new spec.
  - Adds a Folders section distinguishing `e2e/anonymous/` (app-behavior, runs against local or deployed) from `e2e/preview/` (deploy-behavior, deployed-only, skips at module load when `PLAYWRIGHT_BASE_URL` is unset).

## Why this exists

`scripts/check-swa-config.mjs` (the `lint:swa-config` gate) asserts the source config declares each required header with the right value. That gate cannot prove the SWA deploy pipeline, Azure Front Door, or any CDN edge is not stripping or rewriting headers on the way to the browser. This spec closes that end-to-end gap by inspecting a real HTTP response from a deployed preview environment.

## How it routes

`playwright.config.ts` already uses `testDir: './e2e'`, so the new `e2e/preview/` folder is auto-discovered with no config change.

- **CI `e2e` job** (`ci.yml`, every push/PR): `PLAYWRIGHT_BASE_URL` unset → spec skips at module load via `test.skip(!baseUrl, ...)`. Job stays green without changes.
- **`cd-preview.yml` `e2e-preview` job** (this PR's own preview deploy): `PLAYWRIGHT_BASE_URL=<preview-url>` set → spec runs against the deployed preview environment. **This PR is the first to exercise the spec.**

## What's NOT in this PR (deliberately)

- The X-XSS-Protection lint gap in `scripts/check-swa-config.mjs` is **left for PR α**, alongside the `cd-preview` flip-to-required and the silent-fallback fail-fast for #221. Folding those into PR α (per D2 decision) keeps the spec-only change cleanly reviewable here.
- No edit to `e2e/README.md`'s axe-a11y "Coverage in the current smoke set" section. The axe scan is a11y-only; mentioning a header spec there would be a category error (per AD-W1 from the advocate Round 2 critique).

## Verification

- `npm run lint:all` — green (tsc, ASCII, spec-patterns, prod-patterns, CSP, SWA, lockfile, prettier, reduced-motion, api/ lint).
- `npm run test:scripts` — 163 / 163 passing (no scripts logic changed; only a comment).
- `npx playwright test --list` — new spec discovered as `preview\security-headers.spec.ts:40:7`.
- `cd-preview` will exercise the spec end-to-end against this PR's own preview env; manually verify the run log shows non-empty `previewBaseUrl =` URL and the new test as `(passed)` rather than `(skipped)`.

## Next steps (after merge)

Per the [#220 close criteria](https://github.com/geevensingh/jotjson/issues/220):

1. Wait for 3 consecutive green `cd-preview` runs across at least 2 different PRs. Manually verify each run log shows a non-empty `previewBaseUrl =` URL (bridges silent-fallback risk until PR α's assertion lands).
2. Open **PR α**: lint X-XSS-Protection + flip `cd-preview` to required + add `preview_url`-non-empty fail-fast (closes #221) + drop stale shadow-mode comments + DESIGN_SPEC / infra / AGENTS spec updates.
3. Repo owner adds `Smoke e2e against preview` to branch-protection required checks.
4. Post-flip verification no-op PR confirms the check appears as REQUIRED on the merge button.
5. Close #220.

## SemVer

No bump. Test-only addition + doc clarifications; no user-visible behavior change.

## Definition of Done

- [x] `npm run lint:all` passes.
- [x] `npm run test:scripts` passes (163 / 163).
- [x] `npx playwright test --list` discovers the new spec.
- [x] ASCII check passes (em dashes intentionally avoided per repo norm).
- [x] No new `tsc` errors.
- [x] DESIGN_SPEC.md not affected (PR α handles the spec table update once the row actually flips out of shadow mode).
- [x] `why-jotjson.md` not affected (no user-visible feature).
- [x] No new telemetry events.
- [x] Plan-and-approval audit trail: Path C plan rubber-ducked twice (Round 1 + Round 2, all 3 personas each round). User decisions D1/D2/D4 recorded in session plan. This PR implements PR β per that plan.

Closes-with: none yet (PR β alone). #220 stays open through PR α and the post-flip verification.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
