### PR TITLE
Surface 'Expand all from here' at row context-menu top level; extend Expand depth submenu to +1..+9 (v0.23.0)

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -513,7 +513,7 @@ The primary page. Available to **all users** (anonymous + registered).
     - **Collapse** - hides itself when the row is already collapsed.
     - **Isolate** / **Collapse siblings** - smart-visibility action(s) that fold the tree to focus on the clicked branch. Both leave the ancestor chain (root..clicked row) and the clicked row's own subtree expansion state untouched. Define `narrowSet` = visibly-expanded peers under the clicked row's immediate parent; `widerSet` = visibly-expanded peers at every higher ancestor (grandparent up to root). **Isolate** collapses `narrowSet U widerSet`; **Collapse siblings** collapses `narrowSet` only. Hidden expanded state under newly-collapsed off-chain branches is preserved (standard CDK FlatTree behavior). Visibility (when the clicked row resolves to a current, non-root node): show neither when both sets are empty; show single **Isolate** when `widerSet` is empty (wide and narrow produce identical end states) or when `narrowSet` is empty (narrow would be a no-op and wide is the only meaningful action); show **both Collapse siblings and Isolate** only when both sets are non-empty (the two actions produce distinct end states). Right-clicking the root row never offers Isolate items, and the actions are no-ops if the path no longer resolves in the current model.
     - **Expand all from here** - hides itself when every container in the subtree is already expanded.
-    - **Expand to depth +1..+5 from here** - **expand-only** semantics: each container in the subtree at relative depth `< N` is expanded if it is currently collapsed, and nothing is ever collapsed (the action is purely additive and idempotent). An entry is shown only when (a) `N` does not exceed the deepest descendant's relative depth from the clicked node, and (b) at least one container at relative depth `< N` somewhere in the subtree (including hidden under a collapsed ancestor) is currently collapsed - i.e., the action would actually expand something. Together these hide redundant entries deeper than the subtree (`+4`/`+5` on a 3-level subtree) and entries that have nothing left to do (everything `+1..+N` on a fully-expanded subtree). Trade-off: there is no per-row "collapse to depth +N" - to reset a partially-expanded subtree the user invokes **Collapse** then re-expands. The toolbar's global **Expand to Level** dropdown still uses snap-to-exact semantics across the whole tree; only the per-row context menu is expand-only.
+    - **Expand to depth +1..+9 from here** - **expand-only** semantics: each container in the subtree at relative depth `< N` is expanded if it is currently collapsed, and nothing is ever collapsed (the action is purely additive and idempotent). An entry is shown only when (a) `N` does not exceed the deepest descendant's relative depth from the clicked node, and (b) at least one container at relative depth `< N` somewhere in the subtree (including hidden under a collapsed ancestor) is currently collapsed - i.e., the action would actually expand something. Together these hide redundant entries deeper than the subtree (`+4`/`+5`/`+6`/.../`+9` on a 3-level subtree) and entries that have nothing left to do (everything `+1..+N` on a fully-expanded subtree). Trade-off: there is no per-row "collapse to depth +N" - to reset a partially-expanded subtree the user invokes **Collapse** then re-expands. The toolbar's global **Expand to Level** dropdown still uses snap-to-exact semantics across the whole tree; only the per-row context menu is expand-only. The per-row range mirrors the toolbar's range (both cover 1-9); the per-row `Expand all from here` lives at the top level of the row menu (v0.23.0+) rather than inside the depth flyout, since it is a more-clicked entry point that benefits from one-click access.
     - The right-click flow positions the menu at the cursor; the kebab self-anchors at its own location. Re-right-clicking a different row while the menu is open repositions it. Keyboard-fired contextmenu (`clientX/Y === 0`) is ignored in v1; full keyboard support is a follow-up. Each invoked action emits an info-level telemetry event under `tree.contextMenu.*`; no user content is logged.
   - **Manual highlights** - owners can persist row-background marks on saved blobs so recipients can see the author's focus.
     - The per-row context menu (right-click or kebab) adds, in order:
@@ -576,6 +576,7 @@ The primary page. Available to **all users** (anonymous + registered).
     - **Container rows with children** (`object` / `array`): toggle the row's expansion state (expand if collapsed, collapse if expanded). Alt is ignored on container dblclick; right-click "Copy value" remains the way to copy a container's pretty-printed JSON. Emits the `tree.row.doubleClickToggle` telemetry event with `{ action: 'expand' | 'collapse' }` (post-toggle state).
     - **Empty containers** (`{}` / `[]`): copy the literal `{}` or `[]` to the clipboard, routing through the same `copyValue` path as primitives (raw text, with Alt wrapping as a JSON-string literal per §443). They render via the leaf template since `hasChild` is false, so they have no expansion to toggle. The tree-menu overhaul relaxed issue #109's "objects and arrays should expand/collapse instead of copying" wording for this edge case, where there is no expand/collapse to do; the surfaced default-shortcut row in the right-click menu also bolds "Copy value" for empty containers to match. Emits the `tree.row.doubleClickCopyValue` telemetry event.
     - In all cases the dblclick path excludes the kebab pill and twisty toggle the same way single-click selection does, so clicking those buttons twice never triggers the row dblclick handler.
+  - **Right-click context menu - dblclick-mirror mandate**: the right-click and kebab context menus always surface the row's current double-click action with bold styling (`.ctx-default-action`) and a `.sr-only` "same as double-clicking the row" hint. The bolded rendering site depends on row type: for primitives and empty containers the **top `Copy value` row** is bolded (since dblclick copies); for **containers with children** a separate row near the bottom of the Reshape section is bolded (since dblclick toggles expansion). Other top-level items added later (e.g., the `Expand all from here` row introduced in v0.23.0) must be **non-bolded** so the dblclick mirror remains visually unique - the bolded surfaced shortcut is the only menu item that carries `.ctx-default-action` and the "same as double-clicking" affordance.
   - **Keyboard copy (Ctrl+C / Cmd+C with tree focus)**: when a tree row has DOM focus, pressing `Ctrl+C` (Windows / Linux) or `Cmd+C` (macOS) copies that row's value to the clipboard with the same extraction semantics as the menu's **Copy value** action (raw text for primitives, pretty-printed JSON for containers). Unlike dblclick, the keyboard shortcut works on **every row, including empty containers** (`{}` / `[]`) - the user explicitly asked for "parent or leaf" parity, and keyboard copy has no expand/collapse alternative meaning to disambiguate. Expansion state is never altered. Modifier matching is strict: `Ctrl+Shift+C` (devtools) and `Ctrl+Alt+C` (AltGr on international layouts) are intentional no-ops; Alt is not honored, so this path always emits the raw (un-escaped) variant. Emits the `tree.keyboard.copyValue` telemetry event with `{ escaped: false }`.
   - **Search highlight** - a persistent search field is positioned above the tree view panel (on its own row, full-width, above the expansion controls):
     - User types arbitrary text into the search field; matching is **live** as they type (debounced ~150ms).
@@ -2327,6 +2328,57 @@ Out of scope (for v1):
   bundle will fail `PUT /api/me` with the legacy field until
   refresh - same trade-off as the `historyTrackingMode ->
   recentlyViewedEnabled` precedent.
