### PR TITLE
Fix: tree row width overflow on long string values (v0.21.1)

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2327,6 +2327,26 @@ Out of scope (for v1):
   minimum amount to reveal the target row (`scrollIntoView({block:
   'nearest'})`-equivalent semantics, computed off the viewport's
   actual scroll offset rather than CDK's buffered rendered range).
+- **0.21.1**: Tree row width hotfix on long string values
+  (regression discovered post-0.21.0 ship). The Phase-2 ellipsify
+  cascade on `.tree-value-string` (`white-space: nowrap; overflow:
+  hidden; text-overflow: ellipsis; min-width: 0`) was correct but
+  never fired for rows whose value's natural single-line render
+  exceeded the panel width. Root cause: CDK's
+  `cdk-virtual-scroll-content-wrapper` ships as `position: absolute;
+  min-width: 100%; width: auto` (vertical orientation), so it
+  shrink-to-fits to row max-content and `.tree-row` sees an
+  effectively-unbounded containing block. Fix: a single
+  `:host ::ng-deep .tree-viewport .cdk-virtual-scroll-content-wrapper
+  { width: 100%; box-sizing: border-box; }` rule in the json-tree
+  SCSS that pins the wrapper at exactly viewport width, letting the
+  cell-level ellipsify cascade do its job. Pure presentation fix --
+  no TS, HTML, or directive changes; the `OverflowDetectorDirective`
+  / `OverflowMeasurementQueue` machinery shipped in 0.21.0 already
+  handles the tooltip gating once ellipsis fires. Out-of-scope
+  follow-ups: long object keys (`.tree-key` has `flex-shrink: 0`),
+  type-badge / pill-cluster width, and deep-nesting invisible
+  clipping at depth >= 25 are tracked as separate issues.
 - **0.20.2**: MSAL silent token refresh fix, part 2 of 2 (0.20.1 was
   part 1). Adds the iframe-side bridge call required for the silent-
   refresh flow to actually complete after the CSP layer was unblocked

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.20.2",
+  "version": "0.21.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.20.2",
+      "version": "0.21.1",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.21.0",
+  "version": "0.21.1",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/shared/components/json-tree/json-tree.component.overflow.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.overflow.spec.ts
@@ -1,0 +1,164 @@
+import { TestBed, type ComponentFixture } from '@angular/core/testing';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { attachFixtureToBody } from '../../../../testing/a11y';
+import { provideFakeAuth } from '../../../../testing/auth.testing';
+import { JsonTreeComponent } from './json-tree.component';
+
+/**
+ * v0.21.1 hotfix regression spec for tree row width overflow.
+ *
+ * Reproduces the bug surfaced by https://jotjson.com/s/HiZ2qI: a row
+ * whose value's natural single-line render is much wider than the
+ * panel pushed the whole tree past its container, breaking the
+ * Phase-2 single-line ellipsify contract declared in DESIGN_SPEC.md
+ * v0.21.0 ("long values truncate with an ellipsis and reveal the
+ * full string on hover instead of wrapping").
+ *
+ * Root cause was the CDK-internal
+ * `cdk-virtual-scroll-content-wrapper`: CDK styles it
+ * `position: absolute; min-width: 100%; width: auto`, so it
+ * shrink-to-fits to the widest row and `.tree-row` sees an
+ * effectively-unbounded containing block. Fix: pin the wrapper at
+ * `width: 100%` via a `:host ::ng-deep .tree-viewport` rule in
+ * `json-tree.component.scss`. See the commentary at the rule itself
+ * for the full explanation.
+ *
+ * Mounting strategy: the host is sized at mount (NOT resize-after-
+ * render) so we don't depend on `ResizeObserver` callback timing.
+ * The four assertions are intentionally layered so any future
+ * regression in any layer surfaces independently:
+ *   1. Sanity: the value's natural single-line width is far wider
+ *      than the panel (proves we're actually exercising the bug).
+ *   2. Wrapper constrained: the load-bearing assertion that the
+ *      `:host ::ng-deep ... { width: 100% }` rule is in effect.
+ *   3. No horizontal scrollbar at the viewport: the user-visible
+ *      symptom we're regressing-protecting.
+ *   4. CDK class still exists: defends against a future Angular CDK
+ *      upgrade silently renaming `cdk-virtual-scroll-content-wrapper`
+ *      and our SCSS selector becoming a no-op.
+ */
+describe('JsonTreeComponent (row-width overflow)', () => {
+  let teardown: (() => void) | undefined;
+  let fixtureValue: unknown;
+
+  beforeAll(async () => {
+    const response = await fetch('/fixtures/LongUnbreakableValue.json');
+    if (!response.ok) {
+      throw new Error(
+        `Failed to load fixtures/LongUnbreakableValue.json: HTTP ${response.status}. ` +
+          `Ensure src/testing/fixtures is registered in angular.json test assets.`,
+      );
+    }
+    fixtureValue = JSON.parse(await response.text());
+  });
+
+  async function configure(panelWidthPx: number): Promise<ComponentFixture<JsonTreeComponent>> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [JsonTreeComponent],
+      providers: [
+        ...provideFakeAuth(),
+        provideNoopAnimations(),
+        { provide: MatSnackBar, useValue: { open: jasmine.createSpy('snackOpen') } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(JsonTreeComponent);
+    fixture.componentRef.setInput('value', fixtureValue);
+
+    // Phase 2 (issue #95) -- the CDK virtual scroll viewport queries
+    // its parent's `clientHeight` synchronously during
+    // `ngAfterViewInit`. Without explicit pixel dimensions on the
+    // host the viewport measures zero and renders zero rows.
+    // Sizing AT mount (rather than after `detectChanges`) means the
+    // first `OverflowDetectorDirective.afterNextRender` measurement
+    // already runs at the constrained size, so we never depend on
+    // ResizeObserver callback timing (no test seam for that).
+    const host = fixture.nativeElement as HTMLElement;
+    host.style.height = '600px';
+    host.style.width = `${panelWidthPx}px`;
+    return fixture;
+  }
+
+  async function drainViewport(fixture: ComponentFixture<JsonTreeComponent>): Promise<void> {
+    fixture.detectChanges();
+    fixture.componentInstance.expandAll();
+    fixture.detectChanges();
+    await Promise.resolve();
+    await Promise.resolve();
+    fixture.detectChanges();
+  }
+
+  afterEach(() => {
+    teardown?.();
+    teardown = undefined;
+  });
+
+  it('constrains the cdk-virtual-scroll-content-wrapper to the viewport width when a row value is much wider', async () => {
+    const PANEL_WIDTH_PX = 400;
+    const fixture = await configure(PANEL_WIDTH_PX);
+    teardown = attachFixtureToBody(fixture, 'dark');
+    await drainViewport(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const viewport = host.querySelector<HTMLElement>('.tree-viewport');
+    expect(viewport)
+      .withContext('the cdk-virtual-scroll-viewport with class .tree-viewport must render')
+      .toBeTruthy();
+
+    const wrapper = host.querySelector<HTMLElement>('.cdk-virtual-scroll-content-wrapper');
+    // Assertion 4: the CDK internal class our SCSS selector targets
+    // must still exist. A future Angular CDK upgrade that renames
+    // this class would silently regress the fix; this assertion
+    // catches that in CI.
+    expect(wrapper)
+      .withContext(
+        'the CDK-internal .cdk-virtual-scroll-content-wrapper element must still exist (the v0.21.1 fix in json-tree.component.scss targets it)',
+      )
+      .toBeTruthy();
+
+    // Find the widest .tree-value-string cell in the rendered DOM.
+    // The fixture's `Parameters[0].Value` is a JSON-escape-laden
+    // ~800-char string with an embedded long URL token; its
+    // single-line natural width far exceeds 400px.
+    const valueCells = Array.from(host.querySelectorAll<HTMLElement>('.tree-value-string'));
+    expect(valueCells.length)
+      .withContext('expandAll should surface at least one string-value cell from the fixture')
+      .toBeGreaterThan(0);
+    const widestCell = valueCells.reduce((widest, cell) =>
+      cell.scrollWidth > widest.scrollWidth ? cell : widest,
+    );
+
+    // Assertion 1 (precondition): the cell's natural single-line
+    // width is at least 2x the panel. If a future fixture edit
+    // makes the value short enough to fit, this assertion fails
+    // loudly and we know the test stopped exercising the bug
+    // class -- rather than passing by coincidence.
+    expect(widestCell.scrollWidth)
+      .withContext(
+        `precondition: the widest .tree-value-string's natural width (scrollWidth=${widestCell.scrollWidth}) must be at least 2x the panel width (${PANEL_WIDTH_PX}px) so we know the test is actually exercising the row-overflow bug; if this fails, edit fixtures/LongUnbreakableValue.json to restore a long unbreakable value`,
+      )
+      .toBeGreaterThanOrEqual(2 * PANEL_WIDTH_PX);
+
+    // Assertion 2 (load-bearing): the wrapper is pinned to the
+    // viewport's clientWidth (1px tolerance for sub-pixel rounding
+    // in headless Chromium).
+    const viewportWidth = viewport!.clientWidth;
+    expect(wrapper!.clientWidth)
+      .withContext(
+        `wrapper.clientWidth (${wrapper!.clientWidth}) must be <= viewport.clientWidth (${viewportWidth}) + 1; without the v0.21.1 SCSS fix, the wrapper grows to the widest row's max-content`,
+      )
+      .toBeLessThanOrEqual(viewportWidth + 1);
+
+    // Assertion 3 (user-visible symptom): the viewport itself
+    // doesn't show a horizontal scrollbar. Pre-fix, the viewport's
+    // scrollWidth would exceed clientWidth and the user would see
+    // a horizontal scrollbar across the entire tree panel.
+    expect(viewport!.scrollWidth)
+      .withContext(
+        `viewport.scrollWidth (${viewport!.scrollWidth}) must be <= viewport.clientWidth (${viewportWidth}) + 1; if this fails the user sees a horizontal scrollbar on the tree (https://jotjson.com/s/HiZ2qI was the live repro for v0.21.0)`,
+      )
+      .toBeLessThanOrEqual(viewportWidth + 1);
+  });
+});

--- a/src/app/shared/components/json-tree/json-tree.component.scss
+++ b/src/app/shared/components/json-tree/json-tree.component.scss
@@ -133,6 +133,46 @@
   contain: strict;
 }
 
+// Phase 2 (issue #95) hotfix v0.21.1 -- pin the CDK-internal
+// `cdk-virtual-scroll-content-wrapper` to viewport width so the
+// `.tree-value-string` ellipsify cascade
+// (`white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+// min-width: 0` on the cell + `min-width: 0` on every row child) can
+// actually fire.
+//
+// Why this is necessary: CDK's vertical-orientation styles set the
+// wrapper to `position: absolute; min-width: 100%; width: auto`
+// (see `@angular/cdk/scrolling` viewport styles, e.g.
+// `node_modules/@angular/cdk/fesm2022/scrolling.mjs`). With
+// `width: auto` on an absolutely-positioned element the wrapper is
+// shrink-to-fit: when row max-content exceeds the panel (e.g., a
+// long string value past ~160 monospace chars at 13px on a 1200px
+// panel), the wrapper grows above 100% and `.tree-row` sees an
+// effectively-unbounded containing block. Flex then gives
+// `.tree-value-string` all the space it wants and the ellipsis
+// never fires.
+//
+// Why `width: 100%` (not `min-width: 100%`): CDK already supplies
+// `min-width: 100%`. We need an upper bound. `width: 100%`
+// overrides `auto` and pins the wrapper at exactly the viewport's
+// width. A future contributor tempted to "simplify" this to
+// `min-width: 100%` would re-introduce the bug -- the duplicate
+// rule is a no-op against CDK's own.
+//
+// Why scoped to `.tree-viewport` (not bare
+// `cdk-virtual-scroll-viewport`): keeps the override isolated to
+// this component's instances if a second virtualized list ever
+// lands in the SPA.
+//
+// `box-sizing: border-box` is defensive -- the wrapper has no
+// padding or border today, but a future CDK upgrade or downstream
+// rule could add one and `content-box` would push the wrapper one
+// box wider than the viewport, re-introducing the overflow.
+:host ::ng-deep .tree-viewport .cdk-virtual-scroll-content-wrapper {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .tree-empty {
   color: var(--tree-muted-color);
   padding: 20px;

--- a/src/testing/fixtures.spec.ts
+++ b/src/testing/fixtures.spec.ts
@@ -24,6 +24,7 @@ const FIXTURE_FILES = [
   'Bad-Config.json',
   'Depth.json',
   'FlatList.json',
+  'LongUnbreakableValue.json',
   'NestedEvents.json',
   'Recursive.json',
   'Semi-valid.json',

--- a/src/testing/fixtures/LongUnbreakableValue.json
+++ b/src/testing/fixtures/LongUnbreakableValue.json
@@ -1,0 +1,14 @@
+{
+  "Method": "POST",
+  "Url": "/api/billing/subscriptions/abc-123/invoke",
+  "Parameters": [
+    {
+      "Name": "RequestBody",
+      "Value": "POST /commerceapi/billing/subscriptions/abc-123/invoke?api-version=2024-01-01&detailLevel=full HTTP/1.1\r\nHost: billingservice.cp.microsoft.com\r\nAuthorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ijl3YXNzdW1lZHRva2VuanNvbndlYnRva2VueWVzaXRpc3JlYWxseWxvbmcifQ.eyJhdWQiOiJodHRwczovL2JpbGxpbmdzZXJ2aWNlLmNwLm1pY3Jvc29mdC5jb20vL2Fic3RyYWN0bG9uZ2F1ZGllbmNlc3RyaW5nIn0.signature\r\nContent-Type: application/json\r\nx-correlation-id: 11111111-2222-3333-4444-555555555555\r\nUser-Agent: BillingClient/2.4.7-internal+build.20260415\r\n\r\n{\"action\":\"renew\",\"plan\":\"enterprise-yearly\",\"seatCount\":150}"
+    },
+    {
+      "Name": "ExpectedStatus",
+      "Value": 200
+    }
+  ]
+}

--- a/src/testing/fixtures/LongUnbreakableValue.json
+++ b/src/testing/fixtures/LongUnbreakableValue.json
@@ -1,10 +1,10 @@
 {
   "Method": "POST",
-  "Url": "/api/billing/subscriptions/abc-123/invoke",
+  "Url": "/api/orders/abc-123/invoke",
   "Parameters": [
     {
       "Name": "RequestBody",
-      "Value": "POST /commerceapi/billing/subscriptions/abc-123/invoke?api-version=2024-01-01&detailLevel=full HTTP/1.1\r\nHost: billingservice.cp.microsoft.com\r\nAuthorization: Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsIng1dCI6Ijl3YXNzdW1lZHRva2VuanNvbndlYnRva2VueWVzaXRpc3JlYWxseWxvbmcifQ.eyJhdWQiOiJodHRwczovL2JpbGxpbmdzZXJ2aWNlLmNwLm1pY3Jvc29mdC5jb20vL2Fic3RyYWN0bG9uZ2F1ZGllbmNlc3RyaW5nIn0.signature\r\nContent-Type: application/json\r\nx-correlation-id: 11111111-2222-3333-4444-555555555555\r\nUser-Agent: BillingClient/2.4.7-internal+build.20260415\r\n\r\n{\"action\":\"renew\",\"plan\":\"enterprise-yearly\",\"seatCount\":150}"
+      "Value": "POST /api/orders/abc-123/invoke?api-version=2024-01-01&detailLevel=full HTTP/1.1\r\nHost: api.example.com\r\nAuthorization: <NOT_A_REAL_TOKEN_PLACEHOLDER_FOR_OVERFLOW_TEST_NOT_A_REAL_TOKEN_PLACEHOLDER_FOR_OVERFLOW_TEST_NOT_A_REAL_TOKEN_PLACEHOLDER_FOR_OVERFLOW_TEST_NOT_A_REAL_TOKEN_PLACEHOLDER_FOR_OVERFLOW_TEST_NOT_A_REAL_TOKEN_PLACEHOLDER_FOR_OVERFLOW_TEST_NOT_A_REAL_TOKEN_PLACEHOLDER_FOR_OVERFLOW_TEST>\r\nContent-Type: application/json\r\nx-correlation-id: 11111111-2222-3333-4444-555555555555\r\nUser-Agent: ExampleClient/1.0.0\r\n\r\n{\"action\":\"renew\",\"plan\":\"enterprise-yearly\",\"seatCount\":150}"
     },
     {
       "Name": "ExpectedStatus",


### PR DESCRIPTION
# Fix tree row width overflow on long string values (v0.21.1)

Hotfix against `main` for a Phase 2 (#236, v0.21.0) regression: rows
whose value renders to a single line wider than the panel push the
tree past its container and produce a horizontal scrollbar, defeating
the [v0.21.0 ellipsify contract](../blob/main/DESIGN_SPEC.md) ("long
values truncate with an ellipsis and reveal the full string on hover
instead of wrapping").

**Live repro:** https://jotjson.com/s/HiZ2qI -- the row at
`$.Parameters[0].Value` (an ~836-char string with `\r\n` escapes and
a long URL fragment) reproduces the bug on v0.21.0.

**Scope of the symptom is broader than the user's repro:** because
`.tree-value-string` has `white-space: nowrap`, _any_ value whose
single-line render exceeds the panel width triggers this -- not just
unbreakable URLs. At 13 px monospace on a 1200 px panel the threshold
is roughly 160 chars. This fix benefits every blob with values past
that threshold.

## Root cause

`<cdk-virtual-scroll-viewport>` injects an internal
`<div class="cdk-virtual-scroll-content-wrapper">` styled
`position: absolute; top: 0; left: 0; contain: content` with the
vertical-orientation rule `min-width: 100%; width: auto` (verified at
`node_modules/@angular/cdk/fesm2022/scrolling.mjs:915`).

With `width: auto` on an absolutely-positioned element the wrapper is
shrink-to-fit: when row max-content exceeds the viewport, the wrapper
grows above 100%. `.tree-row` (its child) then sees an
effectively-unbounded containing block, flex hands `.tree-value-string`
all the space it wants, and `text-overflow: ellipsis` never has a
reason to fire.

CDK's existing `min-width: 100%` is a no-op floor here -- not the
upper bound the cascade needs.

## Fix

One component-scoped `::ng-deep` rule in
`json-tree.component.scss`:

```scss
:host ::ng-deep .tree-viewport .cdk-virtual-scroll-content-wrapper {
  width: 100%;
  box-sizing: border-box;
}
```

`width: 100%` overrides `auto` and pins the wrapper to viewport width.
Scoped to `.tree-viewport` (not bare `cdk-virtual-scroll-viewport`)
so a future second virtualized list in the SPA isn't affected.
`box-sizing: border-box` is defensive against a future CDK upgrade
or formatting-rule extension that adds padding to the wrapper.

A multi-line comment block in the SCSS file explains all of the
above so a future contributor doesn't try to "simplify" the rule
to `min-width: 100%` (which is what CDK already supplies and is
the no-op that lets the bug exist today).

## Test

New Karma spec
`src/app/shared/components/json-tree/json-tree.component.overflow.spec.ts`
mounts the component at viewport width 400 px with a synthetic
800-char-value fixture
(`src/testing/fixtures/LongUnbreakableValue.json`) and asserts:

1. **Precondition** -- `valueCell.scrollWidth >= 2 *
   panelWidth`. Proves the test is actually exercising the bug
   class; if anyone simplifies the fixture later and this stops
   holding, the test fails loudly rather than passing by coincidence.
2. **Wrapper constrained** -- `wrapper.clientWidth <=
   viewport.clientWidth + 1` (1 px tolerance for sub-pixel rounding
   in headless Chromium). Load-bearing assertion.
3. **No horizontal scrollbar** -- `viewport.scrollWidth <=
   viewport.clientWidth + 1`. Tests the user's symptom directly.
4. **Selector still exists** -- a `querySelector('.cdk-virtual-scroll-content-wrapper')`
   call returns a non-null element. If a future CDK upgrade renames
   the class, this assertion fails fast rather than letting the SCSS
   rule become a silent no-op.

The fixture is also registered in `src/testing/fixtures.spec.ts`'s
`FIXTURE_FILES` catalog so it gets the standard parse-and-render
smoke coverage every other fixture gets.

## SemVer

`0.21.0` -> `0.21.1` (patch). User-visible bug fix on a shipped
feature; no contract change. The v0.21.0 entry already declared the
"ellipsify on long values" contract; this change makes the
implementation actually enforce it. `DESIGN_SPEC.md` gets a new
`v0.21.1` paragraph in the version-history section.

## Out of scope (will file as follow-up bugs after this merges)

The skeptic during rubber-duck flagged adjacent overflow issues that
this wrapper fix does **not** address. They are real and worth fixing
but are different bugs in different code; bundling them widens the
hotfix in a way AGENTS.md s9 (Scope Discipline) discourages.

- **`bug` + `priority:medium`**: Long object keys still overflow the
  row. `.tree-key` has `flex-shrink: 0`, so a 200-char unbreakable
  key still pushes the row even after the wrapper is constrained.
  Needs a similar ellipsify pass on the key span.
- **`bug` + `priority:low`**: Type badges and pill clusters
  (`.tree-type-badge`, `.tree-row-right`) have `flex-shrink: 0`
  paths and could push the row in extreme cases. Less common.
- **`bug` + `priority:low`**: Deep-nested rows (depth >= 25,
  `padding-left: 25 * 1.25em`) can have content invisibly clipped
  by the wrapper post-fix. Pre-fix users got a horizontal scrollbar;
  post-fix they don't see it at all. Probably the right call (matches
  the spec contract) but worth a follow-up to consider per-row
  horizontal scroll for extreme depth.

## DoD

- [x] `npm run lint:all` (root + api workspaces)
- [x] `npm test` -- frontend Karma, 2549 passed, 3 skipped
- [x] `npm --prefix api test` -- 452 passed
- [x] `npm run build` -- production build green
- [x] `package.json` bumped 0.21.0 -> 0.21.1
- [x] `DESIGN_SPEC.md` v0.21.1 changelog entry added
- [x] Three-persona rubber-duck (`:skeptic`, `:advocate`,
      `:architect`) per AGENTS.md s11 (DESIGN_SPEC.md touched);
      see plan.md in the session workspace for findings &
      dispositions

## Refs

- Fixes regression introduced in #236 (Phase 2 virtualization)
- Original issue: #95 (tree virtualization)

---
**Session**
- AI-Local: `23ad4e88-8534-4e4b-b9e4-19dd42b9375c`
- AI-Cloud: `4b2294ba-0104-4396-9c2b-081ec8aa94c9`
