### PR TITLE
Show subtree depth on top-level 'Expand all from here' row (v0.25.0)

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2432,6 +2432,31 @@ Out of scope (for v1):
   name `jj-tooltip-wide` is reusable -- future Monaco /
   breadcrumb / status-bar tooltips with long bodies can opt in
   with one attribute.
+- **0.25.0**: Tree row top-level **Expand all from here** label gains
+  a depth hint when the subtree has at least two container levels
+  reachable: `Expand all from here (+5 levels)` (matching the
+  existing `+N levels` suffix vocabulary on the per-row depth
+  submenu at TS:633-641) rather than the bare `Expand all from
+  here`. The hint surfaces on the row whenever
+  `maxDescendantDepth(node) >= 2`; at depth 1 the suffix is
+  intentionally omitted to avoid visually duplicating the bolded
+  `Expand 1 level` surfaced dblclick mirror immediately above. The
+  hint scales past the depth-submenu's `+1..+9` ceiling -- e.g.,
+  `(+12 levels)` on a deeply-nested chain -- since the top-level
+  row is the only path to "Expand all" once the submenu's range is
+  exhausted, so a depth signal here also tells users how deep the
+  subtree goes when the toolbar's Expand-to-Level range can't
+  reach the bottom. New `$localize` ID
+  `@@tree.contextMenu.expandAllFromHere.withDepth` (always plural
+  source string, no ICU -- the codebase has zero `$localize` ICU
+  precedents and the depth-1 threshold rules out the singular).
+  Telemetry shape unchanged (`tree.contextMenu.expandAllFromHere`
+  still emits `{ source: 'topRow' }`); enriching the event with
+  the depth bucket is deferred to issue #241 alongside the
+  `logger.info -> logger.event` migration so the sink and bucket
+  ship atomically per AGENTS.md §4. No HTML structure change --
+  only the label binding swaps from `ctxExpandAllFromHereElevatedLabel`
+  to the new `ctxExpandAllFromHereLabelFor(cn)` method.
 - **0.23.2**: Restore the v0.19.0 row-menu icon contract on the
   new top-level **Expand all from here** row. v0.19.0 (Phase 3
   of the tree-menu overhaul) established that "every top-level

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -2433,15 +2433,33 @@ Out of scope (for v1):
   breadcrumb / status-bar tooltips with long bodies can opt in
   with one attribute.
 - **0.25.0**: Tree row top-level **Expand all from here** label gains
