### PR TITLE
Add product-analytics workbook; extract generic workbook.bicep module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ Thumbs.db
 
 # Bicep build output (from `az bicep build`)
 /infra/**/*.json
+# Exception: workbook content templates are source files, not build output.
+# These are loaded by `infra/modules/workbook.bicep` via `loadTextContent()`.
+!/infra/workbooks/*.json
 
 # Scratch directory for scripts/generate-icons.mjs (ephemeral sharp install).
 /.iconbuild

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -3058,7 +3058,16 @@ Out of scope (for v1):
        real HTTP 404 status (`followup-true-404`). See SEO / Social
        section above for the full implementation.
    - ~~**M7i**: Monitoring (App Insights dashboards & alerts).~~ (done)
-     - App Insights workbook (5 sections) + 4 alerts + 1 action group shipped. Bicep modules: `infra/modules/{actionGroup,alerts,monitoringWorkbook}.bicep` + `infra/main.bicep` wiring + `infra/modules/appInsights.bicep` outputs. Docs: see `docs/telemetry.md` -> "Dashboards & alerts (M7i)". Post-V1 follow-ups: issues #87-#94.
+     - Two App Insights workbooks (`JotJSON operator monitoring`,
+       `JotJSON product analytics`) via shared `infra/modules/workbook.bicep`
+       module + 4 alerts + 1 action group shipped. Content lives in
+       `infra/workbooks/{monitoring,product-analytics}.json`. Bicep modules:
+       `infra/modules/{actionGroup,alerts,workbook}.bicep` + `infra/main.bicep`
+       wiring + `infra/modules/appInsights.bicep` outputs. Docs: see
+       `docs/telemetry.md` -> "Dashboards & alerts". Post-V1 follow-ups:
+       issues #87-#94, #240 (workbook CI gate), #241 (instrumentation
+       migration: `logger.info()` -> `logger.event()` for ~25 tree.*
+       events), #242 (third `JotJSON telemetry hygiene` workbook).
    - ~~**M7j**: Static Web Apps upgrade to Standard tier - flipped during M7e (commit 1ba34e1) because apex custom-domain binding requires Standard. See M7o for the BYO Functions follow-up.~~ (done)
    - ~~**M7k**: Surface JSONC comments in the tree view - the parser harvests every `//` and `/* */` comment in a second pass and attaches it to the nearest tree node; comments render as dimmed inline annotations on the same row as the value they document (trailing slot when on the same source line as the value, leading slot when introducing the next value). Single-line + ellipsis with full text via tooltip; toggleable via `treeShowComments` (default true). Comments do not participate in formatting-rules matching or tree search. Decoration-vs-data font philosophy codified alongside (commits `7d937c5` M7k-0 mockup-rule docs, `82f9073` M7k-1 parser harvest, `4f7d604` M7k-2 tree rendering, `66f695d` font philosophy, `fa02122` placement fix-up, plus this commit for M7k-3 preference + spec).~~ (done)
    - ~~**M7l**: Responsive layout - on viewports narrower than 768px, collapse the editor/tree split to a single visible pane: when persisted `paneVisibility` is `both`, render the tree pane by default (view-first at narrow widths); when persisted is `editor-only` or `tree-only`, honor the single-pane choice. The toolbar's segmented control collapses to a 2-state toggle (`editor-only` | `tree-only`); the persisted `paneVisibility` is never mutated by the override. Also collapse the status bar (M7m) to a single-line summary - keep Bytes, Lines, and Mode; hide Chars, cursor, nodes, depth, object/array counts, and the build/version badge.~~ (done)

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -1019,12 +1019,12 @@ rule alerts wired to a single action group:
   health, perf regressions, auth/access failures, API issues, or quota
   pressure. No workbook-level time picker; each tile is tuned to an
   operator-relevant window (1h-7d).
-- **`JotJSON product analytics`** -- six sections (Leading conversion +
-  top 20; Context menu; Subtree submenu; Tree row interactions;
-  Breadcrumb; Highlight; Decoded viewer & Extract). Audience: PM /
-  founder asking "which features are getting used, and at what rate?".
-  Workbook-level `TimeRange` picker (default 30d, options 24h / 7d /
-  30d / 90d).
+- **`JotJSON product analytics`** -- seven sections (Leading
+  conversion + top 20; Context menu; Subtree submenu; Tree row
+  interactions; Breadcrumb; Highlight; Decoded viewer & Extract).
+  Audience: PM / founder asking "which features are getting used, and
+  at what rate?". Workbook-level `TimeRange` picker (default 30d,
+  options 24h / 7d / 30d / 90d).
 
 Both workbooks deploy via the generic `infra/modules/workbook.bicep`
 module with content in `infra/workbooks/{monitoring,product-analytics}.json`.

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -992,9 +992,12 @@ directory at sign-in.
 - [App Insights component `appi-jotjson-dev` (overview)](https://portal.azure.com/#@68fa6d3c-ab3e-4eea-97bb-f0376ea54cba/resource/subscriptions/db5e75e4-b980-486d-a11e-fe9327a52031/resourceGroups/rg-jotjson-dev/providers/microsoft.insights/components/appi-jotjson-dev/overview)
   -- entry point for Live Metrics, Failures, Performance, App Map, Logs.
 - [App Insights -> Workbooks gallery](https://portal.azure.com/#@68fa6d3c-ab3e-4eea-97bb-f0376ea54cba/resource/subscriptions/db5e75e4-b980-486d-a11e-fe9327a52031/resourceGroups/rg-jotjson-dev/providers/microsoft.insights/components/appi-jotjson-dev/workbooks)
-  -- open the workbook named **`JotJSON monitoring (dev)`**. (If the gallery
-  subpath ever changes, fall back to the App Insights overview link above
-  and click **Workbooks** in the left nav.)
+  -- open the workbook named **`JotJSON operator monitoring`** for app
+  health / perf / auth / API / quotas, or **`JotJSON product analytics`**
+  for feature usage (right-click menu, double-click, keyboard, breadcrumb,
+  highlight, decoded viewer, extract). The same gallery hosts both. If
+  the gallery subpath ever changes, fall back to the App Insights
+  overview link above and click **Workbooks** in the left nav.
 - [Log Analytics workspace `appi-jotjson-dev-law` (overview)](https://portal.azure.com/#@68fa6d3c-ab3e-4eea-97bb-f0376ea54cba/resource/subscriptions/db5e75e4-b980-486d-a11e-fe9327a52031/resourceGroups/rg-jotjson-dev/providers/microsoft.operationalinsights/workspaces/appi-jotjson-dev-law/overview)
 - [Log Analytics -> Alerts](https://portal.azure.com/#@68fa6d3c-ab3e-4eea-97bb-f0376ea54cba/resource/subscriptions/db5e75e4-b980-486d-a11e-fe9327a52031/resourceGroups/rg-jotjson-dev/providers/microsoft.operationalinsights/workspaces/appi-jotjson-dev-law/alerts)
   -- alerts blade scoped to the workspace. (Fallback: open the LAW overview
@@ -1006,10 +1009,25 @@ If you hit a `wrong issuer` token error after sign-in, see
 
 ### Overview
 
-An operator-facing monitoring layer sits on top of the instrumentation
-documented earlier in this file: a workbook with five sections (Health,
-Performance, Auth & Access, API, Quotas) and four scheduled-query-rule alerts
-wired to a single action group.
+An operator-facing monitoring layer and a PM-facing product-analytics
+layer both sit on top of the instrumentation documented earlier in this
+file. They ship as two App Insights workbooks plus four scheduled-query-
+rule alerts wired to a single action group:
+
+- **`JotJSON operator monitoring`** -- five sections (Health, Performance,
+  Auth & Access, API, Quotas). Audience: anyone investigating service
+  health, perf regressions, auth/access failures, API issues, or quota
+  pressure. No workbook-level time picker; each tile is tuned to an
+  operator-relevant window (1h-7d).
+- **`JotJSON product analytics`** -- six sections (Leading conversion +
+  top 20; Context menu; Subtree submenu; Tree row interactions;
+  Breadcrumb; Highlight; Decoded viewer & Extract). Audience: PM /
+  founder asking "which features are getting used, and at what rate?".
+  Workbook-level `TimeRange` picker (default 30d, options 24h / 7d /
+  30d / 90d).
+
+Both workbooks deploy via the generic `infra/modules/workbook.bicep`
+module with content in `infra/workbooks/{monitoring,product-analytics}.json`.
 
 The action group is wired to `jotjsonadmin@gmail.com` in
 `infra/parameters/dev.bicepparam`. Override at deploy time by
@@ -1042,6 +1060,8 @@ silently breaks evaluation; queries return 0 rows or fail.
 
 ### Workbook sections
 
+#### Operator monitoring sections
+
 - **Health** -- overall request volume / failure rate, top exception types,
   `app.boot` version distribution from `customDimensions.appVersion` on the
   `app.boot` event.
@@ -1052,6 +1072,80 @@ silently breaks evaluation; queries return 0 rows or fail.
 - **API** -- Functions request rate, 4xx/5xx breakdown, p95 duration by
   operation.
 - **Quotas** -- `quota.exceeded` event volume, top quota types.
+
+#### Product analytics sections
+
+- **0. Leading** -- two tiles: the menu conversion ratio (opens vs.
+  actions taken) and the top-20 user actions across all surfaces
+  (context menu, double-click, keyboard, breadcrumb, highlight,
+  decoded viewer, extract).
+- **1. Context menu** -- top actions (excluding the menu-open
+  impression), trigger-source mix (row vs. breadcrumb vs. kebab) over
+  time, `expandToDepth` relative-depth distribution (submenu only),
+  copy-action mix across all six copy surfaces.
+- **2. Subtree submenu** -- raw counts for the subtree submenu's six
+  actions, including plain `isolate`. Note: `isolateNarrow` and
+  `isolateWide` carry no `source` prop, so the subtree-vs-top-level
+  split is not telemetrically observable.
+- **3. Tree row interactions** -- double-click and keyboard copy /
+  toggle paths.
+- **4. Breadcrumb** -- breadcrumb click and copy path.
+- **5. Highlight** -- combined view of menu-dispatched highlight
+  (`tree.contextMenu.highlight*`) and applied-highlight signal
+  (`tree.highlight.apply` / `remove` / `swatchOpened`); plus color
+  mix from the 7-value swatch enum.
+- **6. Decoded viewer & Extract** -- mixed-table section unioning
+  `customEvents` (extract.shown / extract.click / decoded.viewerOpened)
+  with `traces` (`tree.contextMenu.extract`, mis-tagged Severity:info
+  pending issue #241 migration).
+
+#### Per-feature usage tile convention
+
+Each `<feature>.*` namespace in the product-analytics workbook gets at
+minimum:
+
+1. A "top events" bar chart for that namespace, time-range bound to the
+   workbook's `TimeRange` parameter.
+2. A source/variant split if the feature has multiple entry points
+   (e.g., context menu's `row | breadcrumb | kebab`).
+
+Conventions:
+
+- **Time range:** all KQL tiles bind to the workbook-level `TimeRange`
+  parameter (default 30d). Time-series tiles use plain
+  `summarize ... by bin(timestamp, ...)` so the workbook filter applies.
+  **Do not use `make-series`** -- it hardcodes a window via
+  `from ago(...) to now()` and breaks the picker.
+- **TimeRange asymmetry:** the operator-monitoring workbook does not
+  currently expose a TimeRange parameter; its tiles are tuned to
+  operator-relevant windows (1h-7d). The product-analytics workbook
+  does, because product-analytics tiles answer different questions
+  across 24h-90d. Aligning the two is a separate plan.
+- **Section ordering:** the leading conversion + top-20 tiles stay at
+  the top. Per-feature sections grow below. Order roughly by traffic
+  volume (highest first), then by product centrality.
+- **Near-zero traffic (`top event < 5 over 30d`):** keep the tile; an
+  empty-ish chart is informative for catalog hygiene.
+- **Retired events:** drop the event from the tile after one full 30d
+  window has elapsed since retirement. Catalog comment in
+  `telemetry-message-ids.ts` is the source of truth.
+- **`severityLevel == 1` filter:** queries that read `traces` filter on
+  `severityLevel == 1` (Information). This excludes `warn` / `error`
+  traces. If future telemetry adds an `Information`-level diagnostic
+  trace that shares a name with a user-action message (none today), the
+  filter would need to tighten further. Catalog JSDoc is the source of
+  truth for the user-action vs diagnostic distinction.
+- **DisplayName collision after prod carve-out:** when prod becomes a
+  separate Azure subscription, both subscriptions will host workbooks
+  named `JotJSON operator monitoring` and `JotJSON product analytics`
+  in their respective App Insights galleries. The gallery is scoped
+  per component, so the names are unambiguous in their context. The
+  env name renders in the workbook header markdown.
+
+Issue #242 covers a third workbook -- `JotJSON telemetry hygiene` --
+that surfaces catalog drift, table-split smells, and cardinality
+outliers. Issue #240 covers a CI gate that schema-validates workbook
+JSON and lints KQL time-binding.
 
 ### Alerts
 
@@ -1117,8 +1211,8 @@ Issue #92 covers expanding to SMS / Teams / webhook receivers.
 
 ### Tuning thresholds
 
-1. Open the workbook; pick a relevant section (for example, "API" for
-   `fn-5xx`).
+1. Open the **operator monitoring** workbook; pick a relevant section
+   (for example, "API" for `fn-5xx`).
 2. Look at the actual baseline rate over the last 7-30 days.
 3. Edit the relevant alert resource in `infra/modules/alerts.bicep`. Update the
    `threshold` value or the underlying KQL.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -84,13 +84,52 @@ module monitoringActions 'modules/actionGroup.bicep' = {
   }
 }
 
-module monitoringWorkbook 'modules/monitoringWorkbook.bicep' = {
-  name: 'monitoringWorkbook'
+// Resource-name seed convention:
+// - operatorWorkbook uses `resourceSuffix` UNSUFFIXED so guid() resolves
+//   to the same name as the pre-refactor `monitoringWorkbook` resource.
+//   This makes the deploy an in-place property update (displayName +
+//   serializedData + tags), preserving saved-portal links and edit
+//   history.
+// - productAnalyticsWorkbook uses `'${resourceSuffix}-analytics'`,
+//   producing a distinct guid -> new resource.
+// - Any future caller MUST use a distinct seed unless it intentionally
+//   targets one of the existing GUIDs.
+var operatorWorkbookContentTemplate = loadTextContent('workbooks/monitoring.json')
+var operatorWorkbookContent = replace(
+  replace(operatorWorkbookContentTemplate, '__ENVIRONMENT_NAME__', environmentName),
+  '__COMPONENT_ID__',
+  insights.outputs.componentId
+)
+
+module operatorWorkbook 'modules/workbook.bicep' = {
+  name: 'operatorWorkbook'
   params: {
-    environmentName: environmentName
+    displayName: 'JotJSON operator monitoring'
+    serializedContent: operatorWorkbookContent
     resourceNameSeed: resourceSuffix
     location: location
     componentId: insights.outputs.componentId
+    purpose: 'operator-monitoring'
+    tags: tags
+  }
+}
+
+var productAnalyticsContentTemplate = loadTextContent('workbooks/product-analytics.json')
+var productAnalyticsContent = replace(
+  replace(productAnalyticsContentTemplate, '__ENVIRONMENT_NAME__', environmentName),
+  '__COMPONENT_ID__',
+  insights.outputs.componentId
+)
+
+module productAnalyticsWorkbook 'modules/workbook.bicep' = {
+  name: 'productAnalyticsWorkbook'
+  params: {
+    displayName: 'JotJSON product analytics'
+    serializedContent: productAnalyticsContent
+    resourceNameSeed: '${resourceSuffix}-analytics'
+    location: location
+    componentId: insights.outputs.componentId
+    purpose: 'product-analytics'
     tags: tags
   }
 }
@@ -155,4 +194,5 @@ output dnsNameServers array = empty(dnsZoneName) ? [] : dns.outputs.nameServers
 output cosmosEndpoint string = cosmos.outputs.endpoint
 output storageAccountName string = storage.outputs.accountName
 output appInsightsConnectionString string = insights.outputs.connectionString
-output monitoringWorkbookId string = monitoringWorkbook.outputs.id
+output operatorWorkbookId string = operatorWorkbook.outputs.id
+output productAnalyticsWorkbookId string = productAnalyticsWorkbook.outputs.id

--- a/infra/modules/workbook.bicep
+++ b/infra/modules/workbook.bicep
@@ -1,0 +1,52 @@
+@description('Display name shown in the App Insights workbook gallery.')
+param displayName string
+
+@description('Workbook content JSON (post-substitution) as a string.')
+param serializedContent string
+
+@description('Deterministic seed for the workbook resource name. The resource name is guid(resourceNameSeed) so callers using the same seed update the same resource in place.')
+param resourceNameSeed string
+
+@description('Azure region for the workbook resource.')
+param location string
+
+@description('Resource ID of the App Insights component the workbook queries.')
+param componentId string
+
+@description('Logical purpose of the workbook. Drives the purpose tag for filterable inventory.')
+@allowed([
+  'operator-monitoring'
+  'product-analytics'
+  'telemetry-hygiene'
+])
+param purpose string
+
+@description('Workbook kind. shared = visible to all RG users; user = personal workbook scoped to creator.')
+@allowed([
+  'shared'
+  'user'
+])
+param kind string = 'shared'
+
+@description('Workbook gallery category. Defaults to the generic workbook gallery.')
+param category string = 'workbook'
+
+@description('Base tags merged onto the resource. The purpose tag is appended automatically.')
+param tags object = {}
+
+resource workbook 'Microsoft.Insights/workbooks@2022-04-01' = {
+  name: guid(resourceNameSeed)
+  location: location
+  kind: kind
+  tags: union(tags, { purpose: purpose })
+  properties: {
+    category: category
+    displayName: displayName
+    serializedData: serializedContent
+    sourceId: componentId
+    version: 'Notebook/1.0'
+  }
+}
+
+output id string = workbook.id
+output displayName string = workbook.properties.displayName

--- a/infra/workbooks/monitoring.json
+++ b/infra/workbooks/monitoring.json
@@ -1,26 +1,10 @@
-@description('Environment short name for the displayName, e.g. dev.')
-param environmentName string
-
-@description('Stable suffix used to derive a deterministic GUID for the workbook resource name, e.g. jotjson-dev-monitoring.')
-param resourceNameSeed string
-
-@description('Azure region for the workbook resource.')
-param location string
-
-@description('Resource ID of the Application Insights component the workbook queries.')
-param componentId string
-
-@description('Tags applied to the resource.')
-param tags object = {}
-
-var workbookContentTemplate = '''
 {
   "version": "Notebook/1.0",
   "items": [
     {
       "type": 1,
       "content": {
-        "json": "# JotJSON monitoring (__ENVIRONMENT_NAME__)\n\nFirst-look dashboard for app health, performance, auth, API, and quotas. See `docs/telemetry.md` for KQL conventions and the full event catalog."
+        "json": "# JotJSON operator monitoring\n\nFirst-look dashboard for app health, performance, auth, API, and quotas. See `docs/telemetry.md` for KQL conventions and the full event catalog. Environment: __ENVIRONMENT_NAME__."
       }
     },
     {
@@ -211,23 +195,3 @@ var workbookContentTemplate = '''
   "fallbackResourceIds": ["__COMPONENT_ID__"],
   "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
 }
-'''
-
-var workbookContent = replace(replace(workbookContentTemplate, '__ENVIRONMENT_NAME__', environmentName), '__COMPONENT_ID__', componentId)
-
-resource workbook 'Microsoft.Insights/workbooks@2022-04-01' = {
-  name: guid(resourceNameSeed)
-  location: location
-  tags: tags
-  kind: 'shared'
-  properties: {
-    displayName: 'JotJSON monitoring (${environmentName})'
-    serializedData: workbookContent
-    version: 'Notebook/1.0'
-    sourceId: componentId
-    category: 'workbook'
-  }
-}
-
-output id string = workbook.id
-output displayName string = workbook.properties.displayName

--- a/infra/workbooks/product-analytics.json
+++ b/infra/workbooks/product-analytics.json
@@ -44,7 +44,7 @@
       "type": 3,
       "content": {
         "version": "KqlItem/1.0",
-        "query": "let opens = toscalar(\n  traces\n  | where severityLevel == 1\n  | where message == 'tree.contextMenu.opened'\n  | count);\nlet actions = toscalar(\n  traces\n  | where severityLevel == 1\n  | where message startswith 'tree.contextMenu.'\n  | where message !in ('tree.contextMenu.opened', 'tree.contextMenu.subtreeOpened')\n  | count);\ndatatable (label: string, value: real, sort: int)\n[\n  'Menu opens',       opens,                                                                                  1,\n  'Actions taken',    actions,                                                                                2,\n  'Follow-through %', iff(opens == 0, real(0), round(100.0 * todouble(actions) / todouble(opens), 1)),         3\n]\n| order by sort asc\n| project label, value",
+        "query": "let opens = toscalar(\n  traces\n  | where severityLevel == 1\n  | where message == 'tree.contextMenu.opened'\n  | count);\nlet actions = toscalar(\n  traces\n  | where severityLevel == 1\n  | where message startswith 'tree.contextMenu.'\n  | where message !in ('tree.contextMenu.opened', 'tree.contextMenu.subtreeOpened')\n  | count);\nunion\n  (print label = 'Menu opens',             value = todouble(opens),  sort = 1),\n  (print label = 'Actions taken',          value = todouble(actions), sort = 2),\n  (print label = 'Actions per 100 opens',  value = iff(opens == 0, real(null), round(100.0 * todouble(actions) / todouble(opens), 1)), sort = 3)\n| order by sort asc\n| project label, value",
         "size": 1,
         "queryType": 0,
         "resourceType": "microsoft.insights/components",
@@ -121,7 +121,7 @@
     {
       "type": 1,
       "content": {
-        "json": "Note: Tile 1.2 uses `summarize ... by bin(timestamp, 1d)` (not `make-series`) so the TimeRange picker applies cleanly across 24h-90d. Days with zero opens don't render as zero-valued points; for total volume / conversion see Tile 0.1."
+        "json": "Note: Tile 1.2 uses `summarize ... by bin(timestamp, 1d)` (not `make-series`) so the TimeRange picker applies cleanly. **Best viewed at 7d+;** at 24h the chart collapses to 1-2 bins by design -- the conversion ratio for a 24h window lives in Tile 0.1. Days with zero opens don't render as zero-valued points."
       }
     },
     {

--- a/infra/workbooks/product-analytics.json
+++ b/infra/workbooks/product-analytics.json
@@ -1,0 +1,260 @@
+{
+  "version": "Notebook/1.0",
+  "items": [
+    {
+      "type": 1,
+      "content": {
+        "json": "# JotJSON product analytics\n\nWhich tree-row, context-menu, keyboard, breadcrumb, highlight, decoded-viewer, and extract actions are getting used, and at what rate. See `docs/telemetry.md` for KQL conventions, the per-feature usage tile convention, and the full event catalog. Environment: __ENVIRONMENT_NAME__."
+      }
+    },
+    {
+      "type": 9,
+      "content": {
+        "version": "KqlParameterItem/1.0",
+        "parameters": [
+          {
+            "id": "time-range",
+            "version": "KqlParameterItem/1.0",
+            "name": "TimeRange",
+            "label": "Time range",
+            "type": 4,
+            "isRequired": true,
+            "value": {
+              "durationMs": 2592000000
+            },
+            "typeSettings": {
+              "selectableValues": [
+                { "durationMs": 86400000 },
+                { "durationMs": 604800000 },
+                { "durationMs": 2592000000 },
+                { "durationMs": 7776000000 }
+              ]
+            }
+          }
+        ]
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 0. Leading\n\nThe headline answer: how often is the right-click menu opened, and how often does opening turn into an action?"
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let opens = toscalar(\n  traces\n  | where severityLevel == 1\n  | where message == 'tree.contextMenu.opened'\n  | count);\nlet actions = toscalar(\n  traces\n  | where severityLevel == 1\n  | where message startswith 'tree.contextMenu.'\n  | where message !in ('tree.contextMenu.opened', 'tree.contextMenu.subtreeOpened')\n  | count);\ndatatable (label: string, value: real, sort: int)\n[\n  'Menu opens',       opens,                                                                                  1,\n  'Actions taken',    actions,                                                                                2,\n  'Follow-through %', iff(opens == 0, real(0), round(100.0 * todouble(actions) / todouble(opens), 1)),         3\n]\n| order by sort asc\n| project label, value",
+        "size": 1,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "tiles",
+        "tileSettings": {
+          "titleContent": {
+            "columnMatch": "label",
+            "formatter": 1
+          },
+          "leftContent": {
+            "columnMatch": "value",
+            "formatter": 12,
+            "formatOptions": {
+              "min": 0,
+              "palette": "blue"
+            },
+            "numberFormat": {
+              "unit": 0,
+              "options": {
+                "style": "decimal"
+              }
+            }
+          },
+          "showBorder": true,
+          "size": "auto"
+        },
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let userActionMessages = dynamic([\n  'tree.contextMenu.copyKey',\n  'tree.contextMenu.copyValue',\n  'tree.contextMenu.copyPath',\n  'tree.contextMenu.searchByKey',\n  'tree.contextMenu.searchByValue',\n  'tree.contextMenu.collapse',\n  'tree.contextMenu.expandAllFromHere',\n  'tree.contextMenu.expandToDepth',\n  'tree.contextMenu.isolate',\n  'tree.contextMenu.isolateNarrow',\n  'tree.contextMenu.isolateWide',\n  'tree.contextMenu.highlight',\n  'tree.contextMenu.highlightSubtree',\n  'tree.contextMenu.extract',\n  'tree.row.doubleClickCopyValue',\n  'tree.row.doubleClickToggle',\n  'tree.keyboard.copyValue',\n  'tree.breadcrumb.click',\n  'tree.breadcrumb.copyPath',\n  'tree.highlight.apply',\n  'tree.highlight.remove',\n  'tree.highlight.swatchOpened'\n]);\nlet userActionEventNames = dynamic([\n  'tree.extract.click',\n  'tree.decoded.viewerOpened'\n]);\nunion\n  (traces\n    | where severityLevel == 1\n    | where message in (userActionMessages)\n    | project name = tostring(message)),\n  (customEvents\n    | where name in (userActionEventNames))\n| summarize count_ = count() by name\n| top 20 by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 1. Context menu\n\nThe right-click / kebab menu. Excludes `opened` and `subtreeOpened` (those are menu impressions, not actions; tile 0.1 already shows the conversion ratio)."
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where severityLevel == 1\n| where message startswith 'tree.contextMenu.'\n| where message !in ('tree.contextMenu.opened', 'tree.contextMenu.subtreeOpened')\n| summarize count_ = count() by tostring(message)\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "customWidth": "50",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where severityLevel == 1\n| where message == 'tree.contextMenu.opened'\n| summarize count_ = count()\n    by bin(timestamp, 1d), source = tostring(customDimensions.source)\n| order by timestamp asc\n| render areachart with (kind = stacked)",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "areachart",
+        "customWidth": "50",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "Note: Tile 1.2 uses `summarize ... by bin(timestamp, 1d)` (not `make-series`) so the TimeRange picker applies cleanly across 24h-90d. Days with zero opens don't render as zero-valued points; for total volume / conversion see Tile 0.1."
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where severityLevel == 1\n| where message == 'tree.contextMenu.expandToDepth'\n| where tostring(customDimensions.source) == 'submenu'\n| summarize count_ = count() by relativeDepth = toint(customDimensions.relativeDepth)\n| order by relativeDepth asc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "customWidth": "50",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let copyMessages = dynamic([\n  'tree.contextMenu.copyKey',\n  'tree.contextMenu.copyValue',\n  'tree.contextMenu.copyPath',\n  'tree.row.doubleClickCopyValue',\n  'tree.keyboard.copyValue',\n  'tree.breadcrumb.copyPath'\n]);\ntraces\n| where severityLevel == 1\n| where message in (copyMessages)\n| summarize count_ = count() by tostring(message)\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "customWidth": "50",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 2. Subtree submenu\n\nNote: `isolateNarrow` and `isolateWide` carry no `source` prop, so we can't distinguish subtree-submenu vs top-level invocation telemetrically. Chart shows raw counts."
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where severityLevel == 1\n| where message in (\n    'tree.contextMenu.subtreeOpened',\n    'tree.contextMenu.expandAllFromHere',\n    'tree.contextMenu.isolate',\n    'tree.contextMenu.isolateNarrow',\n    'tree.contextMenu.isolateWide',\n    'tree.contextMenu.highlightSubtree'\n  )\n| summarize count_ = count() by tostring(message)\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 3. Tree row interactions\n\nDouble-click and keyboard copy paths."
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where severityLevel == 1\n| where message in (\n    'tree.row.doubleClickCopyValue',\n    'tree.row.doubleClickToggle',\n    'tree.keyboard.copyValue'\n  )\n| summarize count_ = count() by tostring(message)\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 4. Breadcrumb"
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where severityLevel == 1\n| where message in ('tree.breadcrumb.click', 'tree.breadcrumb.copyPath')\n| summarize count_ = count() by tostring(message)\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 5. Highlight\n\nCovers both menu-dispatched highlight (`tree.contextMenu.highlight*`) and the applied-highlight signal (`tree.highlight.apply` / `tree.highlight.remove` / `tree.highlight.swatchOpened`). The color mix tile uses the 7-value swatch enum -- cardinality is bounded by design."
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "let highlightMessages = dynamic([\n  'tree.contextMenu.highlight',\n  'tree.contextMenu.highlightSubtree',\n  'tree.highlight.apply',\n  'tree.highlight.remove',\n  'tree.highlight.swatchOpened'\n]);\ntraces\n| where severityLevel == 1\n| where message in (highlightMessages)\n| summarize count_ = count() by tostring(message)\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "customWidth": "50",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "traces\n| where severityLevel == 1\n| where message == 'tree.highlight.apply'\n| summarize count_ = count() by color = tostring(customDimensions.color)\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "customWidth": "50",
+        "timeContextFromParameter": "TimeRange"
+      }
+    },
+    {
+      "type": 1,
+      "content": {
+        "json": "## 6. Decoded viewer & Extract\n\nMixed-table section: `tree.extract.click`, `tree.extract.shown`, and `tree.decoded.viewerOpened` are correctly tagged `Kind: event` (in `customEvents`). The menu-driven extract path (`tree.contextMenu.extract`) is mis-tagged `Severity: info` and lives in `traces`. This tile unions both tables so the menu-vs-pill comparison stays intact until the instrumentation migration (issue #241) ships. `tree.decoded.click` was retired in v0.20.0 and is deliberately omitted."
+      }
+    },
+    {
+      "type": 3,
+      "content": {
+        "version": "KqlItem/1.0",
+        "query": "union\n  (customEvents\n    | where name in (\n        'tree.extract.shown',\n        'tree.extract.click',\n        'tree.decoded.viewerOpened'\n      )\n    | project name),\n  (traces\n    | where severityLevel == 1\n    | where message == 'tree.contextMenu.extract'\n    | project name = tostring(message))\n| summarize count_ = count() by name\n| order by count_ desc\n| render barchart",
+        "size": 0,
+        "queryType": 0,
+        "resourceType": "microsoft.insights/components",
+        "visualization": "barchart",
+        "timeContextFromParameter": "TimeRange"
+      }
+    }
+  ],
+  "fallbackResourceIds": ["__COMPONENT_ID__"],
+  "$schema": "https://github.com/Microsoft/Application-Insights-Workbooks/blob/master/schema/workbook.json"
+}


### PR DESCRIPTION
Adds a new App Insights workbook for product analytics, and extracts a generic, content-agnostic `infra/modules/workbook.bicep` module that both the existing monitoring workbook and the new analytics workbook share.

## What ships

**New: JotJSON product analytics workbook**

Answers "which features are getting used, and at what rate?" -- right-click menu, double-click, keyboard shortcuts, breadcrumb, highlight, decoded viewer, extract. Seven sections / nine tiles, including a workbook-level `TimeRange` picker (default 30d, options 24h/7d/30d/90d):

- **0. Leading** -- conversion ratio (menu opens vs. actions taken) and top-20 user actions across all surfaces.
- **1. Context menu** -- top actions (excluding menu-open impressions), trigger-source mix over time, `expandToDepth` relative-depth distribution, copy-action mix.
- **2. Subtree submenu** -- raw counts.
- **3. Tree row interactions** -- double-click and keyboard copy/toggle paths.
- **4. Breadcrumb** -- click + copy.
- **5. Highlight** -- combined menu + applied-highlight signal, plus color mix from the 7-value swatch enum.
- **6. Decoded viewer & Extract** -- mixed-table union (`customEvents` + `traces`) until issue #241 ships.

**Refactor: extract infra/modules/workbook.bicep**

Content-agnostic generic module: `displayName`, `serializedContent`, `resourceNameSeed`, `componentId`, `@allowed purpose/kind`, default `category`, base `tags`.

The existing monitoring workbook migrates to this module. Content moves from a multi-line Bicep string in `infra/modules/monitoringWorkbook.bicep` (deleted) to `infra/workbooks/monitoring.json` (loaded via `loadTextContent()`). The resource GUID is preserved (`resourceNameSeed: resourceSuffix`) so this is an **in-place property update**, not a replace -- saved-portal links and edit history are preserved.

## Operator-visible changes

- **App Insights gallery rename:** `JotJSON monitoring (dev)` -> `JotJSON operator monitoring`. The `(dev)` env suffix dropped from the gallery name; the env name now renders inside the workbook header markdown.
- **New gallery entry:** `JotJSON product analytics`.
- **Bicep output rename:** `monitoringWorkbookId` -> `operatorWorkbookId`; new `productAnalyticsWorkbookId` output. Nothing in-repo currently consumes the old output (verified via grep), but external scripts/workflows that read `az deployment show` outputs would notice.

## Follow-ups filed

- **#241** -- Migrate ~25 `tree.contextMenu.*` / `tree.row.*` / `tree.keyboard.*` / `tree.breadcrumb.*` / `tree.highlight.*` events from `logger.info()` to `logger.event()` so user actions land in `customEvents` instead of `traces` (per `LoggerService` doc comment at `logger.service.ts:131-135` and AGENTS.md \u00a74 "Pick the right sink up front"). Once shipped, the tile queries simplify and the `severityLevel == 1` filter goes away.
- **#242** -- Add `JotJSON telemetry hygiene` workbook (third workbook using this new generic module): catalog drift, table-split smells, cardinality outliers, backend events.
- **#240** -- CI gate: `scripts/check-workbook-json.mjs` to schema-validate workbook JSON and lint KQL time-binding (no `make-series` in TimeRange-bound tiles; no raw `ago()` filters that would shadow the picker; no `#NNN` placeholders).

