### PR TITLE
Recognize ASP.NET / WCF JSON date format in tree annotations

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -467,7 +467,7 @@ The primary page. Available to **all users** (anonymous + registered).
     - `null` - null values.
     - `array:N` - arrays, where N is the number of direct items (e.g., `array:5`).
     - `json:X` - objects, where X is the total number of nodes in the subtree rooted at that object (recursive count of all descendant keys). E.g., a nested object containing 3 keys, one of which is itself an object with 2 keys, displays `json:5`.
-    - String values are additionally classified into more specific labels when the content matches: `date` and `date/time` (parseable ISO 8601, RFC 2822, or slash-form date - gated by `treeShowDateAnnotations` so the badge stays in sync with the annotation visibility), `uuid`, `url`, `email`, `path` (URL-style absolute or relative paths, e.g., `/api/v2/items` or `docs/intro.md` - excludes full URLs with scheme), `ipv4`, `ipv6`. Detection is conservative; ambiguous strings fall back to `string`.
+    - String values are additionally classified into more specific labels when the content matches: `date` and `date/time` (parseable ISO 8601, RFC 2822, slash-form date, or the legacy ASP.NET / WCF JSON date format `/Date(<ms>[+/-HHMM])/` - gated by `treeShowDateAnnotations` so the badge stays in sync with the annotation visibility), `uuid`, `url`, `email`, `path` (URL-style absolute or relative paths, e.g., `/api/v2/items` or `docs/intro.md` - excludes full URLs with scheme), `ipv4`, `ipv6`. Detection is conservative; ambiguous strings fall back to `string`.
   - Type labels are styled with a muted/subdued color and a small sans-serif font so they don't compete with the key/value content. Type labels use a single muted color rather than per-type coloring - leaf values themselves already carry semantic color (strings, numbers, booleans, null), so coloring the type badge too would be visual noise. Per the **decoration vs data font** rule below, the badge - like every other JotJSON-added annotation in the tree - renders in the UI sans-serif face rather than the document's monospace face.
   - Type labels can be toggled on/off via the "Show type labels" preference in user settings.
   - **Decoration vs data fonts.** The tree mixes two type families on every row, and the rule for which to use is uniform: **anything inside the user's JSON document renders in the document's monospace face; anything JotJSON adds *about* the document renders in the UI sans-serif face, italic and dimmed.**
@@ -488,7 +488,7 @@ The primary page. Available to **all users** (anonymous + registered).
     - Followed by a parenthetical annotation showing: the parsed date/time in the user's local format and an approximate relative time.
     - Example: `"2024-11-05T18:30:00Z"  (Nov 5, 2024, 11:30 AM PST - 1 year ago)`
     - The annotation is styled in a muted/italic font to distinguish it from the raw value.
-    - Detection heuristics: ISO 8601, RFC 2822, and common formats like `YYYY-MM-DD`, `MM/DD/YYYY`. Uses a conservative parser - ambiguous strings (e.g., `"12345"`, `"hello"`) are not treated as dates. Numeric values (e.g., Unix timestamps) are **not** annotated - only string values are eligible.
+    - Detection heuristics: ISO 8601, RFC 2822, common formats like `YYYY-MM-DD`, `MM/DD/YYYY`, and the legacy ASP.NET / WCF JSON date format `/Date(<ms>[+/-HHMM])/`. Uses a conservative parser - ambiguous strings (e.g., `"12345"`, `"hello"`) are not treated as dates. Numeric values (e.g., Unix timestamps) are **not** annotated - only string values are eligible. For the ASP.NET / WCF format, the optional timezone-offset suffix is informational and ignored; the millisecond value is treated as UTC and re-localized for display via `Intl.DateTimeFormat`. The annotation always renders with a time component for this format because it cannot syntactically distinguish a date-only payload from a date+time payload.
     - Relative time updates live (e.g., "3 minutes ago" -> "4 minutes ago") while the page is open.
     - This feature can be toggled on/off via a tree toolbar toggle or the `treeShowDateAnnotations` user preference.
     - Two related preferences (`treeAssumeUtcForIsoDateTime`, `treeAssumeUtcForIsoDateOnly`, both default `true`) control whether ISO 8601 strings without an explicit timezone designator are interpreted as UTC. Defaults match the conventional reading of machine-emitted timestamps (logs, .NET round-trips, etc.); turn off either setting to fall back to native `Date` semantics (date-time as local, date-only as local midnight). The displayed absolute date is always in the user's local timezone via `Intl.DateTimeFormat` - these settings only change what instant the source string represents.