-  a depth hint when the subtree has at least two container levels
-  reachable: `Expand all from here (+5 levels)` (matching the
-  existing `+N levels` suffix vocabulary on the per-row depth
-  submenu at TS:633-641) rather than the bare `Expand all from
-  here`. The hint surfaces on the row whenever
-  `maxDescendantDepth(node) >= 2`; at depth 1 the suffix is
-  intentionally omitted to avoid visually duplicating the bolded
-  `Expand 1 level` surfaced dblclick mirror immediately above. The
-  hint scales past the depth-submenu's `+1..+9` ceiling -- e.g.,
+  a level-count hint whenever the row is visible:
+  `Expand all from here (+6 levels)` (matching the existing
+  `+N levels` suffix vocabulary on the per-row depth submenu at
+  TS:633-641) rather than the bare `Expand all from here`. The
+  hint surfaces whenever the top-level row is visible.
+
+  **Metric**: the suffix is `maxDescendantDepth(node) + 1` -- one
+  more than the deepest container descendant's relative depth.
+  `expandAllFromHere` walks every container at relative depths
+  `0..maxDescendantDepth`, which equals that many `+N levels` of
+  expansion in the submenu's vocabulary. The submenu (per-row
+  `+N`) caps at `maxDescendantDepth` to avoid duplicating this
+  row's end state, so this label always reads exactly one more
+  than the largest submenu entry. That `+1` gap is intentional:
+  it signals "Expand all reaches one level beyond the largest
+  partial-expand option," and is honest about the action's reach
+  (the prior off-by-one made the label look identical to the
+  submenu's max while doing strictly more).
+
+  **Telemetry divergence**: `tree.expand.slow` continues to emit
+  `depth: maxDescendantDepth` for both top-row and submenu sources
+  (preserving cross-version analytics continuity). The visible
+  label and the emitted `depth` are intentionally off-by-one for
+  top-row events. Renaming or splitting the telemetry field is
+  out of scope and is batched with issue #241.
+
+  The hint scales past the depth-submenu's `+1..+9` ceiling -- e.g.,
   `(+12 levels)` on a deeply-nested chain -- since the top-level
   row is the only path to "Expand all" once the submenu's range is
   exhausted, so a depth signal here also tells users how deep the
@@ -2449,7 +2467,8 @@ Out of scope (for v1):
   reach the bottom. New `$localize` ID
   `@@tree.contextMenu.expandAllFromHere.withDepth` (always plural
   source string, no ICU -- the codebase has zero `$localize` ICU
-  precedents and the depth-1 threshold rules out the singular).
+  precedents and the smallest visible suffix is `+2` so the
+  singular case never arises).
   Telemetry shape unchanged (`tree.contextMenu.expandAllFromHere`
   still emits `{ source: 'topRow' }`); enriching the event with
   the depth bucket is deferred to issue #241 alongside the

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.23.2",
+  "version": "0.25.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.23.2",
+      "version": "0.25.0",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.23.2",
+  "version": "0.25.0",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/shared/components/json-tree/json-tree.component.html
+++ b/src/app/shared/components/json-tree/json-tree.component.html
@@ -745,7 +745,7 @@
     @if (showExpandAllFromHere(cn) && hasContainerDescendants(cn)) {
       <button mat-menu-item type="button" (click)="expandAllFromHere(cn, 'topRow')">
         <jj-icon name="expand-subtree" [size]="18" />
-        <span>{{ ctxExpandAllFromHereElevatedLabel }}</span>
+        <span>{{ ctxExpandAllFromHereLabelFor(cn) }}</span>
       </button>
     }
     @if (showSubtreeMenu(cn)) {

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -6798,28 +6798,32 @@ describe('JsonTreeComponent', () => {
 
       // ---- v0.25.0: depth-aware label suffix ----
 
-      it('Expand all label keeps the base form at depth 1 (suffix would collide with surfaced shortcut)', async () => {
+      it('Expand all label shows "(+2 levels)" at the smallest visible depth (maxDescendantDepth=1)', async () => {
         await createWith({ outer: { mid: { inner: 1 } } });
         cmp.collapseAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
-        // Precondition: depth 1 (mid is the only container descendant; inner is primitive).
-        // The suffix is intentionally omitted here so users don't see
-        // "(+1 level)" sitting directly under the bolded "Expand 1 level"
-        // surfaced shortcut.
-        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe(cmp.ctxExpandAllFromHereElevatedLabel);
+        // Precondition: maxDescendantDepth(outer)=1 (mid is the only
+        // container descendant; inner is primitive). "Expand all"
+        // walks containers at relative depths 0..1 -- 2 distinct
+        // levels of expansion. The smallest visible suffix value is
+        // therefore 2, never 1, so no collision with the bolded
+        // "Expand 1 level" surfaced shortcut row above.
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe('Expand all from here (+2 levels)');
       });
 
-      it('Expand all label gains a "(+N levels)" suffix at depth >= 2', async () => {
+      it('Expand all label suffix tracks containerDepth + 1 at depth >= 2', async () => {
         // Fixture: 5 container descendants below outer. Walk:
         // outer (d=0) -> a (d=1) -> b (d=2) -> c (d=3) -> d (d=4) -> e (d=5).
         // f is the primitive leaf, so e is the deepest container.
         // maxDescendantDepth(outer) === 5.
+        // "Expand all" walks containers at relative depths 0..5 ->
+        // 6 distinct levels of expansion.
         await createWith({ outer: { a: { b: { c: { d: { e: { f: 1 } } } } } } });
         cmp.collapseAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
-        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe('Expand all from here (+5 levels)');
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe('Expand all from here (+6 levels)');
       });
 
       it('Expand all label scales beyond the +1..+9 depth-submenu range', async () => {
@@ -6835,7 +6839,7 @@ describe('JsonTreeComponent', () => {
         // children and short-circuits the walk before its depth is
         // recorded (maxDescendantDepth counts containers whose
         // descendants include at least one container).
-        // maxDescendantDepth(outer) === 11.
+        // maxDescendantDepth(outer) === 11, label suffix = 12.
         const buildDeep = (n: number): unknown => {
           let v: unknown = 1;
           for (let i = 0; i < n; i++) v = { x: v };
@@ -6845,7 +6849,43 @@ describe('JsonTreeComponent', () => {
         cmp.collapseAll();
         fixture.detectChanges();
         const outer = nodeAt('$.outer');
-        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe('Expand all from here (+11 levels)');
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe('Expand all from here (+12 levels)');
+      });
+
+      it('Expand all label N matches expandToDepthFromHere end state (action-equivalence)', async () => {
+        // Binds the label's N to the END STATE of the action, not
+        // to a structural metric. Specifically: the smallest N such
+        // that `expandToDepthFromHere(node, N)` produces the same
+        // expanded-paths set as `expandAllFromHere(node)` is the N
+        // the label advertises. Future refactors that break either
+        // walk surface here.
+        //
+        // Fixture: maxDescendantDepth(outer) === 2, so labelN = 3.
+        await createWith({ outer: { a: { b: { c: 1 } } } });
+        const helpers = cmp.__getHelpersForTesting();
+        const outer = nodeAt('$.outer');
+        const labelN = 3;
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe(
+          `Expand all from here (+${labelN} levels)`,
+        );
+        // "Source: 'top'" since production never offers
+        // relativeDepth > maxDescendantDepth via submenu.
+        cmp.collapseAll();
+        fixture.detectChanges();
+        cmp.expandAllFromHere(outer, 'topRow');
+        const allPaths = Array.from(helpers.readExpandedPaths()).sort();
+        cmp.collapseAll();
+        fixture.detectChanges();
+        cmp.expandToDepthFromHere(outer, labelN, 'top');
+        const depthPaths = Array.from(helpers.readExpandedPaths()).sort();
+        expect(depthPaths).toEqual(allPaths);
+        // Sanity: labelN - 1 produces a strict subset (label is the
+        // SMALLEST submenu value that matches expand-all's end state).
+        cmp.collapseAll();
+        fixture.detectChanges();
+        cmp.expandToDepthFromHere(outer, labelN - 1, 'top');
+        const shallowerPaths = Array.from(helpers.readExpandedPaths()).sort();
+        expect(shallowerPaths.length).toBeLessThan(allPaths.length);
       });
 
       it('Expand all label returns base form for primitives-only containers (safe default)', async () => {
@@ -6884,8 +6924,11 @@ describe('JsonTreeComponent', () => {
         const items = Array.from(
           document.body.querySelectorAll<HTMLButtonElement>('button.mat-mdc-menu-item'),
         );
-        const expandAllRow = items.find(
-          (el) => (el.textContent ?? '').trim() === cmp.ctxExpandAllFromHereElevatedLabel,
+        const expandAllRow = items.find((el) =>
+          // Tolerate any `(+N levels)` suffix added by
+          // ctxExpandAllFromHereLabelFor (v0.25.0); the elevated
+          // label stem is still the stable prefix.
+          (el.textContent ?? '').trim().startsWith(cmp.ctxExpandAllFromHereElevatedLabel),
         );
         // Hard assertion: the row MUST be in the rendered menu. A
         // missing row would be a regression in the gating predicate
@@ -7129,8 +7172,11 @@ describe('JsonTreeComponent', () => {
         const items = Array.from(
           document.body.querySelectorAll<HTMLButtonElement>('button.mat-mdc-menu-item'),
         );
-        const expandAllRow = items.find(
-          (el) => (el.textContent ?? '').trim() === cmp.ctxExpandAllFromHereElevatedLabel,
+        const expandAllRow = items.find((el) =>
+          // Tolerate any `(+N levels)` suffix added by
+          // ctxExpandAllFromHereLabelFor (v0.25.0); the elevated
+          // label stem is still the stable prefix.
+          (el.textContent ?? '').trim().startsWith(cmp.ctxExpandAllFromHereElevatedLabel),
         );
         expect(expandAllRow)
           .withContext('precondition: Expand-all top-level row must be in the rendered menu')

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -6796,6 +6796,72 @@ describe('JsonTreeComponent', () => {
         });
       });
 
+      // ---- v0.25.0: depth-aware label suffix ----
+
+      it('Expand all label keeps the base form at depth 1 (suffix would collide with surfaced shortcut)', async () => {
+        await createWith({ outer: { mid: { inner: 1 } } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        // Precondition: depth 1 (mid is the only container descendant; inner is primitive).
+        // The suffix is intentionally omitted here so users don't see
+        // "(+1 level)" sitting directly under the bolded "Expand 1 level"
+        // surfaced shortcut.
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe(cmp.ctxExpandAllFromHereElevatedLabel);
+      });
+
+      it('Expand all label gains a "(+N levels)" suffix at depth >= 2', async () => {
+        // Fixture: 5 container descendants below outer. Walk:
+        // outer (d=0) -> a (d=1) -> b (d=2) -> c (d=3) -> d (d=4) -> e (d=5).
+        // f is the primitive leaf, so e is the deepest container.
+        // maxDescendantDepth(outer) === 5.
+        await createWith({ outer: { a: { b: { c: { d: { e: { f: 1 } } } } } } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe('Expand all from here (+5 levels)');
+      });
+
+      it('Expand all label scales beyond the +1..+9 depth-submenu range', async () => {
+        // Build a deeply-nested container chain so the depth-aware
+        // label exercises a depth that the +N submenu never offers.
+        // This is the whole point of the label hint: deep subtrees
+        // that don't fit the submenu's range still get a depth
+        // signal on the top-level row.
+        //
+        // Walk trace (n=12 nested `x` wrappers around primitive 1):
+        // outer (d=0) -> x_1 (d=1) -> x_2 (d=2) -> ... -> x_11 (d=11).
+        // x_12 contains a primitive leaf so it has no container
+        // children and short-circuits the walk before its depth is
+        // recorded (maxDescendantDepth counts containers whose
+        // descendants include at least one container).
+        // maxDescendantDepth(outer) === 11.
+        const buildDeep = (n: number): unknown => {
+          let v: unknown = 1;
+          for (let i = 0; i < n; i++) v = { x: v };
+          return { outer: v };
+        };
+        await createWith(buildDeep(12));
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe('Expand all from here (+11 levels)');
+      });
+
+      it('Expand all label returns base form for primitives-only containers (safe default)', async () => {
+        // The row itself is hidden in production by hasContainerDescendants,
+        // but the method must return a sensible label for any programmatic
+        // caller. depth 0 -> base label.
+        await createWith({ outer: { x: 1, y: 2 } });
+        cmp.collapseAll();
+        fixture.detectChanges();
+        const outer = nodeAt('$.outer');
+        expect(cmp.hasContainerDescendants(outer))
+          .withContext('precondition: primitives-only -> row hidden in production')
+          .toBeFalse();
+        expect(cmp.ctxExpandAllFromHereLabelFor(outer)).toBe(cmp.ctxExpandAllFromHereElevatedLabel);
+      });
+
       it('top-level Expand all row is not bolded (dblclick-mirror mandate guardrail)', async () => {
         // Setup: expand the root so $.outer is rendered, then
         // collapse from $.outer so showExpandAllFromHere(outer) is

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -3957,31 +3957,60 @@ export class JsonTreeComponent {
 
   /**
    * Returns the label for the top-level `Expand all from here` row.
-   * When the subtree has at least two container levels reachable,
-   * suffixes the label with the depth count (`(+N levels)`) so the
-   * user can see how deep `all` will go before clicking.
+   * Suffixes the label with the level count (`(+N levels)`) whenever
+   * the row is visible, so the user can see how deep `all` will go
+   * before clicking.
    *
-   * Threshold behavior (`maxDescendantDepth >= 2` for suffix):
-   * - depth 0 (primitives-only): row is hidden by the
-   *   `hasContainerDescendants` gate; method returns the base label
-   *   as a safe default for any programmatic caller.
-   * - depth 1: suffix omitted. The bolded `Expand 1 level` surfaced
-   *   shortcut row sits directly above; a `(+1 level)` suffix here
-   *   would visually collide with that shortcut's depth call-out.
-   *   The two actions still differ in scope (the bolded shortcut
-   *   only expands the clicked container; `expandAll` also expands
-   *   the deeper container descendant), but the verbs `1 level` vs
-   *   `all` carry that distinction without an explicit count.
-   * - depth >= 2: suffix shown so the action's reach is visible.
+   * Metric note: `maxDescendantDepth(node)` returns the relative
+   * depth of the deepest **container** descendant (containers below
+   * `node`; primitive leaves don't extend the count). But
+   * `expandAllFromHere` walks every container at relative depths
+   * `0..maxDescendantDepth` -- that's `maxDescendantDepth + 1`
+   * distinct levels of expansion in the submenu's `+N levels`
+   * vocabulary. The submenu's per-row depth options
+   * (`showExpandToDepth`) cap at `maxDescendantDepth` to avoid
+   * duplicating this row's end state; this label therefore always
+   * reads exactly one more than the largest submenu entry, which is
+   * the deliberate "+M+1 levels" the submenu intentionally omits.
+   *
+   * Threshold change (v0.25.0 follow-up bugfix): the prior
+   * `maxDescendantDepth >= 2` threshold was rooted in a now-invalid
+   * concern about a `(+1 level)` suffix colliding with the bolded
+   * `Expand 1 level` surfaced shortcut. With the corrected metric
+   * the smallest visible suffix is `(+2 levels)` -- no `(+1 level)`
+   * is ever rendered. The earlier "the verbs `1 level` vs `all`
+   * carry the distinction without an explicit count" rationale is
+   * superseded: with the corrected metric the suffix carries
+   * genuine information (the action's reach is exactly `+2` rather
+   * than the bolded shortcut's `+1`), not redundant decoration.
+   *
+   * The only remaining early-return is `containerDepth < 1`
+   * (primitives-only safe default). In production the row is gated
+   * out by `hasContainerDescendants` (`maxDescendantDepth > 0`); the
+   * early-return covers programmatic callers.
+   *
+   * Telemetry divergence: `tree.expand.slow`
+   * (`emitSlowExpandIfNeeded`) emits `depth: containerDepth` for both
+   * top-row and submenu sources, preserving cross-version analytics
+   * continuity. The visible label and the telemetry depth field
+   * are therefore intentionally off-by-one for top-row events.
+   * Renaming or splitting the telemetry field is out of scope for
+   * this fix and is batched with issue #241 (telemetry migration).
    *
    * The suffixed message is always plural ("levels") because the
-   * threshold rules out the singular case; the source string avoids
-   * an i18n ICU plural for which the codebase has no precedent.
+   * smallest visible value is 2; the source string avoids an i18n
+   * ICU plural for which the codebase has no precedent.
+   *
+   * The trans-unit ID `@@tree.contextMenu.expandAllFromHere.withDepth`
+   * is historical (introduced when the value was `containerDepth`).
+   * Per i18n stability rule (AGENTS.md s4), the ID stays even though
+   * the value is now `containerDepth + 1` (level count, not depth).
    */
   ctxExpandAllFromHereLabelFor(node: TreeNode): string {
-    const depth = this.maxDescendantDepth(node);
-    if (depth < 2) return this.ctxExpandAllFromHereElevatedLabel;
-    return $localize`:@@tree.contextMenu.expandAllFromHere.withDepth:Expand all from here (+${depth}:DEPTH: levels)`;
+    const containerDepth = this.maxDescendantDepth(node);
+    if (containerDepth < 1) return this.ctxExpandAllFromHereElevatedLabel;
+    const levels = containerDepth + 1;
+    return $localize`:@@tree.contextMenu.expandAllFromHere.withDepth:Expand all from here (+${levels}:LEVELS: levels)`;
   }
 
   /**

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -3956,6 +3956,35 @@ export class JsonTreeComponent {
   }
 
   /**
+   * Returns the label for the top-level `Expand all from here` row.
+   * When the subtree has at least two container levels reachable,
+   * suffixes the label with the depth count (`(+N levels)`) so the
+   * user can see how deep `all` will go before clicking.
+   *
+   * Threshold behavior (`maxDescendantDepth >= 2` for suffix):
+   * - depth 0 (primitives-only): row is hidden by the
+   *   `hasContainerDescendants` gate; method returns the base label
+   *   as a safe default for any programmatic caller.
+   * - depth 1: suffix omitted. The bolded `Expand 1 level` surfaced
+   *   shortcut row sits directly above; a `(+1 level)` suffix here
+   *   would visually collide with that shortcut's depth call-out.
+   *   The two actions still differ in scope (the bolded shortcut
+   *   only expands the clicked container; `expandAll` also expands
+   *   the deeper container descendant), but the verbs `1 level` vs
+   *   `all` carry that distinction without an explicit count.
+   * - depth >= 2: suffix shown so the action's reach is visible.
+   *
+   * The suffixed message is always plural ("levels") because the
+   * threshold rules out the singular case; the source string avoids
+   * an i18n ICU plural for which the codebase has no precedent.
+   */
+  ctxExpandAllFromHereLabelFor(node: TreeNode): string {
+    const depth = this.maxDescendantDepth(node);
+    if (depth < 2) return this.ctxExpandAllFromHereElevatedLabel;
+    return $localize`:@@tree.contextMenu.expandAllFromHere.withDepth:Expand all from here (+${depth}:DEPTH: levels)`;
+  }
+
+  /**
    * Length of the longest path from `node` down to any descendant
    * **container** (not counting primitive leaves). Drives the cap on
    * visible "Expand to depth +N" entries so we never offer an `+N`

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -4341,24 +4341,24 @@
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.expandAllFromHere.withDepth" datatype="html">
-        <source>Expand all from here (+<x id="DEPTH" equiv-text="depth"/> levels)</source>
+        <source>Expand all from here (+<x id="LEVELS" equiv-text="levels"/> levels)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3984</context>
+          <context context-type="linenumber">4013</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.beacon.badge.tooltip.single" datatype="html">
         <source>Jump to hidden beacon (<x id="icon" equiv-text="icon"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">4404</context>
+          <context context-type="linenumber">4433</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.beacon.badge.tooltip.many" datatype="html">
         <source>Jump to first of <x id="count" equiv-text="descendantCount"/> hidden <x id="icon" equiv-text="icon"/> beacons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">4405</context>
+          <context context-type="linenumber">4434</context>
         </context-group>
       </trans-unit>
       <trans-unit id="splash.label.render" datatype="html">

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -114,39 +114,39 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1150</context>
+          <context context-type="linenumber">1295</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1834</context>
+          <context context-type="linenumber">1986</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1844</context>
+          <context context-type="linenumber">1996</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1852</context>
+          <context context-type="linenumber">2004</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1862</context>
+          <context context-type="linenumber">2014</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2159</context>
+          <context context-type="linenumber">2311</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2169</context>
+          <context context-type="linenumber">2321</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2205</context>
+          <context context-type="linenumber">2357</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2215</context>
+          <context context-type="linenumber">2367</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/rule-sets-toolbar/rule-sets-toolbar.component.ts</context>
@@ -543,7 +543,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2185</context>
+          <context context-type="linenumber">2337</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.cancel" datatype="html">
@@ -562,7 +562,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2186</context>
+          <context context-type="linenumber">2338</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/rule-sets-toolbar/clone-preset-dialog.component.ts</context>
@@ -577,7 +577,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2204</context>
+          <context context-type="linenumber">2356</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.failed" datatype="html">
@@ -588,7 +588,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2214</context>
+          <context context-type="linenumber">2366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="formattingRules.title" datatype="html">
@@ -2051,175 +2051,175 @@
         <source>JotJSON - JSON viewer, formatter, and tree explorer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">532</context>
+          <context context-type="linenumber">662</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.title.untitled" datatype="html">
         <source>Untitled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">722</context>
+          <context context-type="linenumber">852</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.coldBootClipboard.snackbar.pasted" datatype="html">
         <source>Pasted from clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">995</context>
+          <context context-type="linenumber">1125</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.coldBootClipboard.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">996</context>
+          <context context-type="linenumber">1126</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.toast" datatype="html">
         <source>Reloaded - this blob was changed in another tab</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1149</context>
+          <context context-type="linenumber">1294</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.title" datatype="html">
         <source>Blob changed in another tab</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1232</context>
+          <context context-type="linenumber">1377</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.message" datatype="html">
         <source>Your local changes conflict with the latest version. Discard your changes or replace the remote version on your next save?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1233</context>
+          <context context-type="linenumber">1378</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.replaceRemote" datatype="html">
         <source>Replace remote</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1234</context>
+          <context context-type="linenumber">1379</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.discardMine" datatype="html">
         <source>Discard my changes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1235</context>
+          <context context-type="linenumber">1380</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.tooMany" datatype="html">
         <source>Please drop one file at a time.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1833</context>
+          <context context-type="linenumber">1985</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.tooLarge" datatype="html">
         <source>File too large - max 5 MB</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1843</context>
+          <context context-type="linenumber">1995</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.binary" datatype="html">
         <source>File does not appear to be a text file - upload was ignored.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1851</context>
+          <context context-type="linenumber">2003</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.readFailed" datatype="html">
         <source>Could not read file</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1861</context>
+          <context context-type="linenumber">2013</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.quotaExceeded" datatype="html">
         <source>Blob limit reached - delete one from your saved blobs to save a new blob.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2034</context>
+          <context context-type="linenumber">2186</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.signIn" datatype="html">
         <source>Please sign in to save</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2052</context>
+          <context context-type="linenumber">2204</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.forbidden" datatype="html">
         <source>You do not own this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2055</context>
+          <context context-type="linenumber">2207</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.generic" datatype="html">
         <source>Could not save - please try again</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2057</context>
+          <context context-type="linenumber">2209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.success" datatype="html">
         <source>Share link copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2134</context>
+          <context context-type="linenumber">2286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.failed" datatype="html">
         <source>Failed to copy share link.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2135</context>
+          <context context-type="linenumber">2287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2136</context>
+          <context context-type="linenumber">2288</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.public" datatype="html">
         <source>Blob is now public.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2157</context>
+          <context context-type="linenumber">2309</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.private" datatype="html">
         <source>Blob is now private.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2158</context>
+          <context context-type="linenumber">2310</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.failed" datatype="html">
         <source>Failed to update visibility.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2168</context>
+          <context context-type="linenumber">2320</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.title" datatype="html">
         <source>Delete this blob?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2183</context>
+          <context context-type="linenumber">2335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.message" datatype="html">
         <source>&quot;<x id="name" equiv-text="label"/>&quot; will be permanently deleted. This cannot be undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2184</context>
+          <context context-type="linenumber">2336</context>
         </context-group>
       </trans-unit>
       <trans-unit id="formattingRules.clone.title" datatype="html">
@@ -3562,50 +3562,50 @@
         <source>Date annotation</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">346,347</context>
+          <context context-type="linenumber">348,349</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.extract.button.title" datatype="html">
         <source>Extract embedded JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">409,410</context>
+          <context context-type="linenumber">412,413</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.extract.button.aria" datatype="html">
         <source>Extract embedded JSON from this string</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">411,413</context>
+          <context context-type="linenumber">414,416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.highlighted.aria" datatype="html">
         <source>highlighted</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">439,441</context>
+          <context context-type="linenumber">442,444</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">556,558</context>
+          <context context-type="linenumber">561,563</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">592,594</context>
+          <context context-type="linenumber">599,601</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.empty" datatype="html">
         <source> Paste or type JSON on the left to see the tree view. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">602,605</context>
+          <context context-type="linenumber">609,612</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.extract.menu.label" datatype="html">
         <source>Extract embedded JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.html</context>
-          <context context-type="linenumber">657,660</context>
+          <context context-type="linenumber">664,667</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.type.date" datatype="html">
@@ -4263,95 +4263,102 @@
         <source>Path copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2692</context>
+          <context context-type="linenumber">2706</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.copyPath.failed" datatype="html">
         <source>Failed to copy path.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2693</context>
+          <context context-type="linenumber">2707</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.copyPath.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2694</context>
+          <context context-type="linenumber">2708</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.decoded.tooltipTruncated" datatype="html">
         <source>... (<x id="PH" equiv-text="remaining"/> more characters; open the pill to view full value)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">2923</context>
+          <context context-type="linenumber">2937</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.success.key" datatype="html">
         <source>Key copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3039</context>
+          <context context-type="linenumber">3053</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.failed.key" datatype="html">
         <source>Failed to copy key.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3040</context>
+          <context context-type="linenumber">3054</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3041</context>
+          <context context-type="linenumber">3055</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3075</context>
+          <context context-type="linenumber">3089</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.success.value" datatype="html">
         <source>Value copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3073</context>
+          <context context-type="linenumber">3087</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.copy.failed.value" datatype="html">
         <source>Failed to copy value.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3074</context>
+          <context context-type="linenumber">3088</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.highlight.swatch.aria" datatype="html">
         <source><x id="name" equiv-text="swatch.name"/> <x id="hex" equiv-text="swatch.hex"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3268</context>
+          <context context-type="linenumber">3282</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.contextMenu.removeTreeHighlight.rooted" datatype="html">
         <source>Remove tree highlight rooted at <x id="ancestorPath" equiv-text="ancestorPath"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">3277</context>
+          <context context-type="linenumber">3291</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="tree.contextMenu.expandAllFromHere.withDepth" datatype="html">
+        <source>Expand all from here (+<x id="DEPTH" equiv-text="depth"/> levels)</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
+          <context context-type="linenumber">3984</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.beacon.badge.tooltip.single" datatype="html">
         <source>Jump to hidden beacon (<x id="icon" equiv-text="icon"/>)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">4361</context>
+          <context context-type="linenumber">4404</context>
         </context-group>
       </trans-unit>
       <trans-unit id="tree.beacon.badge.tooltip.many" datatype="html">
         <source>Jump to first of <x id="count" equiv-text="descendantCount"/> hidden <x id="icon" equiv-text="icon"/> beacons</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/json-tree/json-tree.component.ts</context>
-          <context context-type="linenumber">4362</context>
+          <context context-type="linenumber">4405</context>
         </context-group>
       </trans-unit>
       <trans-unit id="splash.label.render" datatype="html">


### PR DESCRIPTION
## Summary

Adds a depth hint to the v0.23.0 top-level **Expand all from here** row
in the per-row right-click / kebab context menu. When the row is
visible at all (the `hasContainerDescendants` gate ensures at least
one container descendant exists), the row's label becomes
`Expand all from here (+N levels)` so users can see how deep `all`
will go before clicking.

| Subtree depth (`maxDescendantDepth`) | Label rendered today | Label rendered after this PR |
|---|---|---|
| 0 (primitives-only) | row hidden by `hasContainerDescendants` gate | (unchanged - row hidden) |
| 1 (one container descendant) | `Expand all from here` | `Expand all from here (+2 levels)` |
| 5 | `Expand all from here` | `Expand all from here (+6 levels)` |
| 11 | `Expand all from here` | `Expand all from here (+12 levels)` |

The label scales past the `+1..+9` ceiling of the per-row depth
submenu, which is the whole point of the hint: deep subtrees that the
submenu can't reach get a depth signal on the top-level row instead.

## Why

The user asked the right question: "when we're doing 'expand all', do
we always know how deep 'all' is? if so, should we indicate that
somehow?" We do know (`maxDescendantDepth(node) + 1`, see metric note
below), and on a deep subtree the bare `Expand all from here` label
tells the user nothing about how much expansion they're about to
trigger. The hint matches the existing `+N levels` vocabulary the
per-row depth submenu already uses, so the whole right-click menu
speaks one unit of measure.

## The metric: `maxDescendantDepth(node) + 1`

The label uses `containerDepth + 1` where `containerDepth =
maxDescendantDepth(node)`. The `+ 1` matters: `expandAllFromHere`
walks every container at relative depth `0..maxDescendantDepth`
(inclusive), which is `maxDescendantDepth + 1` distinct depths of
expansion in the submenu's `+N levels` vocabulary. The earlier
version of this PR used `maxDescendantDepth` directly and undercounted
by 1 - the fix is in the follow-up commit on this branch.

A deliberate `+1` gap remains between the largest submenu option and
the top-level row: the submenu caps at `+M levels` (where `M =
maxDescendantDepth`), and the top-level row reads `+(M + 1) levels`.
That gap is the informative signal "Expand all from here reaches one
level beyond the largest submenu option."

## Implementation

Surgical scope: one new public method + one template binding swap +
one new `$localize` ID.

- `ctxExpandAllFromHereLabelFor(node: TreeNode): string` -- returns
  the base label when `containerDepth < 1` (defensive guard;
  production callers are already filtered by
  `hasContainerDescendants`), else returns the suffixed label via
  `$localize`-with-interpolation. The interpolation syntax
  `${levels}:LEVELS:` matches the existing precedent at
  `toolbar.component.ts:292`.
- Template `json-tree.component.html:748` swaps
  `{{ ctxExpandAllFromHereElevatedLabel }}` for
  `{{ ctxExpandAllFromHereLabelFor(cn) }}`.
- New `$localize` ID `@@tree.contextMenu.expandAllFromHere.withDepth`
  with always-plural source string ("levels"). No ICU plural -- the
  codebase has zero `$localize` ICU precedents and the smallest
  visible suffix is `(+2 levels)`, so the singular case never arises.

No HTML structure change, no type-union edits, no predicate edits, no
spec-level redesign.

## Bug fix follow-up

Initial commit shipped with two bugs found in self-review of two
screenshots:

1. **Threshold-at-2 hid the depth-1 case from the user.** The first
   screenshot showed `Parameters` (a depth-1 container) without a
   suffix even though `Expand all` reached 2 levels. The original
   plan suppressed the suffix at depth 1 to avoid "collision" with
   the bolded `Expand 1 level` row above, but the user pointed out
   the suffix is the whole feature - hiding it defeats the request.
   **Fix:** threshold dropped; suffix shown whenever the row is.
2. **Off-by-one undercount.** The second screenshot showed `Expand
   all from here (+2 levels)` while the submenu also topped out at
   `+2 levels`, even though `Expand all` reaches one level beyond
   the submenu. **Fix:** label uses `maxDescendantDepth + 1` instead
   of `maxDescendantDepth`. See "The metric" section above.

Both fixes ship in the follow-up commit. Tests updated to match:
- Deleted the old depth-1-suppression test.
- Added a smallest-visible-depth test (depth-1 fixture ->
  `(+2 levels)`).
- Updated depth-5 fixture to `(+6 levels)` and depth-11 fixture to
  `(+12 levels)`.
- Added an action-equivalence test that compares
  `expandAllFromHere` end-state to
  `expandToDepthFromHere(_, labelN)` end-state via the
  `__getHelpersForTesting().readExpandedPaths()` seam.

## Why this is label-only (telemetry deferred)

The initial plan also proposed migrating
`tree.contextMenu.expandAllFromHere` from `logger.info()` to
`logger.event()` and adding a depth bucket. Skeptic round 4 found:
1. Strict `toHaveBeenCalledWith` matchers at `spec.ts:6788` and
   `:7152` would break.
2. The `defaultActionKind() as 'expandRow'|'collapseRow'` cast would
   be unsound for programmatic callers (returns `'none'` too).
3. The `logger.info -> logger.event` migration would move one event
   from `traces` to `customEvents` mid-batch, splitting issue #241's
   atomic migration.
4. AGENTS.md §4 prescribes shipping bucket + raw together;
   deferring the bucket alone violates the convention.

So telemetry is unchanged here and rolls up with issue #241.

**Known telemetry divergence:** the `tree.expand.slow` event still
emits `depth: maxDescendantDepth` from the top-level row (i.e., one
less than the suffix the user sees). The field-rename and value
reconciliation are batched with issue #241.

## SemVer

Minor pre-1.0. New user-visible affordance (depth hint on row label).
Bumped 0.23.2 -> **0.25.0** because PR #263 (safer-extract-ux) is
open and targeting v0.24.0. If that PR lands *after* this one, the
bump should revert to 0.24.0 in a follow-up commit (mention this if
reviewing in either order).

## Mockups (ASCII)

**Shallow subtree (depth 1, fixture `{ outer: { mid: { inner: 1 } } }`):**

```
| *Expand 1 level          |  <- bolded surfaced dblclick mirror
| Expand all from here (+2 levels) |  <- NEW
| Subtree              >   |
```

**Mid subtree (`maxDescendantDepth = 5`):**

```
| *Expand 1 level          |
| Expand all from here (+6 levels) |  <- NEW
| Subtree              >   |
```

**Deep subtree (`maxDescendantDepth = 11`, beyond the +1..+9 submenu range):**

```
| *Expand 1 level          |
| Expand all from here (+12 levels) |  <- NEW (the submenu can't reach this far)
| Subtree              >   |
```

## DoD verification (local)

All §7 gates pass on `expand-all-show-depth` after the follow-up commit:

- `npm run lint:all` (root + api lint chains): OK
- `npm test`: 2621 frontend tests pass (3 skipped, 0 failed)
- `npm --prefix api test`: 465 api tests pass
- `npm run build`: production build + prerender + postbuild-seo all OK

Critical-thinking notes for the reviewer:

- The `ctxExpandAllFromHereLabelFor` method is called from the
  template, so it runs once per change-detection tick when the menu
  is open. This is the same call frequency as the existing
  `hasContainerDescendants(cn)` template gate, which already calls
  `maxDescendantDepth(cn)` internally. So the menu now does **two**
  walks of the subtree per CD tick where it used to do one.
  Acceptable in practice (the menu only renders when open, and the
  walk is O(containers)), but worth noting; if it ever shows up in a
  profile, both can share a memoized result.
- The `$localize`-with-interpolation form is evaluated on every call.
  `$localize` itself is fast, but the new tagged-template result is
  freshly allocated each time. Same caveat as above.

## Pre-presentation gate

| | |
|---|---|
| Critic agent | `deep-review:skeptic` (rounds 1-4) + `deep-review:architect` + `deep-review:advocate` (round 3); plus two further `deep-review:skeptic` passes on the bug-fix follow-up. |
| Critic conclusions | Initial: 15 + 11 + panel-of-3 + 6 findings collapsed plan to label-only. Bug-fix follow-up rubber-duck rounds 1 and 2 surfaced 8 + 5 findings (off-by-one math, threshold-dropped docstring, test-assertion drift, telemetry divergence note, brittle test parsing); all addressed in the follow-up commit. |
| Net result | Plan collapsed to **label-only** in the initial commit; off-by-one and threshold bugs caught in self-review and fixed in the follow-up commit. Telemetry, sink migration, and bucket all deferred to issue #241. |

---

**Session**

- AI-Local: `a99fe0fa-0920-4e14-90d3-50e374c78cab`
- AI-Cloud: `db29e626-0f53-4547-9430-937da15d4b33`
