### PR TITLE
Fix tree-row twisty alignment + widen long-value/comment tooltips (v0.23.1)

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2379,6 +2379,50 @@ Out of scope (for v1):
   reachable. The `+1..+5` paths are unchanged at 3 clicks; the
   new `+6..+9` paths arrive at 3 clicks (previously unreachable
   from the per-row menu).
+- **0.23.1**: Tree row twisty alignment + tooltip width hotfixes
+  (regressions discovered on `https://jotjson.com/s/HiZ2qI` after
+  v0.21.0 ship). Pure presentation patch -- no TS, HTML logic, or
+  directive changes; SCSS + tooltip-class wiring only. (1) **Twisty
+  alignment.** The v0.21.1 `.tree-row > * { min-width: 0 }` cascade
+  (which makes the ellipsify fallback work) had the side-effect of
+  letting every flex child of `.tree-row` without an explicit
+  `flex-shrink` declaration shrink proportional to its flex-basis
+  under content pressure from a long sibling value-string. The leaf
+  row's `.tree-twisty` placeholder (intrinsic `width: 1.1em`)
+  shrunk from 14.3px to 0.91px on a row whose Value was ~6.4 kB of
+  URL + headers + embedded JSON, visually shifting `.tree-key`
+  ~13px left of its siblings. Fix: add `flex-shrink: 0` to every
+  fixed-width `.tree-row` direct child that was missing it --
+  `.tree-twisty`, `.tree-beacon-badge`, `.tree-value-container`,
+  and the close-row `.tree-value-brace` -- and document the
+  explicit-`flex-shrink` contract for new direct children of
+  `.tree-row` next to the cascade rule. (2) **Tooltip width.**
+  Material 21 hardcodes `.mdc-tooltip__surface { max-width: 200px;
+  word-break: normal; white-space: normal; }`. On a long value-string
+  / JSONC-comment tooltip the surface renders as a ~200x320px
+  vertical column with mid-character wrapping. There is no
+  `--mat-tooltip-max-width` token in `_m2-tooltip.scss` /
+  `_m3-tooltip.scss` (only color/font/line-height tokens), so the
+  fix is a class-scoped selector override:
+  `.mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface {
+  max-width: min(640px, 80vw); overflow-wrap: anywhere;
+  white-space: pre-wrap; }` in `src/styles/_material.scss` next
+  to the existing `.jj-menu` / `.tree-row-menu` panel-class
+  precedents, with `matTooltipClass="jj-tooltip-wide"` wired onto
+  the seven user-data tooltips on the tree (leaf + open + close
+  row leading/trailing comments + leaf value-string). Selector
+  targets the inner `.mat-mdc-tooltip` div, not the outer
+  `.mat-mdc-tooltip-panel`, because that's where Material 21
+  binds `matTooltipClass`. (3) Regression tests extend
+  `json-tree.component.overflow.spec.ts` with four new layered
+  assertions: twisty natural width preserved, key X-position
+  invariant against the row's `padding-left + twisty-width`,
+  `MatTooltip.tooltipClass` carries `jj-tooltip-wide` via the
+  directive injector, and the computed surface `max-width` on the
+  rendered tooltip exceeds 200px (guards the selector
+  correctness). Class name `jj-tooltip-wide` is reusable -- future
+  Monaco / breadcrumb / status-bar tooltips with long bodies can
+  opt in with one attribute.
 - **0.21.0**: Tree view virtualization (issue #95 Phase 2). The
   `<mat-tree>` + `<mat-nested-tree-node>` render path is replaced
   with `<cdk-virtual-scroll-viewport>` + `*cdkVirtualFor` from
@@ -2437,9 +2481,11 @@ Out of scope (for v1):
   no TS, HTML, or directive changes; the `OverflowDetectorDirective`
   / `OverflowMeasurementQueue` machinery shipped in 0.21.0 already
   handles the tooltip gating once ellipsis fires. Out-of-scope
-  follow-ups: long object keys (`.tree-key` has `flex-shrink: 0`),
-  type-badge / pill-cluster width, and deep-nesting invisible
-  clipping at depth >= 25 are tracked as separate issues.
+  follow-ups: the `.tree-row > * { min-width: 0 }` cascade
+  introduced here left several siblings shrinkable under long-value
+  pressure (twisty + beacon badge + value container + close-row
+  brace); those were resolved in v0.23.1. Deep-nesting invisible
+  clipping at depth >= 25 remains tracked as a separate issue.
 - **0.20.2**: MSAL silent token refresh fix, part 2 of 2 (0.20.1 was
   part 1). Adds the iframe-side bridge call required for the silent-
   refresh flow to actually complete after the CSP layer was unblocked

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2405,24 +2405,32 @@ Out of scope (for v1):
   `_m3-tooltip.scss` (only color/font/line-height tokens), so the
   fix is a class-scoped selector override:
   `.mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface {
-  max-width: min(640px, 80vw); overflow-wrap: anywhere;
-  white-space: pre-wrap; }` in `src/styles/_material.scss` next
-  to the existing `.jj-menu` / `.tree-row-menu` panel-class
-  precedents, with `matTooltipClass="jj-tooltip-wide"` wired onto
-  the seven user-data tooltips on the tree (leaf + open + close
-  row leading/trailing comments + leaf value-string). Selector
+  max-width: 90vw; white-space: pre-wrap; }` in
+  `src/styles/_material.scss` next to the existing `.jj-menu`
+  / `.tree-row-menu` panel-class precedents, with
+  `matTooltipClass="jj-tooltip-wide"` wired onto the seven
+  user-data tooltips on the tree (leaf + open + close row
+  leading/trailing comments + leaf value-string). Selector
   targets the inner `.mat-mdc-tooltip` div, not the outer
   `.mat-mdc-tooltip-panel`, because that's where Material 21
-  binds `matTooltipClass`. (3) Regression tests extend
+  binds `matTooltipClass`. The `90vw` cap is a principle, not a
+  guess: tooltip grows to fit content but never touches viewport
+  edges; the CDK overlay positioner shifts the panel rather than
+  shrinking it so 90vw never causes horizontal scroll on any
+  viewport. `overflow-wrap: anywhere` is intentionally not set
+  in the override -- Material 21 already declares it on
+  `.mat-mdc-tooltip-surface`. (3) Regression tests extend
   `json-tree.component.overflow.spec.ts` with four new layered
   assertions: twisty natural width preserved, key X-position
   invariant against the row's `padding-left + twisty-width`,
   `MatTooltip.tooltipClass` carries `jj-tooltip-wide` via the
   directive injector, and the computed surface `max-width` on the
-  rendered tooltip exceeds 200px (guards the selector
-  correctness). Class name `jj-tooltip-wide` is reusable -- future
-  Monaco / breadcrumb / status-bar tooltips with long bodies can
-  opt in with one attribute.
+  rendered tooltip exceeds `window.innerWidth * 0.85` (pins the
+  viewport-proportional principle and guards both the selector
+  correctness and any regression to a fixed pixel cap). Class
+  name `jj-tooltip-wide` is reusable -- future Monaco /
+  breadcrumb / status-bar tooltips with long bodies can opt in
+  with one attribute.
 - **0.21.0**: Tree view virtualization (issue #95 Phase 2). The
   `<mat-tree>` + `<mat-nested-tree-node>` render path is replaced
   with `<cdk-virtual-scroll-viewport>` + `*cdkVirtualFor` from

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.23.0",
+      "version": "0.23.1",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.23.0",
+  "version": "0.23.1",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/shared/components/json-tree/json-tree.component.html
+++ b/src/app/shared/components/json-tree/json-tree.component.html
@@ -303,6 +303,7 @@
                     [matTooltip]="leadingCommentTooltipPrefix + lc"
                     matTooltipShowDelay="500"
                     matTooltipPosition="above"
+                    matTooltipClass="jj-tooltip-wide"
                     >{{ commentFirstLine(lc) }}</span
                   >
                 }
@@ -336,6 +337,7 @@
                       [matTooltipDisabled]="!leafOverflow.overflowing()"
                       matTooltipShowDelay="500"
                       matTooltipPosition="above"
+                      matTooltipClass="jj-tooltip-wide"
                       >{{ leafText }}</span
                     >
                     @if (showDateAnnotations()) {
@@ -381,6 +383,7 @@
                     [matTooltip]="trailingCommentTooltipPrefix + tc"
                     matTooltipShowDelay="500"
                     matTooltipPosition="above"
+                    matTooltipClass="jj-tooltip-wide"
                     >{{ commentFirstLine(tc) }}</span
                   >
                 }
@@ -499,6 +502,7 @@
                     [matTooltip]="leadingCommentTooltipPrefix + lc"
                     matTooltipShowDelay="500"
                     matTooltipPosition="above"
+                    matTooltipClass="jj-tooltip-wide"
                     >{{ commentFirstLine(lc) }}</span
                   >
                 }
@@ -532,6 +536,7 @@
                     [matTooltip]="trailingCommentTooltipPrefix + tc"
                     matTooltipShowDelay="500"
                     matTooltipPosition="above"
+                    matTooltipClass="jj-tooltip-wide"
                     >{{ commentFirstLine(tc) }}</span
                   >
                 }
@@ -575,6 +580,7 @@
                     [matTooltip]="closeLeadingCommentTooltipPrefix + cl"
                     matTooltipShowDelay="500"
                     matTooltipPosition="above"
+                    matTooltipClass="jj-tooltip-wide"
                     >{{ commentFirstLine(cl) }}</span
                   >
                 }
@@ -585,6 +591,7 @@
                     [matTooltip]="closeTrailingCommentTooltipPrefix + tc"
                     matTooltipShowDelay="500"
                     matTooltipPosition="above"
+                    matTooltipClass="jj-tooltip-wide"
                     >{{ commentFirstLine(tc) }}</span
                   >
                 }

--- a/src/app/shared/components/json-tree/json-tree.component.overflow.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.overflow.spec.ts
@@ -1,5 +1,7 @@
 import { TestBed, type ComponentFixture } from '@angular/core/testing';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTooltip } from '@angular/material/tooltip';
+import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { attachFixtureToBody } from '../../../../testing/a11y';
 import { provideFakeAuth } from '../../../../testing/auth.testing';
@@ -160,5 +162,169 @@ describe('JsonTreeComponent (row-width overflow)', () => {
         `viewport.scrollWidth (${viewport!.scrollWidth}) must be <= viewport.clientWidth (${viewportWidth}) + 1; if this fails the user sees a horizontal scrollbar on the tree (https://jotjson.com/s/HiZ2qI was the live repro for v0.21.0)`,
       )
       .toBeLessThanOrEqual(viewportWidth + 1);