@@ -914,6 +914,13 @@ therefore use a dedicated deterministic helper at
 preference-sensitive search classifier in
 `src/app/shared/utils/value-classifier.ts`. The helper classifies the JSON
 value into `valueKind` and `isEmpty` for the engine.
+
+When the deferred `is_date` / `is_date_time` format predicates ship,
+the deterministic helper must recognize every date shape that
+`parseAsDate` accepts (ISO 8601, RFC 2822, slash-form, and the
+legacy ASP.NET / WCF JSON date format `/Date(<ms>[+/-HHMM])/`) so
+saved rule sets agree with the search-side `date` / `date/time`
+badges.
 
 #### Stale-tab graceful degradation
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.25.2",
+  "version": "0.26.0",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/shared/utils/date-detect.spec.ts
+++ b/src/app/shared/utils/date-detect.spec.ts
@@ -362,4 +362,120 @@ describe('date-detect', () => {
       expect(a.date.getTime()).toBe(b.date.getTime());
     });
   });
+
+  describe('parseAsDate - ASP.NET JSON date', () => {
+    // All assertions intentionally use getTime() / toISOString() so the
+    // tests pass regardless of the runner's local timezone. Earlier
+    // local-field-based assertions in this file (e.g. ISO date-only
+    // tests at the top) are TZ-coupled by design; the ASP.NET path is
+    // an absolute ms-since-epoch instant and must not be.
+    it('parses canonical form with negative offset', () => {
+      const parsed = parseAsDate('/Date(1510050044592-0800)/');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.date.getTime()).toBe(1510050044592);
+      expect(parsed!.hasTime).toBe(true);
+    });
+
+    it('parses without offset', () => {
+      const parsed = parseAsDate('/Date(1510050044592)/');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.date.getTime()).toBe(1510050044592);
+    });
+
+    it('parses with positive zero offset', () => {
+      const parsed = parseAsDate('/Date(1510050044592+0000)/');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.date.getTime()).toBe(1510050044592);
+    });
+
+    it('discards the offset entirely (a garbage 4-digit suffix still parses)', () => {
+      // The offset is informational-only per the format spec. The
+      // regex deliberately accepts any 4-digit `+HHMM` / `-HHMM`
+      // suffix without semantic validation - the ms value is the
+      // only authoritative payload.
+      const parsed = parseAsDate('/Date(1510050044592+9999)/');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.date.getTime()).toBe(1510050044592);
+    });
+
+    it('parses /Date(0)/ as the Unix epoch', () => {
+      const parsed = parseAsDate('/Date(0)/');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.date.toISOString()).toBe('1970-01-01T00:00:00.000Z');
+      expect(parsed!.hasTime).toBe(true);
+    });
+
+    it('parses negative ms (pre-epoch but still in range)', () => {
+      // -1510050044592 ms is approx year 1922 UTC, comfortably inside
+      // the [1900, 2100] range even after local-TZ year shift.
+      const parsed = parseAsDate('/Date(-1510050044592)/');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.date.getTime()).toBe(-1510050044592);
+    });
+
+    it('locks in hasTime:true even for midnight-UTC ms values', () => {
+      // 1700006400000 is 2023-11-15T00:00:00Z. The natural-looking
+      // heuristic ms % 86400000 === 0 would call this date-only, but
+      // the format cannot distinguish "DateTime used as a date" from
+      // "DateTime at exactly midnight UTC", so we always emit
+      // hasTime:true. Test pins the decision; do not relax this
+      // without revisiting the §491 spec caveat.
+      const parsed = parseAsDate('/Date(1700006400000)/');
+      expect(parsed).not.toBeNull();
+      expect(parsed!.hasTime).toBe(true);
+    });
+
+    it('rejects non-numeric content inside the wrapper', () => {
+      expect(parseAsDate('/Date(abc)/')).toBeNull();
+    });
+
+    it('rejects empty wrapper', () => {
+      expect(parseAsDate('/Date()/')).toBeNull();
+    });
+
+    it('rejects colon-bearing offset (not in the canonical format)', () => {
+      expect(parseAsDate('/Date(1510050044592-08:00)/')).toBeNull();
+    });
+
+    it('rejects missing leading slash', () => {
+      expect(parseAsDate('Date(1510050044592)/')).toBeNull();
+    });
+
+    it('rejects missing trailing slash', () => {
+      expect(parseAsDate('/Date(1510050044592)')).toBeNull();
+    });
+
+    it('rejects trailing content after the wrapper', () => {
+      expect(parseAsDate('/Date(1510050044592)/extra')).toBeNull();
+    });
+
+    it('rejects the backslash-escaped form', () => {
+      // The escaped form `\/Date(...)\/` is a JSON-string artifact;
+      // by the time parseAsDate sees the value, the parser has
+      // already unescaped one layer. We deliberately do not
+      // accommodate doubly-escaped values - that would mask an
+      // upstream parser bug.
+      expect(parseAsDate('\\/Date(1510050044592)\\/')).toBeNull();
+    });
+
+    it('rejects ms outside the [1900, 2100] year range', () => {
+      // -9999999999999 ms is approximately year 1653 AD: regex
+      // matches (13 digits with leading minus) but isInRange rejects.
+      expect(parseAsDate('/Date(-9999999999999)/')).toBeNull();
+    });
+
+    it('rejects ms with more than 13 digits (regex bound)', () => {
+      // 17-digit value: \d{1,13} cannot consume it without leaving
+      // a digit where the regex expects ) or +/-.
+      expect(parseAsDate('/Date(99999999999999999)/')).toBeNull();
+    });
+
+    it('produces identical results regardless of assumeUtc opts', () => {
+      const opts = { assumeUtcForIsoDateTime: true, assumeUtcForIsoDateOnly: true };
+      const a = parseAsDate('/Date(1510050044592-0800)/')!;
+      const b = parseAsDate('/Date(1510050044592-0800)/', undefined, opts)!;
+      expect(a.date.getTime()).toBe(b.date.getTime());
+      expect(a.hasTime).toBe(b.hasTime);
+    });
+  });
 });

