### PR TITLE
MSAL silent refresh: post auth code from iframe via redirect-bridge (part 2/2)

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2300,7 +2300,7 @@ Out of scope (for v1):
   silent-refresh iframe never bootstraps the full SPA - it just posts
   the auth code over `BroadcastChannel(libraryState.id)` and lets the
   parent's `waitForBridgeResponse` listener resolve. The
-  `auth.msalBridge.failed` telemetry message id (severity warn) is
+  `auth.msalBridge.failed` telemetry message id (severity error) is
   registered and `LoggerService.flushSessionStorage` replays the
   `jotjson.msalBridgeErr` slot as a `trackException` envelope on the
   parent's next bootstrap, mirroring the existing `boot.failed` /

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2284,6 +2284,45 @@ Out of scope (for v1):
   aria-valuenow + arrow-key resize (issue #125) are post-V1; the
   toolbar pane-toggle provides the practical keyboard alternative
   for switching between panes.
+- **0.20.2**: MSAL silent token refresh fix, part 2 of 2 (0.20.1 was
+  part 1). Adds the iframe-side bridge call required for the silent-
+  refresh flow to actually complete after the CSP layer was unblocked
+  in 0.20.1. New helper `src/app/core/auth/msal-iframe-bridge.ts`
+  exports `isInMsalSilentIframe(win?)` (predicate: `win.self !==
+  win.top` AND URL hash/query carries an MSAL-shaped
+  `state=<base64url-20+>` plus `code=` or `error=`) and
+  `postAuthResponseToParent(loader?)` (dynamic-imports
+  `@azure/msal-browser/redirect-bridge` and awaits
+  `broadcastResponseToMainFrame()`, persisting `{name, message}` to
+  `sessionStorage['jotjson.msalBridgeErr']` on failure). `src/main.ts`
+  wraps `bootstrapApplication(...)` in an `if (isInMsalSilentIframe())
+  { void postAuthResponseToParent(); } else { bootstrap... }` so the
+  silent-refresh iframe never bootstraps the full SPA - it just posts
+  the auth code over `BroadcastChannel(libraryState.id)` and lets the
+  parent's `waitForBridgeResponse` listener resolve. The
+  `auth.msalBridge.failed` telemetry message id (severity warn) is
+  registered and `LoggerService.flushSessionStorage` replays the
+  `jotjson.msalBridgeErr` slot as a `trackException` envelope on the
+  parent's next bootstrap, mirroring the existing `boot.failed` /
+  `jotjson.bootErr` pattern. The bridge is a dynamic import so it
+  stays out of the entry chunk on top-level page loads (the iframe
+  pays the chunk fetch but never bootstraps Angular). **Caveat**: the
+  early-return skips `bootstrapApplication` and the provider tree,
+  but it does NOT skip parse of `AppComponent`, `appConfig`, and
+  their transitive imports - those static imports at the top of
+  `main.ts` evaluate on every load including in the iframe. If
+  measured impact warrants it, a pre-bootstrap inline script in
+  `index.html` could push detection earlier; deferred until measured.
+  **Why a compensating helper instead of the MS-recommended
+  `/blank.html` redirect URI?** Migrating `redirectUri` requires an
+  Entra app registration change (operational coordination), a SWA
+  config update, and a lockstep deploy plan - more risk surface than
+  this firefight allows. The migration is tracked at issue #230 as
+  `priority:medium`; when it ships, both the helper file and the
+  `main.ts` LEGACY branch are deleted, and `auth.msalBridge.failed`
+  is removed. Backend, infrastructure, and the existing
+  CSP/redirect-uri config are untouched.
+
 - **0.20.1**: MSAL silent token refresh fix (continuation of 0.14.7
   precedent) - add `'self'` to the enforced CSP `frame-src` directive
   in `staticwebapp.config.json`. The CSP value was byte-identical
@@ -2326,10 +2365,9 @@ Out of scope (for v1):
   change; no SPA or backend code touched. Affected users may need to
   sign out and sign back in once to clear the broken cached MSAL state
   from before the fix shipped. **Known follow-up**: this fix unblocks
-  the silent-refresh iframe at the CSP layer; a separate change is
-  needed in `main.ts` to actually post the auth code back to the
-  parent via `@azure/msal-browser/redirect-bridge` (tracked
-  separately).
+  the silent-refresh iframe at the CSP layer; the matching change to
+  actually post the auth code back to the parent via
+  `@azure/msal-browser/redirect-bridge` ships in 0.20.2 (above).
 - **0.20.0**: Decoded value viewer dialog (issue #95 Phase 0). The
   per-row "Show as decoded text" toggle on string leaves is replaced
   with a dedicated `MatDialog` viewer reached from the same row

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.20.1",
+      "version": "0.20.2",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/core/auth/msal-iframe-bridge.spec.ts
+++ b/src/app/core/auth/msal-iframe-bridge.spec.ts
@@ -1,0 +1,142 @@
+import { isInMsalSilentIframe, postAuthResponseToParent } from './msal-iframe-bridge';
+
+const BRIDGE_FAIL_KEY = 'jotjson.msalBridgeErr';
+const VALID_STATE = 'AQIDBAUGBwgJCgsMDQ4PEBESExQ'; // 27-char base64url string
+
+interface FakeLocation {
+  hash: string;
+  search: string;
+}
+
+function makeWinStub(opts: {
+  isTop?: boolean;
+  hash?: string;
+  search?: string;
+  topThrows?: boolean;
+}): Window {
+  const stub: { self: unknown; location: FakeLocation } & { top?: unknown } = {
+    self: null as unknown,
+    location: { hash: opts.hash ?? '', search: opts.search ?? '' },
+  };
+  stub.self = stub;
+  if (opts.topThrows) {
+    Object.defineProperty(stub, 'top', {
+      get: () => {
+        throw new Error('SecurityError: cross-origin access denied');
+      },
+    });
+  } else {
+    stub.top = opts.isTop ? stub : { __sentinel: 'differentWindow' };
+  }
+  return stub as unknown as Window;
+}
+
+describe('isInMsalSilentIframe', () => {
+  it('returns false when win.self === win.top (top-level browsing context)', () => {
+    const win = makeWinStub({ isTop: true, hash: `#code=abc&state=${VALID_STATE}` });
+    expect(isInMsalSilentIframe(win)).toBe(false);
+  });
+
+  it('returns false in iframe context without auth markers in URL', () => {
+    const win = makeWinStub({ isTop: false, hash: '#some/route', search: '?foo=bar' });
+    expect(isInMsalSilentIframe(win)).toBe(false);
+  });
+
+  it('returns true in iframe with #code=...&state=<base64url> (hash mode)', () => {
+    const win = makeWinStub({ isTop: false, hash: `#code=abc.def&state=${VALID_STATE}` });
+    expect(isInMsalSilentIframe(win)).toBe(true);
+  });
+
+  it('returns true in iframe with #error=...&state=<base64url>', () => {
+    const win = makeWinStub({
+      isTop: false,
+      hash: `#error=interaction_required&state=${VALID_STATE}`,
+    });
+    expect(isInMsalSilentIframe(win)).toBe(true);
+  });
+
+  it('returns true in iframe with ?code=...&state=<base64url> (query mode)', () => {
+    const win = makeWinStub({ isTop: false, search: `?code=abc&state=${VALID_STATE}` });
+    expect(isInMsalSilentIframe(win)).toBe(true);
+  });
+
+  it('returns false when state= is present but code/error is absent', () => {
+    const win = makeWinStub({ isTop: false, hash: `#state=${VALID_STATE}&other=1` });
+    expect(isInMsalSilentIframe(win)).toBe(false);
+  });
+
+  it('returns false when code= is present but state= is absent', () => {
+    const win = makeWinStub({ isTop: false, hash: '#code=abc.def' });
+    expect(isInMsalSilentIframe(win)).toBe(false);
+  });
+
+  it('returns false when state= value is too short to be a libraryState', () => {
+    // Regression guard: tracker strings like "?state=ok" must not trigger.
+    const win = makeWinStub({ isTop: false, search: '?code=abc&state=ok' });
+    expect(isInMsalSilentIframe(win)).toBe(false);
+  });
+
+  it('returns false when win.top access throws SecurityError', () => {
+    const win = makeWinStub({ topThrows: true, hash: `#code=abc&state=${VALID_STATE}` });
+    expect(isInMsalSilentIframe(win)).toBe(false);
+  });
+});
+
+describe('postAuthResponseToParent', () => {
+  beforeEach(() => {
+    sessionStorage.removeItem(BRIDGE_FAIL_KEY);
+  });
+
+  afterEach(() => {
+    sessionStorage.removeItem(BRIDGE_FAIL_KEY);
+  });
+
+  it('calls broadcastResponseToMainFrame exactly once when loader resolves', async () => {
+    const broadcastSpy = jasmine.createSpy('broadcast').and.resolveTo(undefined);
+    const loader = jasmine
+      .createSpy('loader')
+      .and.resolveTo({ broadcastResponseToMainFrame: broadcastSpy });
+
+    await postAuthResponseToParent(loader);
+
+    expect(loader).toHaveBeenCalledTimes(1);
+    expect(broadcastSpy).toHaveBeenCalledTimes(1);
+    expect(sessionStorage.getItem(BRIDGE_FAIL_KEY)).toBeNull();
+  });
+
+  it('resolves without throwing when broadcast rejects with parse error', async () => {
+    // Regression guard for the unhandled-rejection bug: if the bridge
+    // call were not awaited, this test would pass with the rejection
+    // bubbling out asynchronously after the function returned.
+    const broadcastSpy = jasmine
+      .createSpy('broadcast')
+      .and.rejectWith(new Error('No payload found in URL'));
+    const loader = () => Promise.resolve({ broadcastResponseToMainFrame: broadcastSpy });
+
+    await expectAsync(postAuthResponseToParent(loader)).toBeResolved();
+    expect(broadcastSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('persists sanitized error to sessionStorage on rejection', async () => {
+    const cause = new Error('No payload found in URL');
+    cause.name = 'AuthError';
+    const broadcastSpy = jasmine.createSpy('broadcast').and.rejectWith(cause);
+    const loader = () => Promise.resolve({ broadcastResponseToMainFrame: broadcastSpy });
+
+    await postAuthResponseToParent(loader);
+
+    const raw = sessionStorage.getItem(BRIDGE_FAIL_KEY);
+    expect(raw).not.toBeNull();
+    const parsed = JSON.parse(raw ?? '{}') as { name?: string; message?: string };
+    expect(parsed.name).toBe('AuthError');
+    expect(parsed.message).toBe('No payload found in URL');
+  });
+
+  it('swallows sessionStorage failures', async () => {
+    const broadcastSpy = jasmine.createSpy('broadcast').and.rejectWith(new Error('boom'));
+    const loader = () => Promise.resolve({ broadcastResponseToMainFrame: broadcastSpy });
+    spyOn(sessionStorage, 'setItem').and.throwError('QuotaExceededError');
+
+    await expectAsync(postAuthResponseToParent(loader)).toBeResolved();
+  });
+});

--- a/src/app/core/auth/msal-iframe-bridge.spec.ts
+++ b/src/app/core/auth/msal-iframe-bridge.spec.ts
@@ -80,6 +80,14 @@ describe('isInMsalSilentIframe', () => {
     const win = makeWinStub({ topThrows: true, hash: `#code=abc&state=${VALID_STATE}` });
     expect(isInMsalSilentIframe(win)).toBe(false);
   });
+
+  it('returns false when called with no arguments at top-level (default-resolution path)', () => {
+    // Regression guard for the default-parameter fix: ensures the
+    // signature default expression evaluates without throwing even
+    // when no arg is passed. In Karma's top-level browsing context,
+    // `window.self === window.top`, so the result is false.
+    expect(isInMsalSilentIframe()).toBe(false);
+  });
 });
 
 describe('postAuthResponseToParent', () => {

--- a/src/app/core/auth/msal-iframe-bridge.ts
+++ b/src/app/core/auth/msal-iframe-bridge.ts
@@ -1,0 +1,90 @@
+// LEGACY: compensating code for `redirectUri = origin root`. When the
+// /blank.html migration (issue #230) ships, iframes will load
+// /blank.html instead of main.ts and this helper becomes dead code -
+// delete the file at that time.
+//
+// BROWSER ONLY. Never import from app.config.server.ts or any
+// prerendered path (would throw at parse time on the server platform).
+//
+// Caveat (skeptic Medium #4): the early-return in main.ts skips
+// bootstrapApplication and the entire provider tree instantiation
+// (router, AppUpdateService, MSAL provider factory, APP_INITIALIZER,
+// SW registration). It does NOT skip parse of `AppComponent`,
+// `appConfig`, and their transitive imports - those static imports at
+// the top of main.ts evaluate on every load. If measured impact
+// warrants it later, a pre-bootstrap inline script in index.html
+// could push detection even earlier; deferred until measured.
+
+import type { broadcastResponseToMainFrame } from '@azure/msal-browser/redirect-bridge';
+
+type BridgeModule = { broadcastResponseToMainFrame: typeof broadcastResponseToMainFrame };
+
+const BRIDGE_FAIL_KEY = 'jotjson.msalBridgeErr';
+
+// state= is base64url and always 20+ chars (libraryState JSON encoded
+// by MSAL's ProtocolUtils). Tighter than `\bstate=` alone - reduces
+// false-positive surface for hypothetical same-origin embeds with
+// short tracker strings like "state=ok".
+const RESPONSE_MARKERS = /[?&#]state=[A-Za-z0-9_-]{20,}/;
+const CODE_OR_ERROR = /[?&#](?:code|error)=/;
+
+/**
+ * True when running inside an iframe whose URL carries an MSAL
+ * authentication response (code+state or error+state). Does NOT
+ * detect popup flows - if we ever add `acquireTokenPopup`, the
+ * detection must be extended. Same-origin only by virtue of CSP
+ * `frame-ancestors 'self'`.
+ *
+ * Returns false in non-browser contexts (SSR safety) and when the
+ * cross-origin check on `window.top` throws (defense in depth -
+ * CSP frame-ancestors 'self' makes this impossible today but we
+ * fail-closed regardless).
+ *
+ * @param win - test seam; defaults to the global `window`.
+ */
+export function isInMsalSilentIframe(win: Window = window): boolean {
+  try {
+    if (typeof win === 'undefined') return false;
+    if (win.self === win.top) return false;
+  } catch {
+    return false;
+  }
+  const hash = win.location.hash;
+  const search = win.location.search;
+  const looksLikeMsalResponse = (urlPart: string): boolean =>
+    RESPONSE_MARKERS.test(urlPart) && CODE_OR_ERROR.test(urlPart);
+  return looksLikeMsalResponse(hash) || looksLikeMsalResponse(search);
+}
+
+/**
+ * Dynamic-imports `@azure/msal-browser/redirect-bridge` and posts the
+ * auth response to the parent over BroadcastChannel. On any failure,
+ * persists a sanitized record to sessionStorage so `LoggerService` can
+ * replay it as a `auth.msalBridge.failed` warning on the parent's next
+ * bootstrap. The parent will see `redirect_bridge_timeout` from
+ * `acquireTokenSilent` regardless; this replay is the diagnostic
+ * channel telling us *why* the iframe-side bridge failed.
+ *
+ * @param loader - test seam; defaults to a real dynamic import of the
+ *   MSAL `redirect-bridge` subpath export.
+ */
+export async function postAuthResponseToParent(
+  loader: () => Promise<BridgeModule> = () => import('@azure/msal-browser/redirect-bridge'),
+): Promise<void> {
+  try {
+    const mod = await loader();
+    await mod.broadcastResponseToMainFrame();
+  } catch (error: unknown) {
+    try {
+      const name = error instanceof Error ? error.name || 'Error' : 'BridgeError';
+      const message =
+        error instanceof Error
+          ? (error.message ?? '').slice(0, 500)
+          : '<non-error thrown in bridge>';
+      sessionStorage.setItem(BRIDGE_FAIL_KEY, JSON.stringify({ name, message }));
+    } catch {
+      // sessionStorage may be unavailable (privacy mode); nothing
+      // more we can do from outside Angular.
+    }
+  }
+}

--- a/src/app/core/auth/msal-iframe-bridge.ts
+++ b/src/app/core/auth/msal-iframe-bridge.ts
@@ -35,22 +35,25 @@ const CODE_OR_ERROR = /[?&#](?:code|error)=/;
  * detection must be extended. Same-origin only by virtue of CSP
  * `frame-ancestors 'self'`.
  *
- * Returns false in non-browser contexts (SSR safety) and when the
- * cross-origin check on `window.top` throws (defense in depth -
- * CSP frame-ancestors 'self' makes this impossible today but we
- * fail-closed regardless).
+ * Returns false in non-browser contexts (no global `window`) and
+ * when the cross-origin check on `window.top` throws (defense in
+ * depth - CSP frame-ancestors 'self' makes this impossible today
+ * but we fail-closed regardless).
  *
- * @param win - test seam; defaults to the global `window`.
+ * @param win - test seam; when omitted, resolves to the global
+ *   `window` if defined, else `undefined` (which causes the function
+ *   to return false without attempting any property access).
  */
-export function isInMsalSilentIframe(win: Window = window): boolean {
+export function isInMsalSilentIframe(win?: Window): boolean {
+  const w = win ?? (typeof window !== 'undefined' ? window : undefined);
+  if (!w) return false;
   try {
-    if (typeof win === 'undefined') return false;
-    if (win.self === win.top) return false;
+    if (w.self === w.top) return false;
   } catch {
     return false;
   }
-  const hash = win.location.hash;
-  const search = win.location.search;
+  const hash = w.location.hash;
+  const search = w.location.search;
   const looksLikeMsalResponse = (urlPart: string): boolean =>
     RESPONSE_MARKERS.test(urlPart) && CODE_OR_ERROR.test(urlPart);
   return looksLikeMsalResponse(hash) || looksLikeMsalResponse(search);

--- a/src/app/core/telemetry/logger.service.spec.ts
+++ b/src/app/core/telemetry/logger.service.spec.ts
@@ -154,6 +154,45 @@ describe('LoggerService', () => {
     expect(bootCall).toBeDefined();
   });
 
+  it('reads and clears sessionStorage msal bridge error on connect', async () => {
+    sessionStorage.setItem(
+      'jotjson.msalBridgeErr',
+      JSON.stringify({ name: 'AuthError', message: 'No payload found in URL' }),
+    );
+    const log = makeWithFakeTelemetry(false);
+    await log.connect();
+    expect(sessionStorage.getItem('jotjson.msalBridgeErr')).toBeNull();
+    const calls = trackException.calls.allArgs();
+    const bridgeCall = calls.find((args) => {
+      const props = args[1] as Record<string, unknown>;
+      return props && props['messageId'] === 'auth.msalBridge.failed';
+    });
+    expect(bridgeCall).toBeDefined();
+    const [normalized] = bridgeCall ?? [];
+    expect((normalized as { name?: string }).name).toBe('AuthError');
+    expect((normalized as { message?: string }).message).toBe('No payload found in URL');
+  });
+
+  it('replays bridge error even when boot error slot is empty', async () => {
+    // Regression guard: an early `return` in flushSessionStorage's
+    // boot-error block must not skip the bridge-error block when no
+    // boot error is queued.
+    sessionStorage.removeItem('jotjson.bootErr');
+    sessionStorage.setItem(
+      'jotjson.msalBridgeErr',
+      JSON.stringify({ name: 'AuthError', message: 'bridge failed' }),
+    );
+    const log = makeWithFakeTelemetry(false);
+    await log.connect();
+    expect(sessionStorage.getItem('jotjson.msalBridgeErr')).toBeNull();
+    const calls = trackException.calls.allArgs();
+    const bridgeCall = calls.find((args) => {
+      const props = args[1] as Record<string, unknown>;
+      return props && props['messageId'] === 'auth.msalBridge.failed';
+    });
+    expect(bridgeCall).toBeDefined();
+  });
+
   it('produces normalized HttpError when given HTTP context', async () => {
     const { HttpErrorResponse } = await import('@angular/common/http');
     const err = new HttpErrorResponse({ url: '/api/x?secret', status: 500 });

--- a/src/app/core/telemetry/logger.service.ts
+++ b/src/app/core/telemetry/logger.service.ts
@@ -11,6 +11,7 @@ import {
 
 const BUFFER_CAP = 100;
 const BOOT_FAIL_KEY = 'jotjson.bootErr';
+const BRIDGE_FAIL_KEY = 'jotjson.msalBridgeErr';
 
 type Severity = 'info' | 'warn' | 'error';
 
@@ -225,19 +226,35 @@ export class LoggerService {
   private flushSessionStorage(): void {
     try {
       const raw = sessionStorage.getItem(BOOT_FAIL_KEY);
-      if (!raw) {
-        return;
+      if (raw) {
+        sessionStorage.removeItem(BOOT_FAIL_KEY);
+        const parsed = JSON.parse(raw) as { name?: string; message?: string };
+        this.telemetry.trackException(
+          {
+            kind: 'error',
+            name: parsed.name ?? 'BootError',
+            message: parsed.message ?? '<no message>',
+          },
+          { messageId: 'boot.failed' },
+        );
       }
-      sessionStorage.removeItem(BOOT_FAIL_KEY);
-      const parsed = JSON.parse(raw) as { name?: string; message?: string };
-      this.telemetry.trackException(
-        {
-          kind: 'error',
-          name: parsed.name ?? 'BootError',
-          message: parsed.message ?? '<no message>',
-        },
-        { messageId: 'boot.failed' },
-      );
+    } catch {
+      // ignore
+    }
+    try {
+      const raw = sessionStorage.getItem(BRIDGE_FAIL_KEY);
+      if (raw) {
+        sessionStorage.removeItem(BRIDGE_FAIL_KEY);
+        const parsed = JSON.parse(raw) as { name?: string; message?: string };
+        this.telemetry.trackException(
+          {
+            kind: 'error',
+            name: parsed.name ?? 'BridgeError',
+            message: parsed.message ?? '<no message>',
+          },
+          { messageId: 'auth.msalBridge.failed' },
+        );
+      }
     } catch {
       // ignore
     }

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -887,6 +887,34 @@ export const TELEMETRY_MESSAGE_IDS = [
   'auth.devMode.misconfigured',
 
   /**
+   * Severity: warn
+   * Fired by: `LoggerService.flushSessionStorage` via direct
+   *           `telemetry.trackException(..., {messageId})` in
+   *           `core/telemetry/logger.service.ts` (does NOT route
+   *           through `logger.warn`). Replays a `{name, message}`
+   *           shape persisted to `sessionStorage` by
+   *           `postAuthResponseToParent` in
+   *           `core/auth/msal-iframe-bridge.ts` when the
+   *           silent-refresh iframe's call to
+   *           `broadcastResponseToMainFrame()` (from the
+   *           `@azure/msal-browser/redirect-bridge` subpath export)
+   *           rejected. The parent surfaces `redirect_bridge_timeout`
+   *           independently; this event is the diagnostic channel
+   *           telling us *why* the iframe-side bridge call failed
+   *           (parse error, missing state, missing id/meta, etc.).
+   * Props: none. (The `messageId` tag is attached to the
+   * `trackException` envelope, not as `props`. The `{name, message}`
+   * shape lands in the exception body.)
+   * Exception: a `{name, message}` shape reconstructed from
+   * `sessionStorage[BRIDGE_FAIL_KEY]`.
+   *
+   * LEGACY: removed when the `/blank.html` redirect URI migration
+   * (issue #230) ships and the compensating code in
+   * `msal-iframe-bridge.ts` is deleted.
+   */
+  'auth.msalBridge.failed',
+
+  /**
    * Kind: event
    * Fired by: `AuthService.setCurrentUser` on every null -> user
    *           transition (`core/auth/auth.service.ts`). Covers BOTH

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -887,11 +887,11 @@ export const TELEMETRY_MESSAGE_IDS = [
   'auth.devMode.misconfigured',
 
   /**
-   * Severity: warn
+   * Severity: error
    * Fired by: `LoggerService.flushSessionStorage` via direct
    *           `telemetry.trackException(..., {messageId})` in
    *           `core/telemetry/logger.service.ts` (does NOT route
-   *           through `logger.warn`). Replays a `{name, message}`
+   *           through `logger.error`). Replays a `{name, message}`
    *           shape persisted to `sessionStorage` by
    *           `postAuthResponseToParent` in
    *           `core/auth/msal-iframe-bridge.ts` when the

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@
 import { bootstrapApplication } from '@angular/platform-browser';
 import { AppComponent } from './app/app.component';
 import { appConfig } from './app/app.config';
+import { isInMsalSilentIframe, postAuthResponseToParent } from './app/core/auth/msal-iframe-bridge';
 // Type-only import: erased at runtime so it does NOT pull
 // LoggerService (and the App Insights SDK) into the entry bundle.
 // LoggerService itself is loaded dynamically below, only when the
@@ -26,66 +27,77 @@ declare global {
   }
 }
 
-bootstrapApplication(AppComponent, appConfig)
-  .then(async (appRef) => {
-    // Perf-harness self-attach (DR-007). Best-effort: production has
-    // no harness shim so this block resolves to a no-op. Wrapped in
-    // try/catch so any failure (injector lookup error, unexpected
-    // harness shape, etc.) cannot block the build-info banner below
-    // or the rest of the .then chain.
-    try {
-      if (typeof window !== 'undefined') {
-        const harness = window.__jotjsonPerfHarness;
-        if (harness && Array.isArray(harness.events)) {
-          // Dynamic import keeps LoggerService (and the App Insights
-          // SDK) out of the entry bundle in production, mirroring the
-          // lazy-load pattern in AppComponent.ngOnInit. The module URL
-          // is the same one AppComponent uses, so the ES module cache
-          // returns the same instance and `providedIn: 'root'` resolves
-          // to the same singleton from `appRef.injector.get(...)`.
-          const { LoggerService } = await import('./app/core/telemetry/logger.service');
-          const logger = appRef.injector.get(LoggerService);
-          logger.__attachPerfHarnessForTesting((event: PerfHarnessEvent) => {
-            harness.events.push(event);
-          });
-          harness.attached = true;
+// LEGACY: compensating code for `redirectUri = origin root`. When the
+// /blank.html redirect URI migration (issue #230) ships, iframes will
+// load /blank.html instead of main.ts and this branch becomes dead
+// code - delete it at that time. Until then, this branch keeps the
+// silent-refresh iframe from bootstrapping the full SPA and instead
+// posts the auth response back to the parent over BroadcastChannel.
+// See msal-iframe-bridge.ts.
+if (isInMsalSilentIframe()) {
+  void postAuthResponseToParent();
+} else {
+  bootstrapApplication(AppComponent, appConfig)
+    .then(async (appRef) => {
+      // Perf-harness self-attach (DR-007). Best-effort: production has
+      // no harness shim so this block resolves to a no-op. Wrapped in
+      // try/catch so any failure (injector lookup error, unexpected
+      // harness shape, etc.) cannot block the build-info banner below
+      // or the rest of the .then chain.
+      try {
+        if (typeof window !== 'undefined') {
+          const harness = window.__jotjsonPerfHarness;
+          if (harness && Array.isArray(harness.events)) {
+            // Dynamic import keeps LoggerService (and the App Insights
+            // SDK) out of the entry bundle in production, mirroring the
+            // lazy-load pattern in AppComponent.ngOnInit. The module URL
+            // is the same one AppComponent uses, so the ES module cache
+            // returns the same instance and `providedIn: 'root'` resolves
+            // to the same singleton from `appRef.injector.get(...)`.
+            const { LoggerService } = await import('./app/core/telemetry/logger.service');
+            const logger = appRef.injector.get(LoggerService);
+            logger.__attachPerfHarnessForTesting((event: PerfHarnessEvent) => {
+              harness.events.push(event);
+            });
+            harness.attached = true;
+          }
         }
+      } catch {
+        // Bootstrap self-attach is best-effort; production has no harness.
       }
-    } catch {
-      // Bootstrap self-attach is best-effort; production has no harness.
-    }
 
-    try {
-      const { BUILD_INFO } = await import('./generated/build-info');
-      const sha = BUILD_INFO.sha;
-      const isDev = sha === 'dev';
-      const shortSha = isDev ? 'dev' : sha.slice(0, 7);
-      const url = isDev || !BUILD_INFO.repoUrl ? '' : ` ${BUILD_INFO.repoUrl}/commit/${sha}`;
+      try {
+        const { BUILD_INFO } = await import('./generated/build-info');
+        const sha = BUILD_INFO.sha;
+        const isDev = sha === 'dev';
+        const shortSha = isDev ? 'dev' : sha.slice(0, 7);
+        const url = isDev || !BUILD_INFO.repoUrl ? '' : ` ${BUILD_INFO.repoUrl}/commit/${sha}`;
+        // eslint-disable-next-line no-console
+        console.info(`JotJSON v${BUILD_INFO.version} (${shortSha})${url}`);
+      } catch {
+        // Banner emission is best-effort; never let a failure leak to the
+        // bootstrap-error path below.
+      }
+    })
+    .catch((error: unknown) => {
+      // Pre-Angular bootstrap failures land here. Persist a sanitized
+      // record to sessionStorage so `LoggerService.connect()` can replay
+      // it as a `boot.failed` exception once telemetry comes online -
+      // assuming Angular itself eventually bootstraps. If it doesn't,
+      // there is nothing else we can do from outside the framework.
+      try {
+        const name = error instanceof Error ? error.name || 'Error' : 'BootError';
+        const message =
+          error instanceof Error
+            ? (error.message ?? '').slice(0, 500)
+            : '<non-error thrown at bootstrap>';
+        sessionStorage.setItem('jotjson.bootErr', JSON.stringify({ name, message }));
+      } catch {
+        // sessionStorage may be unavailable (privacy mode); ignore.
+      }
+      // Always surface to DevTools so dev-time bootstrap failures are
+      // discoverable without telemetry.
       // eslint-disable-next-line no-console
-      console.info(`JotJSON v${BUILD_INFO.version} (${shortSha})${url}`);
-    } catch {
-      // Banner emission is best-effort; never let a failure leak to the
-      // bootstrap-error path below.
-    }
-  })
-  .catch((error: unknown) => {
-    // Pre-Angular bootstrap failures land here. Persist a sanitized
-    // record to sessionStorage so `LoggerService.connect()` can replay
-    // it as a `boot.failed` exception once telemetry comes online -
-    // assuming Angular itself eventually bootstraps. If it doesn't,
-    // there is nothing else we can do from outside the framework.
-    try {
-      const name = error instanceof Error ? error.name || 'Error' : 'BootError';
-      const message =
-        error instanceof Error
-          ? (error.message ?? '').slice(0, 500)
-          : '<non-error thrown at bootstrap>';
-      sessionStorage.setItem('jotjson.bootErr', JSON.stringify({ name, message }));
-    } catch {
-      // sessionStorage may be unavailable (privacy mode); ignore.
-    }
-    // Always surface to DevTools so dev-time bootstrap failures are
-    // discoverable without telemetry.
-    // eslint-disable-next-line no-console
-    console.error(error);
-  });
+      console.error(error);
+    });
+}


### PR DESCRIPTION
## Summary

Part 2 of 2 in the MSAL silent-refresh restoration. Closes the user-visible part of the regression that PR #227 (0.20.1) only addressed at the CSP layer.

PR #227 added `'self'` to `frame-src` so the IdP could 302 the silent-refresh iframe back to our origin. With that block gone, the iframe **does** reach `https://jotjson.com/#code=...&state=...`, but the SPA bootstraps Angular instead of forwarding the auth code to the parent. The parent's `waitForBridgeResponse` listener (`new BroadcastChannel(libraryState.id)`) times out at 10s and throws `BrowserAuthError("redirect_bridge_timeout")`. Symptom is unchanged from pre-0.20.1: formatting-rules toolbar stuck on "Loading...", blobs page 401s, save fails.

This change adds the iframe-side `broadcastResponseToMainFrame()` call so the silent-refresh flow actually completes.

## What changed

- **NEW `src/app/core/auth/msal-iframe-bridge.ts`**: two free functions.
  - `isInMsalSilentIframe(win = window): boolean` - `win.self !== win.top` AND URL hash/query carries `state=<base64url-20+>` plus `code=` or `error=`. Returns false in non-browser contexts; defensive try/catch around `window.top` access for cross-origin safety.
  - `postAuthResponseToParent(loader = () => import('@azure/msal-browser/redirect-bridge')): Promise<void>` - dynamic-imports the MSAL bridge subpath export and **awaits** `broadcastResponseToMainFrame()` (the call is async and throws on parse error). On any failure, persists `{name, message}` to `sessionStorage['jotjson.msalBridgeErr']` so the parent's next bootstrap can replay it as a telemetry event.

- **`src/main.ts`**: wraps `bootstrapApplication(...)` in `if (isInMsalSilentIframe()) { void postAuthResponseToParent(); } else { bootstrap... }`. The iframe takes the early branch and never bootstraps Angular - just posts the auth code over `BroadcastChannel` and lets the parent's listener resolve.

- **NEW telemetry id `auth.msalBridge.failed`** registered in `telemetry-message-ids.ts`. `LoggerService.flushSessionStorage` now reads the `jotjson.msalBridgeErr` slot and emits a `trackException` envelope on the parent's next connect, mirroring the existing `boot.failed` / `jotjson.bootErr` pattern. This is the only diagnostic channel for *why* the iframe-side bridge failed (parse error vs. missing state vs. missing id/meta); the parent independently surfaces `redirect_bridge_timeout` regardless of cause.

- **15 new tests**: 13 in `msal-iframe-bridge.spec.ts` (9 predicate + 4 action), 2 in `logger.service.spec.ts` (positive replay + regression guard for an early-return bug discovered during implementation that would have skipped the bridge replay when the boot slot was empty).

## Why a compensating helper instead of `/blank.html`?

Microsoft's recommended pattern is a dedicated static `/blank.html` redirect target whose only job is to call `broadcastResponseToMainFrame()`. That migration requires an Entra app registration redirect-URI update, a SWA config change, and a lockstep deploy plan - more risk surface than this firefight allows. The migration is tracked at issue #230 (`priority:medium`, `tech-debt`); when it ships, both this helper file and the `main.ts` LEGACY branch are deleted, and the `auth.msalBridge.failed` telemetry id is removed.

## Caveat (transparent framing)

The iframe early-return skips `bootstrapApplication` and the entire provider tree (router, MSAL provider factory, `APP_INITIALIZER`, SW registration). It does **not** skip parse of `AppComponent`, `appConfig`, and their transitive imports - those static imports at the top of `main.ts` evaluate on every load including in the iframe. If measured impact warrants it later, a pre-bootstrap inline script in `index.html` could push detection earlier; deferred until measured.

## Verification

**Local DoD:**
- `npm run lint:all` PASS (root + api workspace + reduced-motion)
- `npm test` 2505 pass + 1 skip (was 2490 pre-change)
- `npm run build` PASS; `redirect-bridge` emits as its own ~1.5 KB lazy chunk; main entry chunk references the dynamic import but does not contain the bridge module

**Post-deploy verification** (nonprod first, then prod):
1. Sign in
2. Wait ~1 hour for the cached access token to expire
3. Observe an automatic silent refresh via DevTools Network (iframe sourced from `login.ciamlogin.com`, then `?prompt=none`)
4. No `redirect_bridge_timeout` in DevTools Console
5. Subsequent `/api/me` carries `X-Jotjson-Authorization` and returns 200
6. Saved blobs continue to load and save successfully

## Follow-ups (will file as separate issues after merge)

1. **#230 - `/blank.html` redirect URI migration** (already filed, `priority:medium`): obsoletes this compensating code.
2. **E2E silent-refresh test**: Playwright spec that primes MSAL localStorage with an expiring token, intercepts `/authorize?prompt=none` with a stub IdP, asserts `BroadcastChannel('msal.<id>')` receives the message and the next `/api/me` is sent with a bearer.
3. **Reactive auth-expiry recovery (Option A)**: surface "session expired" snackbar when silent refresh fails for real (refresh token expired after 24h+, 3p cookies blocked, etc.) instead of silent 401s. After Part 1 + Part 2 ship, this is the next robustness layer.

## SemVer

Patch (0.20.2). Compensating-code addition to entry point; no SPA behavior change beyond restoring intended silent-refresh. Mirrors 0.14.7 / 0.20.1 patches.

---
**Session**
- AI-Local: `febc3450-fef0-4d8d-ae4f-6ac1c71617b8`
- AI-Cloud: `71ddbbbc-2bce-4b5d-9003-a37dd9424a3e`