## Implementation notes

- `.gitignore` adds `!/infra/workbooks/*.json` exception (the broader `/infra/**/*.json` line otherwise excluded the new workbook source files as if they were Bicep build output).
- `docs/telemetry.md` gets a new "Per-feature usage tile convention" paragraph documenting the TimeRange binding rule, no-make-series rule, severityLevel filter rationale, and the displayName collision note for the eventual prod carveout.
- The KQL in Tile 1.2 (trigger source over time) uses `summarize ... by bin(timestamp, 1d)` instead of `make-series` so the workbook TimeRange picker applies cleanly to all four selectable durations. Trade-off: days with zero opens don't render as zero-valued points; a markdown caption below the chart explains this and points readers to Tile 0.1 for total volume.
- Tile 0.1 (menu conversion) reshapes its KQL result to a 3-row `datatable` so the `tiles` visualization can render each row as one card (Menu opens / Actions taken / Follow-through %), with an `iff(opens == 0, real(0), ...)` NaN guard for empty windows.

## Verification

- `az bicep build infra/main.bicep` passes (one pre-existing BCP318 warning on `dns.outputs.nameServers`, unrelated).
- `npm run lint:all` passes (root + api).
- `grep -rn '#NNN' infra/ docs/` returns no matches.
- `grep -rn 'monitoringWorkbookId|monitoringWorkbook\.bicep'` returns no matches outside this PR's deletions.

## SemVer

No bump (infra + docs only; no user-facing product behavior change).

## Plan

Plan was iterated through three rubber-duck rounds against the three-persona panel (`deep-review:skeptic` + `:advocate` + `:architect`); the final plan is in the agent's session state.

---
**Session**
- AI-Local: `a99fe0fa-0920-4e14-90d3-50e374c78cab`
- AI-Cloud: `db29e626-0f53-4547-9430-937da15d4b33`