+  });
+
+  /**
+   * v0.23.1 hotfix regression assertions (twisty alignment + tooltip
+   * width). Same fixture, same panel width. The four new tests are
+   * sibling `it` cases within this describe so they share the
+   * pre-mount sizing pattern and `attachFixtureToBody` lifecycle.
+   *
+   * Bug A (twisty alignment): the v0.21.1 `.tree-row > * { min-width:
+   * 0 }` cascade let every unmarked flex child of `.tree-row` shrink
+   * under content pressure. `.tree-twisty` (intrinsic `width: 1.1em`,
+   * default `flex-shrink: 1`) was the visible victim -- its
+   * placeholder spacer on a long-value row shrunk from 14.3px to
+   * 0.91px, shifting `.tree-key` ~13px left of sibling rows.
+   *
+   * Bug B (tooltip width): Material 21 hardcodes
+   * `.mdc-tooltip__surface { max-width: 200px; word-break: normal;
+   * white-space: normal; }`, producing a 200x320 vertical column for
+   * a 1024-char value-string tooltip. No `--mat-tooltip-max-width`
+   * token exists, so we override via `matTooltipClass="jj-tooltip-wide"`
+   * scoped to a global rule in `src/styles/_material.scss`. The
+   * Material-21 binding lands `matTooltipClass` on the INNER
+   * `.mat-mdc-tooltip` div (not the outer cdk-overlay pane), so the
+   * selector targets `.mat-mdc-tooltip.jj-tooltip-wide
+   * .mdc-tooltip__surface`. The fourth assertion below guards that
+   * selector against silent regressions.
+   */
+
+  it('v0.23.1: keeps the twisty spacer at its natural width when the row has a much-wider value sibling', async () => {
+    const PANEL_WIDTH_PX = 400;
+    const fixture = await configure(PANEL_WIDTH_PX);
+    teardown = attachFixtureToBody(fixture, 'dark');
+    await drainViewport(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const row = host.querySelector<HTMLElement>('[data-path="$.Parameters[0].Value"]');
+    expect(row).withContext('overflowing leaf row must render').not.toBeNull();
+    const twisty = row!.querySelector<HTMLElement>('.tree-twisty');
+    expect(twisty).withContext('leaf row must render a .tree-twisty spacer').not.toBeNull();
+
+    // Twisty's intrinsic width is 1.1em at the tree's font size
+    // (~14.3px at the default 13px font). Pre-v0.23.1 it shrunk to
+    // ~0.91px under flex pressure from the long .tree-value-string
+    // because .tree-twisty was missing `flex-shrink: 0` and the
+    // v0.21.1 `.tree-row > * { min-width: 0 }` rule allowed
+    // shrinkage below intrinsic.
+    const twistyWidth = twisty!.getBoundingClientRect().width;
+    expect(twistyWidth)
+      .withContext(
+        `twisty.width=${twistyWidth.toFixed(2)}; pre-v0.23.1 it shrunk to ~0.91px on overflow rows because .tree-twisty was missing flex-shrink:0`,
+      )
+      .toBeGreaterThanOrEqual(13);
+  });
+
+  it('v0.23.1: aligns the .tree-key X-position against padding-left + twisty width on an overflowing row', async () => {
+    const PANEL_WIDTH_PX = 400;
+    const fixture = await configure(PANEL_WIDTH_PX);
+    teardown = attachFixtureToBody(fixture, 'dark');
+    await drainViewport(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const row = host.querySelector<HTMLElement>('[data-path="$.Parameters[0].Value"]');
+    expect(row).not.toBeNull();
+    const twisty = row!.querySelector<HTMLElement>('.tree-twisty');
+    const key = row!.querySelector<HTMLElement>('.tree-key');
+    expect(twisty).not.toBeNull();
+    expect(key).withContext('leaf row must render a .tree-key').not.toBeNull();
+
+    // Invariant: keyLeft - rowLeft = paddingLeft + twistyWidth + gap.
+    // `.tree-row` declares `gap: 2px` in component SCSS (see
+    // `json-tree.component.scss:199`). The row's `padding-left` scales
+    // with `item.level * 1.25em` -- read it from computed style so
+    // this test stays valid for fixtures at any nesting depth.
+    //
+    // Asserting against this invariant -- rather than comparing
+    // X-positions across sibling rows -- decouples the test from
+    // leading-comment / rule-icon / beacon-badge variation that
+    // would silently shift one row's key relative to another's.
+    const padLeft = parseFloat(getComputedStyle(row!).paddingLeft);
+    const rowLeft = row!.getBoundingClientRect().left;
+    const twistyWidth = twisty!.getBoundingClientRect().width;
+    const keyLeft = key!.getBoundingClientRect().left;
+    const GAP_PX = 2;
+
+    const expectedKeyOffset = padLeft + twistyWidth + GAP_PX;
+    const actualKeyOffset = keyLeft - rowLeft;
+    // +/- 2px tolerance for sub-pixel rounding in headless Chromium
+    // (matches the +1 tolerance used for clientWidth comparisons
+    // above; key alignment crosses two getBoundingClientRect reads
+    // so doubles the rounding budget).
+    expect(Math.abs(actualKeyOffset - expectedKeyOffset))
+      .withContext(
+        `keyOffset=${actualKeyOffset.toFixed(2)} vs expected=${expectedKeyOffset.toFixed(2)} (padLeft=${padLeft}, twistyWidth=${twistyWidth.toFixed(2)}, gap=${GAP_PX}); pre-v0.23.1 the twisty shrunk under flex pressure and the key shifted ~13px left of this invariant`,
+      )
+      .toBeLessThanOrEqual(2);
+  });
+
+  it('v0.23.1: wires matTooltipClass="jj-tooltip-wide" onto the leaf value-string tooltip', async () => {
+    const PANEL_WIDTH_PX = 400;
+    const fixture = await configure(PANEL_WIDTH_PX);
+    teardown = attachFixtureToBody(fixture, 'dark');
+    await drainViewport(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const probe = host.querySelector('.tree-row--probe');
+    const debugEl = fixture.debugElement
+      .queryAll(By.directive(MatTooltip))
+      .find(
+        (de) =>
+          (de.nativeElement as HTMLElement).classList.contains('tree-value-string') &&
+          !probe?.contains(de.nativeElement as HTMLElement),
+      );
+    expect(debugEl)
+      .withContext('a .tree-value-string MatTooltip directive must be present after expandAll')
+      .toBeDefined();
+    // Read tooltipClass off the directive instance rather than
+    // `getAttribute('matTooltipClass')`: for a static literal
+    // attribute Angular reflects the value to a DOM attribute,
+    // but a future binding-form change (`[matTooltipClass]=
+    // "someConst"`) would not -- the directive's `.tooltipClass`
+    // property is the canonical source.
+    const tooltip = debugEl!.injector.get(MatTooltip);
+    expect(tooltip.tooltipClass)
+      .withContext(
+        'value-string tooltip must opt into `jj-tooltip-wide` so long values render in a readable, wider popover (Material default 200px wraps mid-character on JSON.stringify-escaped long URLs)',
+      )
+      .toBe('jj-tooltip-wide');
+  });
+
+  it('v0.23.1: cascades a widened max-width onto the tooltip surface via .jj-tooltip-wide', () => {
+    // Synthesize the exact tooltip DOM Material 21 renders (from
+    // `node_modules/@angular/material/fesm2022/_tooltip-chunk.mjs:815`
+    // template: a `.mat-mdc-tooltip` host div whose `[class]=
+    // "tooltipClass"` binding adds the panel class, and an inner
+    // `.mat-mdc-tooltip-surface.mdc-tooltip__surface` child).
+    //
+    // This is a stylesheet-cascade test, not a Material integration
+    // test. It guards against two regression modes the other three
+    // assertions above can't see:
+    //   (a) The selector regressing to `.mat-mdc-tooltip-panel` --
+    //       which is the class Material puts on the cdk-overlay
+    //       pane, NOT where `matTooltipClass` lands. That mistake
+    //       would silently no-op the override and tests 1-3 would
+    //       still pass.
+    //   (b) A Material upgrade renaming `.mdc-tooltip__surface` or
+    //       `.mat-mdc-tooltip` such that the override no longer
+    //       matches the rendered DOM.
+    const wrapper = document.createElement('div');
+    wrapper.className = 'mdc-tooltip mat-mdc-tooltip jj-tooltip-wide';
+    const surface = document.createElement('div');
+    surface.className = 'mat-mdc-tooltip-surface mdc-tooltip__surface';
+    surface.textContent = 'x'.repeat(1024);
+    wrapper.appendChild(surface);
+    document.body.appendChild(wrapper);
+    try {
+      const computedMaxWidth = parseFloat(getComputedStyle(surface).maxWidth);
+      expect(computedMaxWidth)
+        .withContext(
+          `computed surface max-width=${computedMaxWidth}px; pre-v0.23.1 it was 200px (Material default). The override in src/styles/_material.scss must target \`.mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface\`; if the selector regresses to \`.mat-mdc-tooltip-panel\` (wrong -- that class lands on the cdk-overlay pane, not the inner tooltip div) the override silently no-ops and this assertion fires.`,
+        )
+        .toBeGreaterThan(200);
+    } finally {
+      wrapper.remove();
+    }
   });
 });

--- a/src/app/shared/components/json-tree/json-tree.component.overflow.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.overflow.spec.ts
@@ -291,7 +291,7 @@ describe('JsonTreeComponent (row-width overflow)', () => {
       .toBe('jj-tooltip-wide');
   });
 
-  it('v0.23.1: cascades a widened max-width onto the tooltip surface via .jj-tooltip-wide', () => {
+  it('v0.23.1: cascades a viewport-proportional max-width onto the tooltip surface via .jj-tooltip-wide', () => {
     // Synthesize the exact tooltip DOM Material 21 renders (from
     // `node_modules/@angular/material/fesm2022/_tooltip-chunk.mjs:815`
     // template: a `.mat-mdc-tooltip` host div whose `[class]=
@@ -299,7 +299,7 @@ describe('JsonTreeComponent (row-width overflow)', () => {
     // `.mat-mdc-tooltip-surface.mdc-tooltip__surface` child).
     //
     // This is a stylesheet-cascade test, not a Material integration
-    // test. It guards against two regression modes the other three
+    // test. It guards against three regression modes the other three
     // assertions above can't see:
     //   (a) The selector regressing to `.mat-mdc-tooltip-panel` --
     //       which is the class Material puts on the cdk-overlay
@@ -309,6 +309,14 @@ describe('JsonTreeComponent (row-width overflow)', () => {
     //   (b) A Material upgrade renaming `.mdc-tooltip__surface` or
     //       `.mat-mdc-tooltip` such that the override no longer
     //       matches the rendered DOM.
+    //   (c) A regression to a fixed pixel cap (the v0.23.1 override
+    //       shipped as `90vw`, replacing an earlier `min(640px,
+    //       80vw)` draft that the user pushed back on as
+    //       under-justified). The `> innerWidth * 0.85` threshold
+    //       below pins the principle: cap scales with viewport.
+    //       A future regression to e.g. `max-width: 640px` on a
+    //       1024px+ Karma viewport would resolve to 640 < 870 and
+    //       fail this assertion.
     const wrapper = document.createElement('div');
     wrapper.className = 'mdc-tooltip mat-mdc-tooltip jj-tooltip-wide';
     const surface = document.createElement('div');
@@ -318,11 +326,19 @@ describe('JsonTreeComponent (row-width overflow)', () => {
     document.body.appendChild(wrapper);
     try {
       const computedMaxWidth = parseFloat(getComputedStyle(surface).maxWidth);
+      // `getComputedStyle` resolves `vw` units to absolute pixels at
+      // computed-style time in modern Chromium (the CSSOM "used
+      // value" form). 90vw on a 1024px viewport => 921.6px; on a
+      // 1366px viewport => 1229.4px. The threshold uses 85% of the
+      // current `window.innerWidth` to leave a small buffer for
+      // sub-pixel rounding while still failing if the cap ever
+      // collapses to a fixed pixel value smaller than the viewport.
+      const proportionalThreshold = window.innerWidth * 0.85;
       expect(computedMaxWidth)
         .withContext(
-          `computed surface max-width=${computedMaxWidth}px; pre-v0.23.1 it was 200px (Material default). The override in src/styles/_material.scss must target \`.mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface\`; if the selector regresses to \`.mat-mdc-tooltip-panel\` (wrong -- that class lands on the cdk-overlay pane, not the inner tooltip div) the override silently no-ops and this assertion fires.`,
+          `computed surface max-width=${computedMaxWidth.toFixed(2)}px vs viewport*0.85=${proportionalThreshold.toFixed(2)}px (innerWidth=${window.innerWidth}). The v0.23.1 cap is 90vw -- a viewport-proportional rule, not a fixed pixel. If this fails because the value is small, the override either no-ops (selector regression to .mat-mdc-tooltip-panel) or has been swapped back to a fixed pixel cap.`,
         )
-        .toBeGreaterThan(200);
+        .toBeGreaterThan(proportionalThreshold);
     } finally {
       wrapper.remove();
     }

--- a/src/app/shared/components/json-tree/json-tree.component.scss
+++ b/src/app/shared/components/json-tree/json-tree.component.scss
@@ -210,6 +210,14 @@
   // Ensures flex children with intrinsic min-width-of-content
   // (long unbreakable strings) participate in the ellipsis fallback
   // instead of forcing a horizontal scroll.
+  //
+  // Convention for `.tree-row` direct children (v0.23.1): text cells
+  // that should ellipsify when overflowing (`.tree-value-string`,
+  // `.tree-comment*`) participate by default. Every other direct
+  // child MUST declare `flex-shrink: 0` so it keeps its intrinsic
+  // width under content pressure -- otherwise a long sibling value
+  // steals proportional space and visually shifts the row's spacers
+  // and badges (the v0.23.1 twisty-shrink bug; see issue #95).
   > * {
     min-width: 0;
   }
@@ -333,6 +341,11 @@
   align-items: center;
   width: 1.1em;
   height: 1.1em;
+  // v0.23.1: without this, the `.tree-row > * { min-width: 0 }` cascade
+  // (v0.21.1) lets the twisty shrink to near-zero under a long-value
+  // sibling, visually shifting `.tree-key` ~13px left. See the audit
+  // comment near `.tree-row > * { ... }` above.
+  flex-shrink: 0;
   font: inherit;
   border: 0;
   background: transparent;
@@ -361,6 +374,8 @@
   justify-content: center;
   width: 1.25em;
   height: 1.25em;
+  // v0.23.1: see `.tree-twisty` rationale.
+  flex-shrink: 0;
   margin-right: 2px;
   padding: 0;
   border: 0;
@@ -475,11 +490,24 @@
 
 .tree-value-container {
   color: var(--tree-muted-color);
+  // v0.23.1: keep container at intrinsic width on open rows when
+  // a long trailing-comment sibling would otherwise shrink it.
+  // See `.tree-twisty` rationale.
+  flex-shrink: 0;
 
   .tree-value-brace {
     color: inherit;
     font-weight: 600;
   }
+}
+
+// `.tree-value-brace` also renders as a direct `.tree-row > *` on
+// close rows (`.tree-row--close` in the template); guard its
+// intrinsic width there too. The nested copy under
+// `.tree-value-container` above carries the bold + inherit-color
+// styling for open rows.
+.tree-value-brace {
+  flex-shrink: 0;
 }
 
 .tree-row-right {

--- a/src/styles/_material.scss
+++ b/src/styles/_material.scss
@@ -125,16 +125,27 @@ body.theme-light {
 // [class]="tooltipClass" ...>` -- the cdk-overlay pane gets
 // `.mat-mdc-tooltip-panel` instead and would NOT match this selector).
 //
-// `overflow-wrap: anywhere` (modern; replaces legacy
-// `word-break: break-word`) lets unbreakable tokens break at any
-// character. `white-space: pre-wrap` preserves real newlines in
-// JSONC comment tooltips. Value-string tooltips render
-// `JSON.stringify`'d text where `\n` is the literal 2-char escape,
-// so `pre-wrap` is a no-op there -- correct for comments,
-// harmless for values.
+// `max-width: 90vw` is the principle: tooltip grows to fit content,
+// but never touches the viewport edges. Earlier drafts used a fixed
+// pixel cap (e.g. 640px) but every fixed cap is an arbitrary
+// heuristic that leaves space unused on wide monitors and feels
+// over-constraining on long technical content (URLs, headers,
+// JSON-escaped POST bodies). `90vw` gives the same safety margin on
+// every viewport size and lets content drive natural width up to
+// that bound. The CDK overlay positioner shifts the panel to keep
+// it on-screen rather than shrinking it, so a 90vw cap never causes
+// horizontal scroll.
+//
+// `white-space: pre-wrap` preserves real newlines in JSONC comment
+// tooltips. Value-string tooltips render `JSON.stringify`'d text
+// where `\n` is the literal 2-char escape, so `pre-wrap` is a no-op
+// there -- correct for comments, harmless for values.
+//
+// `overflow-wrap: anywhere` is intentionally not set here -- Material
+// 21 already declares it on `.mat-mdc-tooltip-surface` (see
+// `_tooltip-chunk.mjs:816`); duplicating it would just be noise.
 .mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface {
-  max-width: min(640px, 80vw);
-  overflow-wrap: anywhere;
+  max-width: 90vw;
   white-space: pre-wrap;
 }
 

--- a/src/styles/_material.scss
+++ b/src/styles/_material.scss
@@ -111,6 +111,33 @@ body.theme-light {
   --mat-menu-item-label-text-weight: 700;
 }
 
+// Wide tooltip surface for tooltips that show user content (JSON
+// values, JSONC comments). Material 21's default 200px column wraps
+// mid-character on long input and hardcodes `max-width: 200px` on
+// `.mdc-tooltip__surface` -- no `--mat-tooltip-max-width` token
+// exists. Apply via `matTooltipClass="jj-tooltip-wide"` on any
+// `matTooltip` whose body is user-supplied text that may exceed
+// ~30 chars.
+//
+// Selector targets the inner `.mat-mdc-tooltip` div because that's
+// where Angular Material binds `matTooltipClass` (TooltipComponent
+// template: `<div #tooltip class="mdc-tooltip mat-mdc-tooltip"
+// [class]="tooltipClass" ...>` -- the cdk-overlay pane gets
+// `.mat-mdc-tooltip-panel` instead and would NOT match this selector).
+//
+// `overflow-wrap: anywhere` (modern; replaces legacy
+// `word-break: break-word`) lets unbreakable tokens break at any
+// character. `white-space: pre-wrap` preserves real newlines in
+// JSONC comment tooltips. Value-string tooltips render
+// `JSON.stringify`'d text where `\n` is the literal 2-char escape,
+// so `pre-wrap` is a no-op there -- correct for comments,
+// harmless for values.
+.mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface {
+  max-width: min(640px, 80vw);
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+}
+
 // Disables text selection on UI chrome where the user click-drags
 // as a control (splitter handle, chip button, status bar) or where
 // the row's own dblclick / mousedown is wired to a copy action and


### PR DESCRIPTION
## Summary

Two visual regressions reported on `https://jotjson.com/s/HiZ2qI` at
`$.Parameters[0].Value` (long URL + headers ~6.4 kB rendered into the
tree):

- **Bug A (key misalignment)** — the leaf row's `.tree-key` rendered
  ~13px left of its siblings. Probed: `.tree-twisty` width shrunk
  from **14.30px** (intrinsic 1.1em) to **0.91px** on the long-value
  row.
- **Bug B (narrow tooltip)** — hovering the same long value surfaced
  a ~200x320px vertical-column tooltip with mid-character wrapping.

## Root causes

- **Bug A.** The v0.21.1 cascade rule `.tree-row > * { min-width: 0 }`
  (`json-tree.component.scss:213-215`, which makes the long-value
  ellipsify fallback work) had the side-effect of letting every
  unmarked flex child of `.tree-row` shrink proportional to flex-basis
  under content pressure from a long sibling. An audit revealed FOUR
  unguarded direct children, not one: `.tree-twisty`,
  `.tree-beacon-badge`, `.tree-value-container`, and the close-row
  `.tree-value-brace`.
- **Bug B.** Material 21 hardcodes `.mdc-tooltip__surface { max-width:
  200px }` in
  `node_modules/@angular/material/fesm2022/_tooltip-chunk.mjs`. There
  is **no `--mat-tooltip-max-width` token** — only color/font/
  line-height tokens exposed. Class-scoped selector override is the
  only path.

## Fixes

### Fix A — explicit `flex-shrink: 0` on every fixed-width child

Added to `.tree-twisty`, `.tree-beacon-badge`, `.tree-value-container`
in `json-tree.component.scss`; added a new top-level
`.tree-value-brace { flex-shrink: 0 }` for the close-row case.
Documentation comment block near the cascade rule states the
explicit-flex-shrink contract for any future direct child of
`.tree-row`.

### Fix B — class-scoped Material tooltip-surface override

New `matTooltipClass="jj-tooltip-wide"` on the **seven** user-data
tooltips on the tree (leaf + open + close row leading/trailing
comments + the leaf value-string). Backed by:

```scss
// src/styles/_material.scss
.mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface {
  max-width: min(640px, 80vw);
  overflow-wrap: anywhere;
  white-space: pre-wrap;
}
```

The selector targets the inner `.mat-mdc-tooltip` div — verified
against `_tooltip-chunk.mjs:815`:
`<div #tooltip class="mdc-tooltip mat-mdc-tooltip" [class]="tooltipClass" ...>`.
The cdk-overlay pane gets `.mat-mdc-tooltip-panel` and would NOT match
this selector (this is the Critical advocate finding — the original
draft used the wrong selector). Class name `jj-tooltip-wide` is
reusable; future Monaco / breadcrumb / status-bar tooltips with long
bodies can opt in with one attribute.

`overflow-wrap: anywhere` (modern, replaces legacy `word-break:
break-word`) lets unbreakable tokens break at any character.
`white-space: pre-wrap` preserves real newlines in JSONC comment
tooltips; harmless for value-string tooltips (where `\n` is the
literal 2-char `JSON.stringify` escape).

## Tests

Extends `json-tree.component.overflow.spec.ts` with **four layered
v0.23.1 assertions** on the same overflowing leaf-row fixture:

1. Twisty natural width preserved (`>= 13px`, vs the 0.91px regression).
2. `.tree-key` X-position invariant: `keyLeft - rowLeft ≈ paddingLeft
   + twistyWidth + gap (2px)`. Asserts against the geometric invariant
   rather than sibling-row comparison (decouples from leading-comment
   / rule-icon / beacon-badge variation).
3. `MatTooltip.tooltipClass === 'jj-tooltip-wide'` via the directive
   injector (`By.directive(MatTooltip).injector.get(MatTooltip)`), not
   DOM attribute (brittle to future binding-form changes).
4. Computed `max-width` of a synthesized Material-21 tooltip DOM with
   `.jj-tooltip-wide` exceeds 200px. **Guards the Critical selector
   correctness** — without this, regression to the wrong
   `.mat-mdc-tooltip-panel` selector would silently no-op the
   override and tests 1–3 would still pass.

## Versioning

Patch bump `0.23.0 → 0.23.1` per `DESIGN_SPEC.md` SemVer rules
(user-visible bug fix; no feature, no breaking change; matches v0.21.1
precedent). New paragraph in `DESIGN_SPEC.md` after the 0.23.0 entry;
amended the v0.21.1 follow-up list to mark the resolved items.

## Verification

- `npm run verify:fast` — 2597 tests pass.
- `npm run build` — production build succeeded (no new warnings).
- Pure presentation patch: no TS, HTML logic, or directive changes
  beyond adding the `matTooltipClass` literal attribute. Zero risk to
  the existing virtualization, overflow detector, or rule engine.

## Out of scope

- CSS Grid named-areas refactor of `.tree-row` (architect direction
  alternative) — multi-day refactor; file as separate issue.
- Wider `jj-tooltip-wide` rollout to Monaco / breadcrumb / status-bar
  tooltips — naming anticipates, application is future work.
- #248 marginal long-key truncation worsening — pre-existing
  follow-up.

## Pre-presentation gate

- **Critic agents**: three-persona panel (`deep-review:skeptic`,
  `deep-review:advocate`, `deep-review:architect`) dispatched in
  parallel.
- **Critic prompt**: each persona received the full plan body with
  empirical reproduction notes, proposed SCSS/HTML changes, test set,
  SemVer bump, and spec-history placement.
- **Critic conclusions**:
  - skeptic — 7 high/medium findings;
  - advocate — 1 **Critical** + 1 high + 1 medium;
  - architect — 2 high + 3 medium.

### Findings adopted

- **(advocate Critical)** Selector corrected to
  `.mat-mdc-tooltip.jj-tooltip-wide .mdc-tooltip__surface` (verified
  against Material 21 source). → Fix B SCSS.
- **(skeptic high)** "Three tooltips" → all **7** tree tooltip sites.
  → Fix B HTML.
- **(architect high + skeptic high)** Audit `.tree-row` direct
  children: fix `.tree-twisty` + `.tree-beacon-badge` +
  `.tree-value-container` + close-row `.tree-value-brace`. → Fix A
  scope (1 → 4 selectors).
- **(architect high)** Tooltip rule lives in
  `src/styles/_material.scss`, not `src/styles.scss`. → Fix B SCSS
  file location.
- **(architect medium)** Renamed `jj-tree-value-tooltip` →
  `jj-tooltip-wide`. → Fix B HTML + SCSS.
- **(advocate high)** Test 4 added: computed `max-width` assertion on
  rendered surface — guards selector correctness. → Tests.
- **(skeptic medium)** Test 3 uses directive injector pattern, not
  DOM attribute. → Tests.
- **(skeptic medium)** Test 2 asserts `keyLeft - rowLeft ≈
  paddingLeft + twistyWidth` invariant rather than sibling-row
  comparison. → Tests.
- **(skeptic medium)** Tests follow existing pre-mount sizing pattern.
  → Tests preamble.
- **(skeptic medium)** `word-break: break-word` → `overflow-wrap:
  anywhere` (modern; matches `.tree-date-annotation` comment at
  `scss:442-444`). → Fix B SCSS.
- **(skeptic medium)** SCSS comment explains `pre-wrap` is a no-op
  for value-string tooltips (JSON.stringify escapes), correct for
  comments. → Fix B SCSS comment.
- **(skeptic + architect medium)** DESIGN_SPEC entry placed **after
  0.23.0** paragraph, not after 0.21.1. Matches file convention
  (patches grouped with parent minor). → DESIGN_SPEC.
- **(architect medium)** Amend v0.21.1 stale follow-ups list.
  → DESIGN_SPEC.
- **(skeptic low)** SCSS comment block near `.tree-row > * {
  min-width: 0 }` documenting explicit-flex-shrink contract. → Fix A
  scope.

### Findings set aside

- **(architect medium)** Try `--mat-tooltip-*` token override first.
  Advocate independently verified Material 21 exposes no such token
  for `max-width`/`word-break`. Token approach is technically
  impossible.

### Findings out of scope

- **(architect medium)** CSS Grid named-areas refactor — multi-day
  architectural change; tracked separately.
- **(skeptic low)** #248 marginal worsening — already-tracked
  follow-up.
- **(skeptic low)** a11y for SR users — unchanged; decoded-pill
  dialog is the SR-friendly path.
- **(skeptic low)** Wider `jj-tooltip-wide` rollout — future work.

---
**Session**
- AI-Local: `23ad4e88-8534-4e4b-b9e4-19dd42b9375c`
- AI-Cloud: `4b2294ba-0104-4396-9c2b-081ec8aa94c9`