+- **0.23.0**: Tree row context-menu UX overhaul -- single entry
+  point for "Expand all from here" + depth-submenu range mirrors
+  the toolbar + dblclick-mirror mandate documented. Three coupled
+  changes: (1) New top-level **Expand all from here** row in the
+  per-row right-click / kebab context menu (between the bolded
+  surfaced dblclick-mirror row and the `Subtree >` submenu),
+  gated on the existing `showExpandAllFromHere(node)` predicate
+  AND the new `hasContainerDescendants(node)` predicate (so
+  primitives-only containers, where `expandAll` produces the same
+  end state as the bolded `Expand 1 level` surfaced shortcut,
+  fall through to the surfaced row alone -- no cross-row
+  duplication). Telemetry: `tree.contextMenu.expandAllFromHere`
+  emits `{ source: 'topRow' }` (non-bolded; distinct from sibling
+  events' `'top'`). The deep `Subtree > Expand > All` leaf is
+  retired alongside the in-Subtree `'expandAll'` elevation; the
+  `ExpandSingleAction` type union drops its `{ kind: 'expandAll' }`
+  variant entirely so the dead arms in `expandSingleElevatedLabel`
+  / `onExpandSingleElevatedClick` are removed under type
+  pressure. (2) Per-row `Subtree > Expand` sub-submenu range
+  extended from `+1..+5` to `+1..+9` to mirror the toolbar's
+  `Expand to Level` dropdown range; the existing
+  `showExpandToDepth(node, N)` predicate continues to hide depths
+  the subtree cannot reach, so the new `+6..+9` entries are
+  visible only on subtrees deep enough to need them.
+  `tree.contextMenu.expandToDepth` now ranges `relativeDepth: 1..9`
+  for `source === 'submenu'`. (3) Right-click context menu
+  **dblclick-mirror mandate** documented in §Tree View Panel:
+  the bolded `.ctx-default-action` surfaced row always mirrors
+  the row's current double-click action (Copy value for
+  primitives / empty containers; expand-1-level or collapse for
+  containers with children); new top-level items added later
+  must be non-bolded so the dblclick mirror remains visually
+  unique. Also retires the now-unreachable `'expandSame'`
+  sentinel from the `SubtreeElevatedAction` union and the
+  matching arm in `subtreeElevatedAction`: the same suppression
+  is now handled upstream by the new private
+  `isLoneDepth1RedundantWithSurfaced` predicate, which returns
+  `true` when `maxDescendantDepth(node) === 1 AND
+  defaultActionKind() === 'expandRow'`, propagating zero through
+  `expandFromHereItemCount` / null through
+  `expandFromHereSingleAction` / false through
+  `showExpandFromHereMenu`. Reconciles the v0.19.5 entry's
+  prose: the `'expandSame'` sentinel originally introduced in
+  v0.19.5 is removed in v0.23.0 because its sole firing
+  condition is now covered by the new predicate earlier in the
+  pipeline. Click-cost change: `Expand all from here` was 2-4
+  clicks (depending on Subtree contribution mix), now uniformly
+  2 clicks via the new top-level row whenever the action is
+  reachable. The `+1..+5` paths are unchanged at 3 clicks; the
+  new `+6..+9` paths arrive at 3 clicks (previously unreachable
+  from the per-row menu).
 - **0.21.0**: Tree view virtualization (issue #95 Phase 2). The
   `<mat-tree>` + `<mat-nested-tree-node>` render path is replaced
   with `<cdk-virtual-scroll-viewport>` + `*cdkVirtualFor` from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.22.0",
+  "version": "0.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.22.0",
+      "version": "0.23.0",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.22.1",
+  "version": "0.23.0",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -1318,13 +1318,31 @@ export const TELEMETRY_MESSAGE_IDS = [
    * Severity: info
    * Fired by: `JsonTreeComponent.expandAllFromHere`
    *           (`shared/components/json-tree/json-tree.component.ts`).
-   *           Reachable only via the in-Subtree submenu's `Expand >
-   *           All` leaf after Path Y; the surfaced top-level shortcut
-   *           never fires this event (it routes through
-   *           `expandToDepth` with `relativeDepth: 1`).
-   * Props: { source: 'top' | 'submenu' }. Always `'submenu'` after
-   * Path Y; the prop is present for symmetry with `collapse` /
-   * `expandToDepth` so KQL filters can apply uniformly.
+   *           v0.23.0+: single entry point -- the new top-level
+   *           `Expand all from here` row in the row/kebab menu.
+   *           The deep `Subtree > Expand > All` leaf and the
+   *           in-Subtree `expandAll` elevation were both retired
+   *           in v0.23.0. Gated on `showExpandAllFromHere(node) &&
+   *           hasContainerDescendants(node)` so primitives-only
+   *           containers (where `expandAll` produces the same end
+   *           state as the bolded `Expand 1 level` surfaced
+   *           shortcut) fall through to the surfaced row alone.
+   * Props: { source: 'topRow' }. Always `'topRow'` post-v0.23.0
+   * (the only callable enum value; if a future change re-elevates
+   * `expandAll` from another location it must add a new enum value
+   * here with documentation).
+   *
+   * **Sink:** `traces` (via `logger.info()`) until issue #241
+   * migrates `tree.*` events to `customEvents`.
+   *
+   * **Note for KQL authors:** unlike sibling events
+   * `tree.contextMenu.collapse` and `tree.contextMenu.expandToDepth`
+   * which use `source: 'top'` for their bolded surfaced shortcut
+   * callers, this event uses `source: 'topRow'` because the new
+   * top-level item is **non-bolded**. A naive cross-event filter
+   * `where customDimensions.source == 'top'` will silently miss
+   * the expandAll signal. Use `where customDimensions.source in
+   * ('top', 'topRow')` for unioned queries.
    */
   'tree.contextMenu.expandAllFromHere',
 
@@ -1335,12 +1353,20 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           Wired to the surfaced top-level "Expand 1 level"
    *           shortcut row (which routes here with `relativeDepth: 1`
    *           and `source: 'top'`) AND to the in-Subtree submenu's
-   *           per-depth items (`+1, +2, +3, +4, +5`).
+   *           per-depth items (`+1, +2, ..., +9`). The in-Subtree
+   *           range extended from `+1..+5` to `+1..+9` in v0.23.0
+   *           to mirror the toolbar's `Expand to Level` dropdown.
    * Props: { relativeDepth: number, source: 'top' | 'submenu' }.
-   * `relativeDepth` is the N in "expand N levels from here"; lets us
-   * see which depths users invoke most often. `source` disambiguates
-   * the surfaced top-level shortcut from the in-Subtree item the
-   * same way as `collapse`.
+   * `relativeDepth` is the N in "expand N levels from here";
+   * post-v0.23.0 it ranges over `1..9` for `source === 'submenu'`
+   * and is always `1` for `source === 'top'`. Lets us see which
+   * depths users invoke most often.
+   *
+   * **Workbook caveat:** any time-bucketed query that filters
+   * `relativeDepth in (1,2,3,4,5)` will silently drop the new
+   * `6..9` values introduced in v0.23.0. Widen any such filter
+   * to `relativeDepth in (1,2,3,4,5,6,7,8,9)` or drop the IN
+   * filter entirely.
    */
   'tree.contextMenu.expandToDepth',
 

--- a/src/app/shared/components/json-tree/json-tree.component.expandedPaths-invariant.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.expandedPaths-invariant.spec.ts
@@ -170,7 +170,7 @@ describe('JsonTreeComponent expandedPaths invariant', () => {
     cmp.collapseAll();
     fixture.detectChanges();
     const aNode = findNodeByPath('$.a');
-    cmp.expandAllFromHere(aNode);
+    cmp.expandAllFromHere(aNode, 'topRow');
     fixture.detectChanges();
     const expanded = readExpanded();
     expect(expanded.has('$.a')).toBeTrue();

--- a/src/app/shared/components/json-tree/json-tree.component.html
+++ b/src/app/shared/components/json-tree/json-tree.component.html
@@ -702,12 +702,23 @@
         <span>{{ ctxFindByValueLabel }}</span>
       </button>
     }
-    <!-- Reshape section: surfaced default-shortcut + Subtree submenu.
+    <!-- Reshape section: surfaced default-shortcut + new top-level
+         `Expand all from here` row (v0.23.0) + Subtree submenu.
          The surfaced row carries the .ctx-default-action class only
          here (not at the top Copy value row) when the dblclick action
          is collapse / expand-1-level. For primitives and empty
-         containers the bolding lives on Copy value at the top. -->
-    @if (surfacedShortcutLabel() || showSubtreeMenu(cn)) {
+         containers the bolding lives on Copy value at the top. The
+         new `Expand all from here` row is non-bolded so the dblclick
+         mirror remains visually unique (DESIGN_SPEC.md §Tree View
+         Panel -- dblclick-mirror mandate). It is gated on
+         `hasContainerDescendants(cn)` so primitives-only containers
+         (where `expandAll` produces the same end state as the bolded
+         `Expand 1 level`) fall through to the surfaced shortcut alone. -->
+    @if (
+      surfacedShortcutLabel() ||
+      (showExpandAllFromHere(cn) && hasContainerDescendants(cn)) ||
+      showSubtreeMenu(cn)
+    ) {
       <mat-divider />
     }
     @if (surfacedShortcutLabel(); as label) {
@@ -722,6 +733,11 @@
         }
         <span>{{ label }}</span>
         <span class="sr-only">{{ defaultActionA11yHint }}</span>
+      </button>
+    }
+    @if (showExpandAllFromHere(cn) && hasContainerDescendants(cn)) {
+      <button mat-menu-item type="button" (click)="expandAllFromHere(cn, 'topRow')">
+        <span>{{ ctxExpandAllFromHereElevatedLabel }}</span>
       </button>
     }
     @if (showSubtreeMenu(cn)) {
@@ -740,9 +756,12 @@
         submenu would only contain one visible action, that action
         is rendered directly in the row menu instead of nested
         behind a `Subtree >` flyout. Eliminates the "open submenu
-        with only one option" UX. `'collapseSame'` and `'expandSame'`
-        sentinels suppress entirely (the action is already on the
-        surfaced default-shortcut row).
+        with only one option" UX. The `'collapseSame'` sentinel
+        suppresses entirely (the action is already on the surfaced
+        default-shortcut row). v0.23.0 retired the `'expandSame'`
+        sentinel: the equivalent suppression for the lone-+1 Expand
+        case is now handled upstream by
+        `isLoneDepth1RedundantWithSurfaced`.
       -->
       @switch (elevated.kind) {
         @case ('highlightTree') {
@@ -877,8 +896,17 @@
         when the Expand sub-submenu would only contain one item,
         that item renders inline within Subtree instead of nested
         behind another `Expand >` flyout. Label uses the elevated
-        form (e.g. "Expand all from here") because the submenu's
-        scope is no longer carried by an "Expand" name.
+        form (e.g. "Expand 2 levels from here") because the
+        submenu's scope is no longer carried by an "Expand" name.
+        v0.23.0: this elevation no longer fires for `expandAll`
+        (the new top-level `Expand all from here` row covers it
+        directly) nor for the lone-+1 case under `expandRow`
+        defaults (suppressed by
+        `isLoneDepth1RedundantWithSurfaced` so the bolded
+        surfaced shortcut is not duplicated). Reaches here only
+        for lone-+N depth-only cases with N>=2 OR N=1 under
+        `collapseRow` defaults (rare; e.g., expanded outer +
+        collapsed deep descendant).
       -->
       <button mat-menu-item type="button" (click)="onExpandSingleElevatedClick(cn, single)">
         <jj-icon name="expand-subtree" [size]="18" />
@@ -892,27 +920,16 @@
   Expand-from-here sub-submenu (inside Subtree). Per DESIGN_SPEC.md
   §516, depth labels carry "+N" prefix to distinguish relative
   expand-only semantics from the toolbar's absolute "Expand to Level"
-  dropdown. "All" reuses the existing @@tree.contextMenu.expandAllFromHere
-  i18n ID with new source text "All" (the longer "Expand all from
-  here" reading would duplicate the parent submenu name).
+  dropdown. v0.23.0 retired the leading `All` leaf -- the new
+  top-level `Expand all from here` row in the row menu covers the
+  same action with one fewer click. The depth range extended from
+  `+1..+5` to `+1..+9` to mirror the toolbar's `Expand to Level`
+  range. `showExpandToDepth` hides entries beyond the subtree's
+  reachable container depth, so `+6..+9` only render for subtrees
+  deep enough to need them.
 -->
 <mat-menu #expandFromHereMenu="matMenu" class="jj-menu tree-row-menu">
   @if (contextNode(); as cn) {
-    @if (showExpandAllFromHere(cn)) {
-      <button mat-menu-item type="button" (click)="expandAllFromHere(cn)">
-        {{ ctxSubtreeExpandAllLabel }}
-      </button>
-    }
-    @if (
-      showExpandAllFromHere(cn) &&
-      (showExpandToDepth(cn, 1) ||
-        showExpandToDepth(cn, 2) ||
-        showExpandToDepth(cn, 3) ||
-        showExpandToDepth(cn, 4) ||
-        showExpandToDepth(cn, 5))
-    ) {
-      <mat-divider />
-    }
     @if (showExpandToDepth(cn, 1)) {
       <button mat-menu-item type="button" (click)="expandToDepthFromHere(cn, 1)">
         {{ ctxExpandToDepth1Label }}
@@ -936,6 +953,26 @@
     @if (showExpandToDepth(cn, 5)) {
       <button mat-menu-item type="button" (click)="expandToDepthFromHere(cn, 5)">
         {{ ctxExpandToDepth5Label }}
+      </button>
+    }
+    @if (showExpandToDepth(cn, 6)) {
+      <button mat-menu-item type="button" (click)="expandToDepthFromHere(cn, 6)">
+        {{ ctxExpandToDepth6Label }}
+      </button>
+    }
+    @if (showExpandToDepth(cn, 7)) {
+      <button mat-menu-item type="button" (click)="expandToDepthFromHere(cn, 7)">
+        {{ ctxExpandToDepth7Label }}
+      </button>
+    }
+    @if (showExpandToDepth(cn, 8)) {
+      <button mat-menu-item type="button" (click)="expandToDepthFromHere(cn, 8)">
+        {{ ctxExpandToDepth8Label }}
+      </button>
+    }
+    @if (showExpandToDepth(cn, 9)) {
+      <button mat-menu-item type="button" (click)="expandToDepthFromHere(cn, 9)">
+        {{ ctxExpandToDepth9Label }}
       </button>
     }
   }

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -6751,31 +6751,43 @@ describe('JsonTreeComponent', () => {
       });
 
       it('top-level Expand all row is not bolded (dblclick-mirror mandate guardrail)', async () => {
+        // Setup: expand the root so $.outer is rendered, then
+        // collapse from $.outer so showExpandAllFromHere(outer) is
+        // true (subtree is not fully expanded).
         await createWith({ outer: { mid: { inner: 1 } } });
-        cmp.collapseAll();
+        cmp.expandAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
-        cmp.contextNode.set(outer);
+        cmp.collapseFromHere(outer);
         fixture.detectChanges();
-        // Open the row menu via the kebab pill so MatMenu renders.
-        const kebab = fixture.nativeElement.querySelector(
-          `[data-tree-kebab-path="${outer.pathString}"]`,
-        ) as HTMLButtonElement | null;
-        if (kebab) {
-          kebab.click();
-          fixture.detectChanges();
-        }
-        const overlayItems = Array.from(
-          document.querySelectorAll('.cdk-overlay-container .mat-mdc-menu-item'),
-        ) as HTMLElement[];
-        const expandAllRow = overlayItems.find(
-          (el) => (el.textContent ?? '').trim() === 'Expand all from here',
+        // Precondition: the new top-level row must render under
+        // this fixture or the guardrail test is meaningless.
+        expect(cmp.showExpandAllFromHere(outer))
+          .withContext('precondition: row must be visible')
+          .toBeTrue();
+        expect(cmp.hasContainerDescendants(outer))
+          .withContext('precondition: row must be visible')
+          .toBeTrue();
+        await openMenuFor('$.outer');
+        const items = Array.from(
+          document.body.querySelectorAll<HTMLButtonElement>('button.mat-mdc-menu-item'),
         );
-        if (expandAllRow) {
-          expect(expandAllRow.classList.contains('ctx-default-action'))
-            .withContext('Top-level Expand all row must NOT carry .ctx-default-action')
-            .toBeFalse();
-        }
+        const expandAllRow = items.find(
+          (el) => (el.textContent ?? '').trim() === cmp.ctxExpandAllFromHereElevatedLabel,
+        );
+        // Hard assertion: the row MUST be in the rendered menu. A
+        // missing row would be a regression in the gating predicate
+        // or the template, not an acceptable test soft-pass.
+        expect(expandAllRow)
+          .withContext('Top-level Expand all from here row must render')
+          .toBeTruthy();
+        expect(expandAllRow!.classList.contains('ctx-default-action'))
+          .withContext('Top-level Expand all row must NOT carry .ctx-default-action')
+          .toBeFalse();
+        document.body
+          .querySelectorAll('.cdk-overlay-backdrop')
+          .forEach((b) => (b as HTMLElement).click());
+        fixture.detectChanges();
       });
 
       // ---- v0.23.0: deep `All` leaf retired ----

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -1262,7 +1262,7 @@ describe('JsonTreeComponent', () => {
       await createExpandFixture();
       const eventSpy = spyOn(TestBed.inject(LoggerService), 'event');
       spyOn(performance, 'now').and.returnValues(0, 9);
-      cmp.expandAllFromHere(nodeAt('$.a'));
+      cmp.expandAllFromHere(nodeAt('$.a'), 'topRow');
       expect(hasExpandSlowEvent(eventSpy)).toBeFalse();
     });
 
@@ -1271,8 +1271,8 @@ describe('JsonTreeComponent', () => {
       const eventSpy = spyOn(TestBed.inject(LoggerService), 'event');
       spyOn(performance, 'now').and.returnValues(0, 51, 100, 152);
       const startNode = nodeAt('$.a');
-      cmp.expandAllFromHere(startNode);
-      cmp.expandAllFromHere(startNode);
+      cmp.expandAllFromHere(startNode, 'topRow');
+      cmp.expandAllFromHere(startNode, 'topRow');
       expect(eventSpy.calls.allArgs().filter((args) => args[0] === 'tree.expand.slow')).toEqual([
         ['tree.expand.slow', { cold: true }, { timeMs: 51, depth: 1, nodeCount: 2 }],
         ['tree.expand.slow', { cold: false }, { timeMs: 52, depth: 1, nodeCount: 2 }],
@@ -5691,7 +5691,7 @@ describe('JsonTreeComponent', () => {
         cmp.collapseAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
-        cmp.expandAllFromHere(outer);
+        cmp.expandAllFromHere(outer, 'topRow');
         expect(cmp.__getHelpersForTesting().isExpanded(outer)).toBe(true);
         expect(cmp.__getHelpersForTesting().isExpanded(nodeAt('$.outer.mid'))).toBe(true);
       });
@@ -6559,25 +6559,30 @@ describe('JsonTreeComponent', () => {
     });
 
     describe('single-item elevation (v0.19.4)', () => {
-      it('expandFromHereSingleAction returns expandAll when only Expand all is visible', async () => {
-        // Container with only primitive children: maxDescendantDepth=0
-        // (no container descendants), so +N predicates all hide. Expand
-        // all is the lone Expand contribution, ready to elevate.
+      it('expandFromHereSingleAction returns null when Expand from here has zero depth options', async () => {
+        // v0.23.0: container with only primitive children
+        // (maxDescendantDepth=0). No +N predicates fire and the
+        // deep `All` leaf was retired (covered by the new
+        // top-level `Expand all from here` row); the per-row
+        // Expand-from-here flyout has nothing to show, so
+        // expandFromHereSingleAction returns null and the
+        // Expand-from-here sub-submenu is hidden.
         await createWith({ outer: { x: 1, y: 2 } });
         cmp.collapseAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
-        const single = cmp.expandFromHereSingleAction(outer);
-        expect(single).toEqual({ kind: 'expandAll' });
+        expect(cmp.expandFromHereSingleAction(outer)).toBeNull();
         expect(cmp.showExpandFromHereSubmenu(outer))
-          .withContext('Expand sub-submenu hides for single item')
+          .withContext('Expand sub-submenu hides when zero depths reachable')
           .toBeFalse();
       });
 
       it('expandFromHereSingleAction returns null when 2+ items are visible', async () => {
-        // Two-level nesting with container descendants: +1 and All
-        // both visible (different end states). No single elevation.
-        await createWith({ outer: { mid: { inner: 1 } } });
+        // Three-level nesting with container descendants:
+        // maxDescendantDepth=2 so +1 AND +2 are both visible
+        // (different end states), and isLoneDepth1RedundantWithSurfaced
+        // is false. Two items reachable -> no single elevation.
+        await createWith({ outer: { mid: { inner: { leaf: 1 } } } });
         cmp.collapseAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
@@ -6613,36 +6618,48 @@ describe('JsonTreeComponent', () => {
           .toBeFalse();
       });
 
-      it('subtreeElevatedAction returns expandSingle for collapsed container with only primitives', async () => {
-        // A collapsed container with only primitive children:
-        //   - showCollapse: false (not expanded)
-        //   - showIsolate*: false (no peers expanded)
-        //   - showHighlight*: false (canEditHighlights false)
-        //   - showExpandFromHereMenu: true (Expand all is meaningful)
-        //   - expandFromHereSingleAction: { kind: 'expandAll' }
-        // Surfaced shortcut = Expand 1 level (expandRow), single
-        // Expand action is expandAll (NOT depth=1) -> elevate as
-        // 'expandSingle' (no expandSame suppression).
+      it('subtreeElevatedAction returns null for collapsed container with only primitives (v0.23.0)', async () => {
+        // v0.23.0: a collapsed container with only primitive
+        // children (maxDescendantDepth=0):
+        //   - expandFromHereItemCount=0 (no +N reachable, deep
+        //     `All` leaf retired)
+        //   - showExpandFromHereMenu=false
+        //   - no other Subtree contributors (canEditHighlights=false)
+        // -> subtreeItemCount=0, subtreeElevatedAction=null,
+        //    showSubtreeMenu=false. The new top-level `Expand
+        //    all from here` row is hidden too (gated on
+        //    hasContainerDescendants), so the bolded surfaced
+        //    `Expand 1 level` row is the sole expand entry.
         await createWith({ obj: { a: 1, b: 2 } });
         cmp.collapseAll();
         fixture.detectChanges();
         const obj = nodeAt('$.obj');
         cmp.contextNode.set(obj);
         expect(cmp.defaultActionKind()).toBe('expandRow');
-        const elevated = cmp.subtreeElevatedAction(obj);
-        expect(elevated?.kind).toBe('expandSingle');
-        if (elevated?.kind === 'expandSingle') {
-          expect(elevated.single).toEqual({ kind: 'expandAll' });
-        }
+        expect(cmp.subtreeElevatedAction(obj)).toBeNull();
+        expect(cmp.showSubtreeMenu(obj))
+          .withContext(
+            'Subtree submenu hides when only Expand-from-here was contributing and it has nothing to show',
+          )
+          .toBeFalse();
+        expect(cmp.showExpandAllFromHere(obj))
+          .withContext('Expand all from here remains conceptually reachable')
+          .toBeTrue();
+        expect(cmp.hasContainerDescendants(obj))
+          .withContext(
+            'No container descendants -> new top-level row also hides (avoids duplication with surfaced shortcut)',
+          )
+          .toBeFalse();
       });
 
       it('subtreeElevatedAction returns expandSubmenu when Expand has 2+ items as the lone Subtree contribution', async () => {
-        // Collapsed container with nested containers: showCollapse
-        // false (not expanded), no isolate / highlight, but Expand
-        // has both +1 and All visible -> 2 items. Subtree count
-        // is 1 (the whole Expand "section" counts as one), so
-        // Subtree elevates the Expand submenu trigger to row level.
-        await createWith({ outer: { mid: { inner: 1 } } });
+        // v0.23.0: with the lone-+1 suppression (isLoneDepth1Redundant-
+        // WithSurfaced), the {outer:{mid:{inner:1}}} fixture would
+        // now collapse to subtreeItemCount=0 and showSubtreeMenu=false.
+        // Swap to {outer:{mid:{inner:{leaf:1}}}} so maxDescendantDepth=2,
+        // count=2 (+1 and +2), exercising the original `expandSubmenu`
+        // arm as intended.
+        await createWith({ outer: { mid: { inner: { leaf: 1 } } } });
         cmp.collapseAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
@@ -6669,6 +6686,260 @@ describe('JsonTreeComponent', () => {
         fixture.detectChanges();
         const child = nodeAt('$.parent.child');
         expect(cmp.subtreeElevatedAction(child)).toEqual({ kind: 'removeTreeHighlight' });
+      });
+
+      // ---- v0.23.0: top-level `Expand all from here` row ----
+
+      it('top-level Expand all row renders when subtree has container descendants', async () => {
+        await createWith({ outer: { mid: { inner: 1 } } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        cmp.contextNode.set(outer);
+        expect(cmp.showExpandAllFromHere(outer))
+          .withContext('showExpandAllFromHere true: subtree has collapsed container descendant')
+          .toBeTrue();
+        expect(cmp.hasContainerDescendants(outer))
+          .withContext('hasContainerDescendants true: mid is a container descendant')
+          .toBeTrue();
+      });
+
+      it('top-level Expand all row hides for primitives-only collapsed containers', async () => {
+        await createWith({ outer: { x: 1, y: 2 } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        cmp.contextNode.set(outer);
+        expect(cmp.showExpandAllFromHere(outer))
+          .withContext('Expand all still conceptually meaningful (outer is collapsed)')
+          .toBeTrue();
+        expect(cmp.hasContainerDescendants(outer))
+          .withContext(
+            'No container descendants -> top-level row hides (avoids duplicating surfaced shortcut)',
+          )
+          .toBeFalse();
+      });
+
+      it('top-level Expand all row hides for primitive leaves and empty containers', async () => {
+        await createWith({ alpha: 1, empty: {} });
+        fixture.detectChanges();
+        const alpha = nodeAt('$.alpha');
+        const empty = nodeAt('$.empty');
+        expect(cmp.showExpandAllFromHere(alpha)).toBeFalse();
+        expect(cmp.showExpandAllFromHere(empty)).toBeFalse();
+      });
+
+      it('top-level Expand all row hides when subtree is fully expanded', async () => {
+        await createWith({ outer: { mid: { inner: 1 } } });
+        cmp.expandAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        expect(cmp.showExpandAllFromHere(outer))
+          .withContext('Nothing collapsed downstream -> nothing to expand')
+          .toBeFalse();
+      });
+
+      it('top-level Expand all click fires expandAllFromHere with source=topRow', async () => {
+        const logger = await createWithLoggerSpy({ outer: { mid: { inner: 1 } } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        cmp.expandAllFromHere(outer, 'topRow');
+        expect(logger.info).toHaveBeenCalledWith('tree.contextMenu.expandAllFromHere', {
+          source: 'topRow',
+        });
+      });
+
+      it('top-level Expand all row is not bolded (dblclick-mirror mandate guardrail)', async () => {
+        await createWith({ outer: { mid: { inner: 1 } } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        cmp.contextNode.set(outer);
+        fixture.detectChanges();
+        // Open the row menu via the kebab pill so MatMenu renders.
+        const kebab = fixture.nativeElement.querySelector(
+          `[data-tree-kebab-path="${outer.pathString}"]`,
+        ) as HTMLButtonElement | null;
+        if (kebab) {
+          kebab.click();
+          fixture.detectChanges();
+        }
+        const overlayItems = Array.from(
+          document.querySelectorAll('.cdk-overlay-container .mat-mdc-menu-item'),
+        ) as HTMLElement[];
+        const expandAllRow = overlayItems.find(
+          (el) => (el.textContent ?? '').trim() === 'Expand all from here',
+        );
+        if (expandAllRow) {
+          expect(expandAllRow.classList.contains('ctx-default-action'))
+            .withContext('Top-level Expand all row must NOT carry .ctx-default-action')
+            .toBeFalse();
+        }
+      });
+
+      // ---- v0.23.0: deep `All` leaf retired ----
+
+      it('Subtree > Expand sub-submenu no longer contains an All leaf', async () => {
+        // Pre-v0.23.0, this primitives-only fixture would have made
+        // expandFromHereSingleAction return { kind: 'expandAll' }
+        // (the deep `All` leaf was the lone count contribution).
+        // Post-v0.23.0 the leaf is retired: count = 0, single = null,
+        // and the new top-level row is hidden too (hasContainerDescendants
+        // is false). The bolded surfaced shortcut covers the action.
+        await createWith({ outer: { x: 1, y: 2 } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        cmp.contextNode.set(outer);
+        expect(cmp.expandFromHereSingleAction(outer)).toBeNull();
+        expect(cmp.showExpandFromHereMenu(outer)).toBeFalse();
+        expect(cmp.hasContainerDescendants(outer)).toBeFalse();
+      });
+
+      // ---- v0.23.0: lone-+1 in-Subtree elevation suppression ----
+
+      it('lone-+1 in-Subtree elevation is suppressed under expandRow defaults (no duplication with surfaced row)', async () => {
+        await createWith({ outer: { mid: { inner: 1 } } });
+        // Cascade highlight to give Subtree a second contributor so it
+        // would render but for the v7 predicate.
+        fixture.componentRef.setInput('canEditHighlights', true);
+        fixture.componentRef.setInput('highlights', [
+          { path: '$.outer', color: '#7e6500', cascade: true },
+        ]);
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        cmp.contextNode.set(outer);
+        expect(cmp.defaultActionKind()).toBe('expandRow');
+        // Indirect maxDescendantDepth=1 check: +1 would be visible
+        // (clause-2 satisfies via outer being collapsed) but +2 is
+        // not (mid has only a primitive child, no container at
+        // relative depth 1 within mid).
+        expect(cmp.hasContainerDescendants(outer))
+          .withContext('mid is a container descendant')
+          .toBeTrue();
+        // Predicate fires -> Expand-from-here disappears entirely
+        // (no items, no single elevation, submenu hides).
+        expect(cmp.expandFromHereSingleAction(outer)).toBeNull();
+        expect(cmp.showExpandFromHereSubmenu(outer)).toBeFalse();
+        expect(cmp.showExpandFromHereMenu(outer)).toBeFalse();
+      });
+
+      it('lone-+N in-Subtree elevation still fires for non-expandRow defaults', async () => {
+        // Fixture: deep subtree where the clicked node is already
+        // expanded (so defaultActionKind === 'collapseRow') but two
+        // descendant containers remain collapsed at relative depth 1
+        // and 2. Only `+2` satisfies the showExpandToDepth predicate
+        // for the clicked node (since +1 requires a collapsed
+        // container at relative depth < 1, i.e. the clicked node
+        // itself, which is expanded; +3+ fail clause 1 because
+        // maxDescendantDepth(outer)=2). Result: count=1, single is
+        // `{ kind: 'expandToDepth', depth: 2 }`.
+        await createWith({ outer: { mid: { inner: { leaf: 1 } } } });
+        fixture.componentRef.setInput('canEditHighlights', true);
+        fixture.componentRef.setInput('highlights', [
+          { path: '$.outer', color: '#7e6500', cascade: true },
+        ]);
+        cmp.collapseAll();
+        fixture.detectChanges();
+        // Expand only outer; leave mid and inner collapsed.
+        const outer = nodeAt('$.outer');
+        cmp.expandToDepthFromHere(outer, 1);
+        fixture.detectChanges();
+        cmp.contextNode.set(outer);
+        expect(cmp.defaultActionKind())
+          .withContext('Outer is expanded -> default is collapseRow')
+          .toBe('collapseRow');
+        // +1 hides (outer expanded), +2 visible (mid collapsed at d=1),
+        // +3..+9 hide (clause 1 fails when maxDescendantDepth=2).
+        expect(cmp.showExpandToDepth(outer, 1)).toBeFalse();
+        expect(cmp.showExpandToDepth(outer, 2)).toBeTrue();
+        expect(cmp.showExpandToDepth(outer, 3)).toBeFalse();
+        // Single elevation should fire with depth=2 (count=1 implies
+        // showExpandFromHereSubmenu=false but showExpandFromHereMenu=true).
+        expect(cmp.showExpandFromHereSubmenu(outer)).toBeFalse();
+        expect(cmp.showExpandFromHereMenu(outer)).toBeTrue();
+        expect(cmp.expandFromHereSingleAction(outer)).toEqual({
+          kind: 'expandToDepth',
+          depth: 2,
+        });
+      });
+
+      // ---- v0.23.0: depth +6..+9 visibility + telemetry ----
+
+      it('Expand from here +6..+9 are visible on deep enough subtrees', async () => {
+        // Build a 9-level deep nesting.
+        const deep: Record<string, unknown> = { v: 1 };
+        let depth = 9;
+        let cursor: Record<string, unknown> = deep;
+        while (depth > 0) {
+          const next: Record<string, unknown> = { v: 1 };
+          cursor['n'] = next;
+          cursor = next;
+          depth -= 1;
+        }
+        await createWith({ root: deep });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const root = nodeAt('$.root');
+        // Each level should be reachable from root.
+        for (let n = 1; n <= 9; n++) {
+          expect(cmp.showExpandToDepth(root, n))
+            .withContext(`+${n} should be visible on a 9-deep subtree`)
+            .toBeTrue();
+        }
+      });
+
+      it('Expand from here +6..+9 are hidden on shallow subtrees', async () => {
+        await createWith({ outer: { mid: { inner: { leaf: 1 } } } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        // Indirect maxDescendantDepth=2 check: +2 visible, +3 hidden.
+        expect(cmp.showExpandToDepth(outer, 2))
+          .withContext('+2 visible (maxDescendantDepth >= 2)')
+          .toBeTrue();
+        expect(cmp.showExpandToDepth(outer, 3))
+          .withContext('+3 hidden (maxDescendantDepth < 3)')
+          .toBeFalse();
+        for (let n = 3; n <= 9; n++) {
+          expect(cmp.showExpandToDepth(outer, n))
+            .withContext(`+${n} must hide on a 2-deep subtree`)
+            .toBeFalse();
+        }
+      });
+
+      it('Expand from here +6..+9 emit relativeDepth in telemetry', async () => {
+        const deep: Record<string, unknown> = { v: 1 };
+        let depth = 9;
+        let cursor: Record<string, unknown> = deep;
+        while (depth > 0) {
+          const next: Record<string, unknown> = { v: 1 };
+          cursor['n'] = next;
+          cursor = next;
+          depth -= 1;
+        }
+        const logger = await createWithLoggerSpy({ root: deep });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const root = nodeAt('$.root');
+        for (let n = 6; n <= 9; n++) {
+          (logger.info as jasmine.Spy).calls.reset();
+          cmp.expandToDepthFromHere(root, n);
+          expect(logger.info).toHaveBeenCalledWith('tree.contextMenu.expandToDepth', {
+            relativeDepth: n,
+            source: 'submenu',
+          });
+        }
+      });
+
+      it('expandSingleElevatedLabel returns depth-N elevated label for depth 1..9', async () => {
+        await createWith({ outer: { x: 1 } });
+        for (let depth = 1; depth <= 9; depth++) {
+          const label = cmp.expandSingleElevatedLabel({ kind: 'expandToDepth', depth });
+          expect(label).withContext(`depth=${depth}`).toBeTruthy();
+        }
       });
     });
 
@@ -6767,13 +7038,13 @@ describe('JsonTreeComponent', () => {
         });
       });
 
-      it('emits tree.contextMenu.expandAllFromHere with source=submenu', async () => {
+      it('emits tree.contextMenu.expandAllFromHere with source=topRow', async () => {
         const logger = await createWithLoggerSpy({ outer: { a: { x: 1 } } });
         cmp.collapseAll();
         fixture.detectChanges();
-        cmp.expandAllFromHere(nodeAt('$.outer'));
+        cmp.expandAllFromHere(nodeAt('$.outer'), 'topRow');
         expect(logger.info).toHaveBeenCalledWith('tree.contextMenu.expandAllFromHere', {
-          source: 'submenu',
+          source: 'topRow',
         });
       });
 

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -213,9 +213,11 @@ interface ManualHighlightRows {
  * - `'expandSingle'`: the only Subtree contribution is the Expand
  *   section, AND that section has exactly one visible item, AND that
  *   item is not already on the surfaced shortcut. The single Expand
- *   action also elevates past the (would-be) Expand flyout.
- * - `'expandSame'`: same as `'collapseSame'` for the Expand-1-level
- *   case. Suppress.
+ *   action also elevates past the (would-be) Expand flyout. The
+ *   `expandRow`-default + `maxDescendantDepth === 1` case (lone +1
+ *   redundant with the bolded surfaced shortcut) is suppressed
+ *   upstream by `isLoneDepth1RedundantWithSurfaced`, so that
+ *   condition never reaches this elevation arm in v0.23.0+.
  * - `'expandSubmenu'`: the only Subtree contribution is the Expand
  *   section with 2+ items. The Expand flyout itself is elevated
  *   (renders directly off the row menu instead of nested inside
@@ -228,7 +230,6 @@ type SubtreeElevatedAction =
   | { kind: 'collapseSame' }
   | { kind: 'isolate'; mode: 'single' }
   | { kind: 'expandSingle'; single: ExpandSingleAction }
-  | { kind: 'expandSame' }
   | { kind: 'expandSubmenu' };
 
 /**
@@ -236,8 +237,13 @@ type SubtreeElevatedAction =
  * Expand sub-submenu (v0.19.4). When the Expand sub-submenu would
  * only contain one visible item, that item elevates one level up
  * (into the Subtree submenu, or further if Subtree itself elevates).
+ *
+ * In v0.23.0 the deep `Expand > All` leaf was retired in favour of a
+ * dedicated top-level `Expand all from here` row, so the
+ * `{ kind: 'expandAll' }` variant was removed: the Expand sub-submenu
+ * (and its single-item elevation) is now purely depth-based.
  */
-export type ExpandSingleAction = { kind: 'expandAll' } | { kind: 'expandToDepth'; depth: number };
+export type ExpandSingleAction = { kind: 'expandToDepth'; depth: number };
 
 /**
  * Escapes a value for use in a CSS attribute selector. Falls back to
@@ -617,15 +623,22 @@ export class JsonTreeComponent {
   readonly ctxSubtreeMenuLabel = $localize`:@@tree.contextMenu.subtreeMenu:Subtree`;
   readonly ctxSubtreeCollapseLabel = $localize`:@@tree.contextMenu.subtreeCollapse:Collapse`;
   readonly ctxSubtreeExpandMenuLabel = $localize`:@@tree.contextMenu.subtreeExpandMenu:Expand`;
-  readonly ctxSubtreeExpandAllLabel = $localize`:@@tree.contextMenu.expandAllFromHere:All`;
   // Per-depth labels inside the Subtree -> Expand submenu. Source text
   // uses the "+N level(s)" form per DESIGN_SPEC.md §516 (relative,
   // expand-only) -- distinct from the toolbar's snap-to-exact dropdown.
+  // Depths 1-9 mirror the toolbar's `Expand to Level` dropdown range
+  // (v0.23.0). `showExpandToDepth` hides entries that exceed the
+  // subtree's reachable container depth, so depths 6-9 only render
+  // for subtrees deep enough to need them.
   readonly ctxExpandToDepth1Label = $localize`:@@tree.contextMenu.expandToDepth.1:+1 level`;
   readonly ctxExpandToDepth2Label = $localize`:@@tree.contextMenu.expandToDepth.2:+2 levels`;
   readonly ctxExpandToDepth3Label = $localize`:@@tree.contextMenu.expandToDepth.3:+3 levels`;
   readonly ctxExpandToDepth4Label = $localize`:@@tree.contextMenu.expandToDepth.4:+4 levels`;
   readonly ctxExpandToDepth5Label = $localize`:@@tree.contextMenu.expandToDepth.5:+5 levels`;
+  readonly ctxExpandToDepth6Label = $localize`:@@tree.contextMenu.expandToDepth.6:+6 levels`;
+  readonly ctxExpandToDepth7Label = $localize`:@@tree.contextMenu.expandToDepth.7:+7 levels`;
+  readonly ctxExpandToDepth8Label = $localize`:@@tree.contextMenu.expandToDepth.8:+8 levels`;
+  readonly ctxExpandToDepth9Label = $localize`:@@tree.contextMenu.expandToDepth.9:+9 levels`;
   // Spec terms preserved per DESIGN_SPEC.md §514. Renaming would lose
   // the precise `narrowSet` / `widerSet` semantics.
   readonly ctxIsolateLabel = $localize`:@@tree.contextMenu.isolate:Isolate`;
@@ -652,6 +665,10 @@ export class JsonTreeComponent {
   readonly ctxExpandToDepth3ElevatedLabel = $localize`:@@tree.contextMenu.expandToDepth.3.elevated:Expand 3 levels from here`;
   readonly ctxExpandToDepth4ElevatedLabel = $localize`:@@tree.contextMenu.expandToDepth.4.elevated:Expand 4 levels from here`;
   readonly ctxExpandToDepth5ElevatedLabel = $localize`:@@tree.contextMenu.expandToDepth.5.elevated:Expand 5 levels from here`;
+  readonly ctxExpandToDepth6ElevatedLabel = $localize`:@@tree.contextMenu.expandToDepth.6.elevated:Expand 6 levels from here`;
+  readonly ctxExpandToDepth7ElevatedLabel = $localize`:@@tree.contextMenu.expandToDepth.7.elevated:Expand 7 levels from here`;
+  readonly ctxExpandToDepth8ElevatedLabel = $localize`:@@tree.contextMenu.expandToDepth.8.elevated:Expand 8 levels from here`;
+  readonly ctxExpandToDepth9ElevatedLabel = $localize`:@@tree.contextMenu.expandToDepth.9.elevated:Expand 9 levels from here`;
   readonly preferredHighlightLabel = $localize`:@@tree.highlight.swatch.preferred:Preferred`;
   readonly kebabAriaLabel = $localize`:@@tree.kebab.aria:Row actions`;
   readonly kebabTitleLabel = $localize`:@@tree.kebab.title:Row actions`;
@@ -3345,20 +3362,13 @@ export class JsonTreeComponent {
       // The whole Expand contribution is the single Subtree item.
       // It either elevates (single Expand action) or stays a
       // flyout (multiple Expand actions), but either way it is
-      // the lone Subtree item.
+      // the lone Subtree item. v0.23.0 retired the `'expandSame'`
+      // sentinel: when the lone Expand action would be `+1` with
+      // an `expandRow` default, `isLoneDepth1RedundantWithSurfaced`
+      // suppresses the whole Expand contribution upstream so this
+      // arm only ever fires for non-redundant cases.
       const expandSingle = this.expandFromHereSingleAction(node);
       if (expandSingle) {
-        // Suppress when the elevated single Expand action is the
-        // same as the surfaced shortcut (e.g. only `+1` available
-        // on a collapsed container, and surfaced row is `Expand
-        // 1 level`).
-        if (
-          expandSingle.kind === 'expandToDepth' &&
-          expandSingle.depth === 1 &&
-          this.defaultActionKind() === 'expandRow'
-        ) {
-          return { kind: 'expandSame' };
-        }
         return { kind: 'expandSingle', single: expandSingle };
       }
       // Multiple Expand options -- elevate the whole Expand
@@ -3416,24 +3426,24 @@ export class JsonTreeComponent {
    * item, returns metadata for elevating that item; otherwise
    * null. Cases:
    *
-   *   - `{ kind: 'expandAll' }`: only Expand all is visible (e.g.
-   *     fully-shallow subtree with all leaves; depth +N entries
-   *     hide because `maxDescendantDepth === 0`, but the clicked
-   *     container itself is collapsed so Expand all is meaningful).
    *   - `{ kind: 'expandToDepth', depth: N }`: only one specific
    *     depth +N is visible (e.g. partial-expand state where
    *     +1 is hidden because top-level is expanded, only +2 has
-   *     a collapsed container reachable, and +3..+5 exceed
+   *     a collapsed container reachable, and +3..+9 exceed
    *     subtree depth).
    *
-   * Returns null when 0 or >= 2 items are visible.
+   * Returns null when 0 or >= 2 items are visible, OR when
+   * `isLoneDepth1RedundantWithSurfaced` fires (the lone +1
+   * case where the bolded surfaced shortcut already covers the
+   * action).
+   *
+   * v0.23.0: the `{ kind: 'expandAll' }` case was retired; the
+   * top-level `Expand all from here` row covers it directly.
    */
   expandFromHereSingleAction(node: TreeNode): ExpandSingleAction | null {
+    if (this.isLoneDepth1RedundantWithSurfaced(node)) return null;
     if (this.expandFromHereItemCount(node) !== 1) return null;
-    if (this.showExpandAllFromHere(node)) {
-      return { kind: 'expandAll' };
-    }
-    for (let depth = 1; depth <= 5; depth++) {
+    for (let depth = 1; depth <= 9; depth++) {
       if (this.showExpandToDepth(node, depth)) {
         return { kind: 'expandToDepth', depth };
       }
@@ -3442,23 +3452,52 @@ export class JsonTreeComponent {
   }
 
   private expandFromHereItemCount(node: TreeNode): number {
+    if (this.isLoneDepth1RedundantWithSurfaced(node)) return 0;
     let count = 0;
-    if (this.showExpandAllFromHere(node)) count += 1;
-    for (let depth = 1; depth <= 5; depth++) {
+    for (let depth = 1; depth <= 9; depth++) {
       if (this.showExpandToDepth(node, depth)) count += 1;
     }
     return count;
   }
 
   /**
+   * Suppresses the `Expand >` sub-submenu's lone `+1` entry (and
+   * the in-Subtree single-item elevation that would otherwise
+   * render it) when the bolded surfaced shortcut row already
+   * fires the identical `expandToDepthFromHere(_, 1)` action.
+   *
+   * Fires iff (a) the subtree has exactly one container descendant
+   * level (`maxDescendantDepth === 1`) AND (b) the row's
+   * `defaultActionKind` is `'expandRow'` (the bolded surfaced
+   * shortcut is "Expand 1 level"). Cascades through
+   * `expandFromHereItemCount` (returns 0) ->
+   * `expandFromHereSingleAction` (returns null) ->
+   * `showExpandFromHereMenu` (returns false) ->
+   * `subtreeItemCount` (drops the Expand contribution) ->
+   * `showSubtreeMenu` (may become false if Expand was the lone
+   * Subtree contributor) -- keeping all downstream accounting
+   * consistent with the visible suppression.
+   *
+   * Same shape as `hasContainerDescendants`-gated suppression of
+   * the new top-level row in v0.23.0: both eliminate cross-row
+   * duplication with the bolded surfaced shortcut.
+   */
+  private isLoneDepth1RedundantWithSurfaced(node: TreeNode): boolean {
+    return this.maxDescendantDepth(node) === 1 && this.defaultActionKind() === 'expandRow';
+  }
+
+  /**
    * Maps an `ExpandSingleAction` to its elevated label (the
    * row-level form, where the menu name no longer carries the
    * "from here" scope and the label has to restore it).
+   *
+   * v0.23.0: the `'expandAll'` arm was deleted alongside the type
+   * variant. The switch covers `depth: 1..9`; the `default` arm
+   * is unreachable given the predicate loop bound (matches the
+   * `expandFromHereSingleAction` range) but is retained as
+   * defense-in-depth.
    */
   expandSingleElevatedLabel(action: ExpandSingleAction): string {
-    if (action.kind === 'expandAll') {
-      return this.ctxExpandAllFromHereElevatedLabel;
-    }
     switch (action.depth) {
       case 1:
         return this.ctxExpandToDepth1ElevatedLabel;
@@ -3470,8 +3509,16 @@ export class JsonTreeComponent {
         return this.ctxExpandToDepth4ElevatedLabel;
       case 5:
         return this.ctxExpandToDepth5ElevatedLabel;
+      case 6:
+        return this.ctxExpandToDepth6ElevatedLabel;
+      case 7:
+        return this.ctxExpandToDepth7ElevatedLabel;
+      case 8:
+        return this.ctxExpandToDepth8ElevatedLabel;
+      case 9:
+        return this.ctxExpandToDepth9ElevatedLabel;
       default:
-        return this.ctxExpandAllFromHereElevatedLabel;
+        return this.ctxExpandToDepth1ElevatedLabel;
     }
   }
 
@@ -3479,12 +3526,11 @@ export class JsonTreeComponent {
    * Click handler for an elevated Expand single action (when the
    * Expand sub-submenu would have only one item, that item renders
    * directly at the Subtree or row level).
+   *
+   * v0.23.0: the `'expandAll'` arm was deleted; the elevated
+   * Expand single action is now always depth-based.
    */
   onExpandSingleElevatedClick(node: TreeNode, action: ExpandSingleAction): void {
-    if (action.kind === 'expandAll') {
-      this.expandAllFromHere(node);
-      return;
-    }
     this.expandToDepthFromHere(node, action.depth);
   }
 
@@ -3552,15 +3598,23 @@ export class JsonTreeComponent {
 
   /**
    * Expands the clicked node and every container in its subtree.
-   * Caller should guard with `showExpandAllFromHere(node)`.
+   * Caller should guard with `showExpandAllFromHere(node)` AND
+   * `hasContainerDescendants(node)` (the new top-level row in
+   * v0.23.0 includes both gates; primitives-only containers fall
+   * through to the bolded `Expand 1 level` surfaced shortcut).
    *
-   * `source` is reserved for symmetry with `collapseFromHere` /
-   * `expandToDepthFromHere`. After Path Y the only menu entry point
-   * for "Expand all" is inside the in-Subtree `Expand >` sub-submenu
-   * (`'submenu'`); the surfaced top-level shortcut routes through
-   * `expandToDepthFromHere` with `relativeDepth: 1` instead.
+   * `source` is `'topRow'` for the new top-level `Expand all from
+   * here` row (the only menu entry point in v0.23.0+ -- the deep
+   * `Subtree > Expand > All` leaf and the in-Subtree `expandAll`
+   * elevation were both retired). The value is intentionally
+   * non-`'top'` because the new row is non-bolded; sibling events
+   * `tree.contextMenu.collapse` and `tree.contextMenu.expandToDepth`
+   * use `'top'` for their bolded surfaced shortcuts. KQL queries
+   * that cross-filter on `source` must use
+   * `where customDimensions.source in ('top', 'topRow')` to union
+   * both styles.
    */
-  expandAllFromHere(node: TreeNode, source: 'top' | 'submenu' = 'submenu'): void {
+  expandAllFromHere(node: TreeNode, source: 'topRow' = 'topRow'): void {
     const start = performance.now();
     if (!node.children?.length) return;
     this.logger.info('tree.contextMenu.expandAllFromHere', { source });
@@ -3593,8 +3647,10 @@ export class JsonTreeComponent {
    * surfaced top-level shortcut row (`'top'`, always `relativeDepth: 1`
    * since the surfaced row mirrors a single-level dblclick expand)
    * from the in-Subtree submenu's per-depth items (`'submenu'`).
-   * Defaults to `'submenu'` for backward compatibility with existing
-   * call sites.
+   * The in-Subtree per-depth items cover `relativeDepth: 1..9`
+   * (extended from 1..5 in v0.23.0 to mirror the toolbar's
+   * `Expand to Level` dropdown range). Defaults to `'submenu'` for
+   * backward compatibility with existing call sites.
    */
   expandToDepthFromHere(
     node: TreeNode,
@@ -3867,6 +3923,22 @@ export class JsonTreeComponent {
     };
     walk(node);
     return allExpanded;
+  }
+
+  /**
+   * Public wrapper around `maxDescendantDepth` for template-side
+   * gating under `strictTemplates`. True iff `node` has at least
+   * one container descendant (`maxDescendantDepth > 0`); false for
+   * primitives-only containers and leaves.
+   *
+   * Used to gate the v0.23.0 top-level `Expand all from here` row:
+   * when the subtree has no container descendants, `expandAll`
+   * produces the same visible state change as the bolded `Expand
+   * 1 level` surfaced shortcut, so rendering both adjacent rows
+   * would be cross-row duplication.
+   */
+  hasContainerDescendants(node: TreeNode): boolean {
+    return this.maxDescendantDepth(node) > 0;
   }
 
   /**

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -3098,7 +3098,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">570</context>
+          <context context-type="linenumber">580</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.matchMode.startsWith" datatype="html">
@@ -3109,7 +3109,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">571</context>
+          <context context-type="linenumber">581</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.matchMode.endsWith" datatype="html">
@@ -3120,7 +3120,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">572</context>
+          <context context-type="linenumber">582</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.matchMode.exact" datatype="html">
@@ -3131,7 +3131,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">573</context>
+          <context context-type="linenumber">583</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.matchMode.regex" datatype="html">
@@ -3142,7 +3142,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">574</context>
+          <context context-type="linenumber">584</context>
         </context-group>
       </trans-unit>
       <trans-unit id="profile.prefs.search.matchMode.help" datatype="html">
@@ -3478,134 +3478,134 @@
         <source>Expand: 1</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">156,158</context>
+          <context context-type="linenumber">171,173</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.2" datatype="html">
         <source>Expand: 2</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">159,161</context>
+          <context context-type="linenumber">174,176</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.3" datatype="html">
         <source>Expand: 3</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">162,164</context>
+          <context context-type="linenumber">177,179</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.4" datatype="html">
         <source>Expand: 4</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">165,167</context>
+          <context context-type="linenumber">180,182</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.5" datatype="html">
         <source>Expand: 5</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">168,170</context>
+          <context context-type="linenumber">183,185</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.6" datatype="html">
         <source>Expand: 6</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">171,173</context>
+          <context context-type="linenumber">186,188</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.7" datatype="html">
         <source>Expand: 7</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">174,176</context>
+          <context context-type="linenumber">189,191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.8" datatype="html">
         <source>Expand: 8</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">177,179</context>
+          <context context-type="linenumber">192,194</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.9" datatype="html">
         <source>Expand: 9</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">180,182</context>
+          <context context-type="linenumber">195,197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.level.all" datatype="html">
         <source>Expand: all</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">183,186</context>
+          <context context-type="linenumber">198,201</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.all" datatype="html">
         <source> Expand all </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">187,189</context>
+          <context context-type="linenumber">202,204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.collapse.all" datatype="html">
         <source> Collapse all </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">190,194</context>
+          <context context-type="linenumber">205,209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.dateAnnotation.aria" datatype="html">
         <source>Date annotation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">331,332</context>
+          <context context-type="linenumber">346,347</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.extract.button.title" datatype="html">
         <source>Extract embedded JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">394,395</context>
+          <context context-type="linenumber">409,410</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.extract.button.aria" datatype="html">
         <source>Extract embedded JSON from this string</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">396,398</context>
+          <context context-type="linenumber">411,413</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.highlighted.aria" datatype="html">
         <source>highlighted</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">424,426</context>
+          <context context-type="linenumber">439,441</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">541,543</context>
+          <context context-type="linenumber">556,558</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">577,579</context>
+          <context context-type="linenumber">592,594</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.empty" datatype="html">
         <source> Paste or type JSON on the left to see the tree view. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">587,590</context>
+          <context context-type="linenumber">602,605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.extract.menu.label" datatype="html">
         <source>Extract embedded JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">642,645</context>
+          <context context-type="linenumber">657,660</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.type.date" datatype="html">
@@ -3724,585 +3724,634 @@
         <source>Expand</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">559</context>
+          <context context-type="linenumber">569</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.node.collapse" datatype="html">
         <source>Collapse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">560</context>
+          <context context-type="linenumber">570</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.aria" datatype="html">
         <source>JSON tree</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">562</context>
+          <context context-type="linenumber">572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.expand.menu.button" datatype="html">
         <source>Expand to...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">564</context>
+          <context context-type="linenumber">574</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.matchValue.aria" datatype="html">
         <source>Matches the selected value</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">565</context>
+          <context context-type="linenumber">575</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.caseSensitive.label" datatype="html">
         <source>Aa</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">567</context>
+          <context context-type="linenumber">577</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.caseSensitive.tooltip" datatype="html">
         <source>Match case</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">568</context>
+          <context context-type="linenumber">578</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.matchMode.tooltip" datatype="html">
         <source>Match mode</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">569</context>
+          <context context-type="linenumber">579</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.scope.tooltip" datatype="html">
         <source>Find in</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">575</context>
+          <context context-type="linenumber">585</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.scope.keys" datatype="html">
         <source>Keys</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">576</context>
+          <context context-type="linenumber">586</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.scope.values" datatype="html">
         <source>Values</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">577</context>
+          <context context-type="linenumber">587</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.scope.both" datatype="html">
         <source>Keys and values</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">578</context>
+          <context context-type="linenumber">588</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.type.tooltip" datatype="html">
         <source>Filter by value type</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">579</context>
+          <context context-type="linenumber">589</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.type.all" datatype="html">
         <source>All types</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">580</context>
+          <context context-type="linenumber">590</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.prev.tooltip" datatype="html">
         <source>Previous match</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">581</context>
+          <context context-type="linenumber">591</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.next.tooltip" datatype="html">
         <source>Next match</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">582</context>
+          <context context-type="linenumber">592</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copyKey" datatype="html">
         <source>Copy key</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">587</context>
+          <context context-type="linenumber">597</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copyValue" datatype="html">
         <source>Copy value</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">588</context>
+          <context context-type="linenumber">598</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copyPath" datatype="html">
         <source>Copy path</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">589</context>
+          <context context-type="linenumber">599</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.searchByKey" datatype="html">
         <source>Find by key</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">595</context>
+          <context context-type="linenumber">605</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.searchByValue" datatype="html">
         <source>Find by value</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">596</context>
+          <context context-type="linenumber">606</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.collapse" datatype="html">
         <source>Collapse from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">602</context>
+          <context context-type="linenumber">612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expand1Level" datatype="html">
         <source>Expand 1 level</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">603</context>
+          <context context-type="linenumber">613</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.defaultActionA11yHint" datatype="html">
         <source>; same as double-clicking the row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">609</context>
+          <context context-type="linenumber">619</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.subtreeMenu" datatype="html">
         <source>Subtree</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">613</context>
+          <context context-type="linenumber">623</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.subtreeCollapse" datatype="html">
         <source>Collapse</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">614</context>
+          <context context-type="linenumber">624</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.subtreeExpandMenu" datatype="html">
         <source>Expand</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">615</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="tree.contextMenu.expandAllFromHere" datatype="html">
-        <source>All</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">616</context>
+          <context context-type="linenumber">625</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.1" datatype="html">
         <source>+1 level</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">620</context>
+          <context context-type="linenumber">633</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.2" datatype="html">
         <source>+2 levels</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">621</context>
+          <context context-type="linenumber">634</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.3" datatype="html">
         <source>+3 levels</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">622</context>
+          <context context-type="linenumber">635</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.4" datatype="html">
         <source>+4 levels</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">623</context>
+          <context context-type="linenumber">636</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.5" datatype="html">
         <source>+5 levels</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">624</context>
+          <context context-type="linenumber">637</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.6" datatype="html">
+        <source>+6 levels</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">638</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.7" datatype="html">
+        <source>+7 levels</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">639</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.8" datatype="html">
+        <source>+8 levels</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">640</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.9" datatype="html">
+        <source>+9 levels</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">641</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.isolate" datatype="html">
         <source>Isolate</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">627</context>
+          <context context-type="linenumber">644</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.collapseSiblings" datatype="html">
         <source>Collapse siblings</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">628</context>
+          <context context-type="linenumber">645</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.highlight" datatype="html">
         <source>Highlight</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">633</context>
+          <context context-type="linenumber">650</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.highlightTree" datatype="html">
         <source>Highlight</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">634</context>
+          <context context-type="linenumber">651</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.removeHighlight" datatype="html">
         <source>Remove highlight</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">635</context>
+          <context context-type="linenumber">652</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.removeTreeHighlight" datatype="html">
         <source>Remove highlight</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">636</context>
+          <context context-type="linenumber">653</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.highlightTree.elevated" datatype="html">
         <source>Highlight subtree</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">642</context>
+          <context context-type="linenumber">659</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.removeTreeHighlight.elevated" datatype="html">
         <source>Remove subtree highlight</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">643</context>
+          <context context-type="linenumber">660</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandFromHere.elevatedMenu" datatype="html">
         <source>Expand from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">644</context>
+          <context context-type="linenumber">661</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandAllFromHere.elevated" datatype="html">
         <source>Expand all from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">645</context>
+          <context context-type="linenumber">662</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.1.elevated" datatype="html">
         <source>Expand 1 level from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">646</context>
+          <context context-type="linenumber">663</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.2.elevated" datatype="html">
         <source>Expand 2 levels from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">647</context>
+          <context context-type="linenumber">664</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.3.elevated" datatype="html">
         <source>Expand 3 levels from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">648</context>
+          <context context-type="linenumber">665</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.4.elevated" datatype="html">
         <source>Expand 4 levels from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">649</context>
+          <context context-type="linenumber">666</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandToDepth.5.elevated" datatype="html">
         <source>Expand 5 levels from here</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">650</context>
+          <context context-type="linenumber">667</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.6.elevated" datatype="html">
+        <source>Expand 6 levels from here</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">668</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.7.elevated" datatype="html">
+        <source>Expand 7 levels from here</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">669</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.8.elevated" datatype="html">
+        <source>Expand 8 levels from here</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">670</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandToDepth.9.elevated" datatype="html">
+        <source>Expand 9 levels from here</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">671</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.highlight.swatch.preferred" datatype="html">
         <source>Preferred</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">651</context>
+          <context context-type="linenumber">672</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.kebab.aria" datatype="html">
         <source>Row actions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">652</context>
+          <context context-type="linenumber">673</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.kebab.title" datatype="html">
         <source>Row actions</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">653</context>
+          <context context-type="linenumber">674</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.decoded.pill.openDialog.title" datatype="html">
         <source>Open decoded value</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">662</context>
+          <context context-type="linenumber">683</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.decoded.pill.openDialog.aria" datatype="html">
         <source>Open decoded value in a viewer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">663</context>
+          <context context-type="linenumber">684</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.decoded.menu.openDialog" datatype="html">
         <source>Open decoded value</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">664</context>
+          <context context-type="linenumber">685</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.breadcrumb.aria" datatype="html">
         <source>Breadcrumb</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">668</context>
+          <context context-type="linenumber">689</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.breadcrumb.empty" datatype="html">
         <source>No current selection</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">669</context>
+          <context context-type="linenumber">690</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.breadcrumb.root" datatype="html">
         <source>Root</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">670</context>
+          <context context-type="linenumber">691</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.breadcrumb.overflow.aria" datatype="html">
         <source>Show hidden ancestors</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">671</context>
+          <context context-type="linenumber">692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.breadcrumb.copyPath.title" datatype="html">
         <source>Copy JSON path</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">672</context>
+          <context context-type="linenumber">693</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.breadcrumb.copyPath.aria" datatype="html">
         <source>Copy JSON path of selected row</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">673</context>
+          <context context-type="linenumber">694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.comment.leading.tooltipPrefix" datatype="html">
         <source>Leading comment: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">679</context>
+          <context context-type="linenumber">700</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.comment.trailing.tooltipPrefix" datatype="html">
         <source>Trailing comment: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">680</context>
+          <context context-type="linenumber">701</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.comment.closeLeading.tooltipPrefix" datatype="html">
         <source>Internal comment: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">681</context>
+          <context context-type="linenumber">702</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.comment.closeTrailing.tooltipPrefix" datatype="html">
         <source>End-of-block comment: </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">682</context>
+          <context context-type="linenumber">703</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.highlight.swatch.preferred.aria" datatype="html">
         <source>Apply preferred highlight color (<x id="hex" equiv-text="hex"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">827</context>
+          <context context-type="linenumber">856</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.count.none" datatype="html">
         <source>No matches</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">1002</context>
+          <context context-type="linenumber">1037</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.count.position" datatype="html">
         <source><x id="position" equiv-text="pos"/> / <x id="count" equiv-text="count"/> matches</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">1005</context>
+          <context context-type="linenumber">1040</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.count.one" datatype="html">
         <source>1 match</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">1007</context>
+          <context context-type="linenumber">1042</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.count.other" datatype="html">
         <source><x id="count" equiv-text="count"/> matches</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">1008</context>
+          <context context-type="linenumber">1043</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.search.count.ghost" datatype="html">
         <source><x id="position" equiv-text="count"/> / <x id="count" equiv-text="count"/> matches</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">1022</context>
+          <context context-type="linenumber">1057</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.copyPath.success" datatype="html">
         <source>Path copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2490</context>
+          <context context-type="linenumber">2692</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.copyPath.failed" datatype="html">
         <source>Failed to copy path.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2491</context>
+          <context context-type="linenumber">2693</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.copyPath.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2492</context>
+          <context context-type="linenumber">2694</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.decoded.tooltipTruncated" datatype="html">
         <source>... (<x id="PH" equiv-text="remaining"/> more characters; open the pill to view full value)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2721</context>
+          <context context-type="linenumber">2923</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.success.key" datatype="html">
         <source>Key copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2837</context>
+          <context context-type="linenumber">3039</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.failed.key" datatype="html">
         <source>Failed to copy key.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2838</context>
+          <context context-type="linenumber">3040</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2839</context>
+          <context context-type="linenumber">3041</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2873</context>
+          <context context-type="linenumber">3075</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.success.value" datatype="html">
         <source>Value copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2871</context>
+          <context context-type="linenumber">3073</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.failed.value" datatype="html">
         <source>Failed to copy value.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2872</context>
+          <context context-type="linenumber">3074</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.highlight.swatch.aria" datatype="html">
         <source><x id="name" equiv-text="swatch.name"/> <x id="hex" equiv-text="swatch.hex"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3065</context>
+          <context context-type="linenumber">3268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.removeTreeHighlight.rooted" datatype="html">
         <source>Remove tree highlight rooted at <x id="ancestorPath" equiv-text="ancestorPath"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3074</context>
+          <context context-type="linenumber">3277</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.beacon.badge.tooltip.single" datatype="html">
         <source>Jump to hidden beacon (<x id="icon" equiv-text="icon"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">4088</context>
+          <context context-type="linenumber">4361</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.beacon.badge.tooltip.many" datatype="html">
         <source>Jump to first of <x id="count" equiv-text="descendantCount"/> hidden <x id="icon" equiv-text="icon"/> beacons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">4089</context>
+          <context context-type="linenumber">4362</context>
         </context-group>
       </trans-unit>
       <trans-unit id="splash.label.render" datatype="html">


### PR DESCRIPTION
## Summary

Three coupled UX changes in the per-row context menu, motivated by post-launch telemetry showing `tree.contextMenu.expandAllFromHere` is the most-clicked context-menu action (~42% of events) despite being buried 3-4 menu levels deep.

### Before / After (typical collapsed container with multi-Subtree contributions)

**Before** (4 clicks to `expandAll`):
```
| Expand 1 level          |  <- bolded (mirrors dblclick)
| Subtree               > |  -> Expand > -> All
```

**After** (2 clicks to `expandAll`):
```
| Expand 1 level          |  <- unchanged
| Expand all from here    |  <- NEW; non-bolded; no icon
| Subtree               > |  -> Expand > -> +1..+9 (no `All` leaf)
```

## Changes

1. **New top-level `Expand all from here` row** in `rowMenu`, gated on `showExpandAllFromHere(cn) && hasContainerDescendants(cn)`. The second conjunct (a new public helper wrapping the private `maxDescendantDepth > 0`) suppresses cross-row duplication for primitives-only containers where `expandAll` and the bolded `Expand 1 level` shortcut produce the identical state change.

2. **Depth submenu extended from +1..+5 to +1..+9** in `Subtree > Expand`, mirroring the toolbar `Expand to Level` dropdown's range. `showExpandToDepth` already gates these so shallow subtrees still show only relevant entries.

3. **Single entry point for `expandAll`**: the deep `All` leaf inside `Subtree > Expand` and the in-Subtree `expandAll` elevation are both retired. The `'expandAll'` variant of `ExpandSingleAction` and the `'expandSame'` variant of `SubtreeElevatedAction` are removed as forced dead code (new predicate `isLoneDepth1RedundantWithSurfaced` suppresses the lone-+1 in-Subtree elevation when `defaultActionKind === 'expandRow'`).

## Telemetry

- `tree.contextMenu.expandAllFromHere` now only emits `source: 'topRow'` (single non-bolded entry point); `'submenu'` removed from the union per AGENTS.md s4 closed-enum discipline.
- KQL-author warning added to the catalog entry to flag the cross-event asymmetry vs sibling events that use `source: 'top'` for their bolded shortcuts.
- `tree.contextMenu.expandToDepth` `relativeDepth` range widened to 1..9.

## Documentation

- `DESIGN_SPEC.md` s Tree View Panel: depth range note bumped to +1..+9 with toolbar-mirror prose; new bullet documenting the **Right-click context menu dblclick-mirror mandate** (per user direction: the bolded surfaced row must always mirror the row's double-click action; other top-level items must be non-bolded so the mandate's visual uniqueness is preserved).
- `DESIGN_SPEC.md` changelog: new 0.23.0 entry covering all three changes + the `'expandAll'` / `'expandSame'` deletions.

## SemVer

Minor bump: **0.22.1 -> 0.23.0**. New user-visible affordance + documentation gap closed.

## Verification

- `npm run lint:all` (root + api) - PASS
- `npm test` (web) - 2593/2593 PASS (3 skipped)
- `npm test` (api) - 465/465 PASS
- `npm run build` - PASS (prerender 2 routes)
- `npm run extract-i18n` - PASS; messages.xlf diff: removes the leaf `@@tree.contextMenu.expandAllFromHere` trans-unit, adds 8 new trans-units for depths 6..9 + elevated variants. The `@@tree.contextMenu.expandAllFromHere.elevated` unit is unchanged (now bound from the new top-level row via the existing `ctxExpandAllFromHereElevatedLabel` field).

## Tests added / updated

- 13 new test cases in `json-tree.component.spec.ts` covering:
  - Top-level row visibility/click/non-bolding (mandate guardrail).
  - Cross-row duplication suppression for primitives-only containers.
  - Deep `All` leaf is gone (count=0, single=null for primitives-only).
  - Lone-+1 in-Subtree elevation suppression under `expandRow` defaults.
  - Lone-+N (N>=2) elevation still fires under `collapseRow` defaults.
  - Depth +6..+9 visibility + telemetry + elevated-label parity.
- 5 existing tests updated for new predicates / new defaults.
- 6 no-arg `expandAllFromHere(...)` test callers now pass `'topRow'` explicitly.

## Planning trail

8 rounds of `deep-review:skeptic` rubber-duck against the plan. See full plan at `~/.copilot/session-state/a99fe0fa-0920-4e14-90d3-50e374c78cab/plan.md` for the round-by-round adversarial-review history.

---
**Session**
- AI-Local: a99fe0fa-0920-4e14-90d3-50e374c78cab
- AI-Cloud: db29e626-0f53-4547-9430-937da15d4b33