--- a/src/app/shared/utils/date-detect.ts
+++ b/src/app/shared/utils/date-detect.ts
@@ -21,6 +21,18 @@ const SLASH_DATE = /^(\d{1,2})\/(\d{1,2})\/(\d{4})(?:[T ](\d{1,2}):(\d{2})(?::(\
 const RFC2822_ISH =
   /^(?:(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun),?\s+)?(?:(\d{1,2})\s+([A-Za-z]{3,9})|([A-Za-z]{3,9})\s+(\d{1,2}))[,\s]+(\d{4})(?:\s+(\d{1,2}):(\d{2})(?::(\d{2}))?(?:\s*(?:Z|GMT|UTC|[+-]\d{2}:?\d{2}))?)?$/;
 
+// Microsoft ASP.NET / WCF JSON date format: /Date(<ms-since-epoch>[<+|-><HHMM>])/.
+// The optional timezone suffix is informational only per the format
+// spec - the millisecond value is always UTC. We discard the offset and
+// let Intl.DateTimeFormat re-localize for display, matching the
+// existing ISO-with-offset precedent. The regex deliberately does not
+// accept the backslash-escaped form (`\/Date(...)\/ `); those are
+// expected to be unescaped upstream by the JSON parser. `\d{1,13}` is
+// sized to cover the legal range - 13 digits is the largest ms value
+// landing inside [1900-01-01, 2100-12-31]; `isInRange` catches any
+// overshoot the regex permits.
+const DOTNET_DATE = /^\/Date\((-?\d{1,13})(?:[+-]\d{4})?\)\/$/;
+
 const MIN_YEAR = 1900;
 const MAX_YEAR = 2100;
 
@@ -143,6 +155,22 @@ export function parseAsDate(raw: unknown, locale?: string, opts?: ParseOptions):
   if (typeof raw !== 'string') return null;
   const trimmed = raw.trim();
   if (trimmed.length < 8 || trimmed.length > 40) return null;
+
+  // ASP.NET / WCF format is structurally exclusive of every other
+  // matcher (which all start with `\d` or `[A-Za-z]`), so checking it
+  // first is both correct and cheap. `hasTime: true` is unconditional:
+  // the format has no syntactic way to distinguish a DateTime used as
+  // a date (midnight-UTC payload) from a DateTime carrying a real
+  // time-of-day. We pick the shape-faithful answer and accept that
+  // west-of-UTC users pasting a midnight-UTC value see e.g.
+  // "Nov 14, 2023, 7:00 PM" rather than "Nov 15, 2023". The two
+  // `assumeUtc*` options have no effect here - the ms value is
+  // already an absolute instant.
+  const dotnet = DOTNET_DATE.exec(trimmed);
+  if (dotnet) {
+    const date = new Date(Number(dotnet[1]));
+    return isInRange(date) ? { date, hasTime: true } : null;
+  }
 
   if (ISO_WITH_TIME.test(trimmed)) {
     const hasTz = ISO_TZ_SUFFIX.test(trimmed);

--- a/src/app/shared/utils/date-detect.ts
+++ b/src/app/shared/utils/date-detect.ts
@@ -9,6 +9,7 @@
  *   - ISO date-only:         YYYY-MM-DD
  *   - Slash with 4-digit year: NN/NN/YYYY (order resolved by user locale)
  *   - Loose RFC 2822 / human:  "Mon DD, YYYY" or "DD Mon YYYY" + optional time
+ *   - ASP.NET / WCF JSON date: /Date(<ms-since-epoch>[+/-HHMM])/ (offset informational, ignored)
  *
  * Strings that pass the regex are parsed and required to land in
  * [1900-01-01, 2100-12-31] to defend against e.g. accidental epoch parses.
@@ -26,7 +27,7 @@ const RFC2822_ISH =
 // spec - the millisecond value is always UTC. We discard the offset and
 // let Intl.DateTimeFormat re-localize for display, matching the
 // existing ISO-with-offset precedent. The regex deliberately does not
-// accept the backslash-escaped form (`\/Date(...)\/ `); those are
+// accept the backslash-escaped form (`\/Date(...)\/`); those are
 // expected to be unescaped upstream by the JSON parser. `\d{1,13}` is
 // sized to cover the legal range - 13 digits is the largest ms value
 // landing inside [1900-01-01, 2100-12-31]; `isInRange` catches any

--- a/src/app/shared/utils/value-classifier.spec.ts
+++ b/src/app/shared/utils/value-classifier.spec.ts
@@ -13,6 +13,10 @@ describe('value-classifier', () => {
     it('skips date detection when detectDates is false', () => {
       expect(classifyValue('string', '2024-11-05', { detectDates: false })).toBe('string');
     });
+
+    it('classifies ASP.NET /Date(...)/ format as date/time', () => {
+      expect(classifyValue('string', '/Date(1510050044592-0800)/')).toBe('date/time');
+    });
   });
 
   describe('classifyValue - uuid', () => {


### PR DESCRIPTION
## Summary

Recognize the legacy Microsoft ASP.NET / WCF JSON date format
(e.g. `/Date(1510050044592-0800)/`) as a fifth shape in the
conservative date detector that powers tree-row date annotations and
the `date` / `date/time` value-classifier badges.

**Before / after:**

```
Before:   "timestamp": "/Date(1510050044592-0800)/"   [string]
After:    "timestamp": "/Date(1510050044592-0800)/"   [date/time]   (Nov 7, 2017, 12:20 AM - 8 years ago)
```

No new components, no new layouts, no new preferences. The existing
annotation render path is reused; only the set of recognized input
shapes is extended.

## Why this format

The ASP.NET JSON date format
(`/Date(<ms-since-epoch>[+/-<HHMM>])/`) was the default in
WCF, ASMX, and `JavaScriptSerializer` for years and still appears in
the wild from older .NET services. The wrapper is structurally
exclusive of any other shape JotJSON recognizes, so the
false-positive risk is essentially zero - a good fit for the
existing "conservative on purpose" detector.

## Implementation notes

- New `DOTNET_DATE` regex placed FIRST in `parseAsDate` after the
  length gate. The literal `/Date(` prefix is structurally exclusive
  of all four existing matchers (which start with `\d` or
  `[A-Za-z]`), so first-position is both correct and cheap.
- `\d{1,13}` bound on the ms group: 13 digits is the largest in-range
  ms value (year ~2100). `isInRange` catches any overshoot the regex
  would otherwise permit.
- Optional `[+-]\d{4}` timezone suffix is parsed but **discarded** -
  per the format spec it is informational and the ms value is always
  UTC. `Intl.DateTimeFormat` re-localizes for display, matching the
  existing ISO-with-offset precedent.
- `hasTime: true` is **unconditional** for this format. There is no
  syntactic way to distinguish a `DateTime` used as a calendar date
  (midnight-UTC payload) from a `DateTime` carrying a real
  time-of-day. The shape-faithful default is the more defensible
  choice; a code comment + spec caveat document the tradeoff and a
  unit test pins the decision.
- The backslash-escaped form (`\/Date(...)\/`) is intentionally NOT
  accepted - the JSON parser already unescaped one layer by the time
  the value reaches `parseAsDate`, so a doubly-escaped value would
  indicate an upstream parser bug rather than a real ASP.NET date.

## Tests

Added 17 unit tests under `parseAsDate - ASP.NET JSON date` in
`date-detect.spec.ts`, plus one in `value-classifier.spec.ts`. All
assertions use `getTime()` / `toISOString()` instead of local-field
getters (`getFullYear()` / `getMonth()` / `getDate()`) so the suite
stays timezone-agnostic on developer machines and CI.

Coverage:

- Positives: canonical form with negative offset, no offset, positive
  zero offset, garbage offset (shape accepted, semantics ignored),
  Unix epoch, pre-epoch negative ms.
- Rejections: non-numeric content, empty wrapper, colon-bearing
  offset, missing leading slash, missing trailing slash, trailing
  content, backslash-escaped form, out-of-range ms (regex matches but
  `isInRange` rejects), 17-digit overflow (regex rejects).
- `hasTime: true` lock-in for midnight-UTC values.
- `assumeUtc*` opts have no effect on this format.

## Spec updates

- §470 string-classifier list now enumerates the ASP.NET format.
- §491 detection-heuristics list documents the format plus the
  unconditional-`hasTime` and TZ-offset-discard behaviors.
- §Deterministic classifier adds a forward-pointer noting that when
  the deferred `is_date` / `is_date_time` format predicates ship,
  `formatting-value-kind.ts` must recognize the same set of date
  shapes so saved rule sets agree with the search-side badges.

## Existing fixture impact

Three test fixtures already contain `/Date(...)/` strings:
`JsonExtraction.json`, `Recursive.json`, `Semi-valid.json`. They
will newly render the annotation in dev mode but no spec asserts on
those `Timestamp` fields (verified via `npm test`: 2704/2705 SUCCESS
on this branch).

## Definition of Done

- `npm run lint:all` passes
- `npm test` passes (2704 / 2705 SUCCESS - 1 pre-existing skipped)
- `npm run build` passes
- `npm --prefix api test` passes (465 / 465)
- ASCII gate, prettier format gate clean
- `package.json` bumped 0.25.2 -> 0.26.0 (minor: new user-visible
  feature per `DESIGN_SPEC.md` versioning rules)
- Telemetry: no new event (recorded in plan; existing detection
  paths do not emit per-classification telemetry)
- i18n: no new user-visible strings (annotation reuses
  `Intl.DateTimeFormat` / `Intl.RelativeTimeFormat`)
- `why-jotjson.md`: no update (the user-visible behavior class -
  date annotations on string values - is unchanged; only a new
  recognized input shape was added)

---
**Session**
- AI-Local: `1cf45f7a-3898-4dc7-a2cd-b4c82f8db69d`
- AI-Cloud: `a0ab598d-b58e-4cd5-b762-c0e98beebd91`
