### PR TITLE
Route selectedPath writes through setUserSelection helper (#274, v0.27.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.26.0",
+  "version": "0.26.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.26.0",
+      "version": "0.26.2",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.26.1",
+  "version": "0.26.2",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -1,15 +1,24 @@
 #!/usr/bin/env node
 // Verifies that both workspace lockfiles (root and `api/`) are in sync with
-// their respective `package.json` files. Catches the class of bug introduced
-// by `npm install --legacy-peer-deps` or `--force` overrides that omit
-// transitive optional-peer entries which `npm ci` on Linux later rejects.
+// their respective `package.json` files. Catches two classes of bug:
 //
-// Implementation: runs `npm ci --dry-run --no-audit --no-fund` against each
-// workspace. `npm ci` errors if the lockfile and manifest disagree, and
-// `--dry-run` does not skip that sanity check; it just doesn't write to
-// `node_modules` or the working tree. ~2s per workspace on a clean tree.
+//   (a) Dependency-tree drift (e.g., `npm install --legacy-peer-deps` /
+//       `--force` overrides that omit transitive optional-peer entries
+//       which `npm ci` on Linux later rejects). Detected by running
+//       `npm ci --dry-run` per workspace.
 //
-// Two failure modes:
+//   (b) Root `version` field drift (e.g., a bump of `package.json` that
+//       forgot `package-lock.json`). `npm ci --dry-run` does NOT catch
+//       this case because the dependency tree is still consistent --
+//       npm validates the deps but treats the root `version` as
+//       metadata. PR #286 was the second occurrence; this gate
+//       prevents the third. Detected by parsing both JSON files and
+//       comparing `pkg.version === lock.version === lock.packages[""].version`.
+//
+// Implementation: runs (b) first (fast, pure JSON parse, ~5ms); if both
+// workspaces pass, runs (a) (slower, ~2s per workspace).
+//
+// Two failure modes for (a):
 //
 //   Lockfile drift (the case we care about) - npm output contains the
 //                  substring "lock file" (case-insensitive), e.g.
@@ -24,12 +33,18 @@
 //   npm run lint:lockfile
 
 import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, readFileSync, realpathSync } from 'node:fs';
 import { dirname, join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 const WORKSPACES = [
-  { name: 'root', prefix: null, lockfile: 'package-lock.json' },
-  { name: 'api/', prefix: 'api', lockfile: 'api/package-lock.json' },
+  { name: 'root', prefix: null, lockfile: 'package-lock.json', manifest: 'package.json' },
+  {
+    name: 'api/',
+    prefix: 'api',
+    lockfile: 'api/package-lock.json',
+    manifest: 'api/package.json',
+  },
 ];
 
 // Locate npm-cli.js relative to the running node binary so we can invoke it
@@ -50,15 +65,73 @@ function findNpmCli() {
   return null;
 }
 
-const NPM_CLI = findNpmCli();
-if (!NPM_CLI) {
-  console.error(
-    'check-lockfile: cannot locate npm-cli.js relative to process.execPath. Ensure npm is installed alongside node.',
-  );
-  process.exit(2);
+/**
+ * Pure function: compares the root `version` field in package.json against
+ * the two places it is mirrored in package-lock.json (`lock.version` and
+ * `lock.packages[""].version`). Returns null on match, or a short
+ * single-line message describing the drift on mismatch.
+ *
+ * Exported for unit-testing under `scripts/check-lockfile.test.mjs`.
+ *
+ * @param {unknown} pkg - parsed package.json contents
+ * @param {unknown} lock - parsed package-lock.json contents
+ * @returns {string | null}
+ */
+export function checkVersionInSync(pkg, lock) {
+  if (typeof pkg !== 'object' || pkg === null) {
+    return 'package.json did not parse to an object';
+  }
+  if (typeof lock !== 'object' || lock === null) {
+    return 'package-lock.json did not parse to an object';
+  }
+  const pkgVersion = /** @type {Record<string, unknown>} */ (pkg).version;
+  if (typeof pkgVersion !== 'string') {
+    return 'package.json is missing a string `version` field';
+  }
+  const lockVersion = /** @type {Record<string, unknown>} */ (lock).version;
+  const lockPackages = /** @type {Record<string, unknown>} */ (lock).packages;
+  if (typeof lockVersion !== 'string') {
+    return 'package-lock.json is missing a top-level string `version` field';
+  }
+  if (typeof lockPackages !== 'object' || lockPackages === null) {
+    return 'package-lock.json is missing the `packages` map';
+  }
+  const rootPkg = /** @type {Record<string, unknown>} */ (lockPackages)[''];
+  if (typeof rootPkg !== 'object' || rootPkg === null) {
+    return 'package-lock.json is missing the root `packages[""]` entry';
+  }
+  const rootPkgVersion = /** @type {Record<string, unknown>} */ (rootPkg).version;
+  if (typeof rootPkgVersion !== 'string') {
+    return 'package-lock.json `packages[""]` is missing a string `version` field';
+  }
+  if (pkgVersion !== lockVersion || pkgVersion !== rootPkgVersion) {
+    return (
+      `version drift: package.json=${pkgVersion}, ` +
+      `package-lock.json=${lockVersion}, ` +
+      `package-lock.json packages[""]=${rootPkgVersion}`
+    );
+  }
+  return null;
 }
 
-function runDryRun(workspace) {
+function printVersionDriftMessage(workspace, detail) {
+  const cdHint = workspace.prefix ? `cd ${workspace.prefix}; ` : '';
+  console.error('');
+  console.error(`check-lockfile: FAILED for workspace '${workspace.name}' (version drift)`);
+  console.error(`  ${detail}`);
+  console.error('  Common cause: bumped package.json `version` without syncing the lockfile.');
+  console.error('  Fix (hand-edit, avoids transitive churn):');
+  console.error(
+    `    Edit ${workspace.lockfile} so both top-level \`version\` and \`packages[""].version\``,
+  );
+  console.error(
+    `    match the new \`${workspace.manifest}\` \`version\`. \`npm ci --dry-run\` does NOT`,
+  );
+  console.error('    catch this case, so the gate above is the only repo-wide signal.');
+  console.error(`    git add ${workspace.lockfile}`);
+}
+
+function runDryRun(NPM_CLI, workspace) {
   const args = [NPM_CLI];
   if (workspace.prefix) {
     args.push('--prefix', workspace.prefix);
@@ -126,55 +199,107 @@ function printOtherFailureMessage(workspace, status) {
   );
 }
 
-let firstFailure = null;
-
-for (const workspace of WORKSPACES) {
-  if (!existsSync(workspace.lockfile)) {
+export function main() {
+  const NPM_CLI = findNpmCli();
+  if (!NPM_CLI) {
     console.error(
-      `check-lockfile: missing lockfile for workspace '${workspace.name}': ${workspace.lockfile}`,
+      'check-lockfile: cannot locate npm-cli.js relative to process.execPath. Ensure npm is installed alongside node.',
     );
-    process.exit(2);
+    return 2;
   }
 
-  process.stdout.write(`check-lockfile: validating workspace '${workspace.name}' ... `);
-  const result = runDryRun(workspace);
+  let firstFailure = null;
 
-  if (result.ok) {
-    process.stdout.write('OK\n');
-    continue;
+  // Phase 1 (fast): version-drift gate. Pure JSON parse, no subprocess.
+  // Catches PR #286-class bugs that `npm ci --dry-run` does not.
+  for (const workspace of WORKSPACES) {
+    if (!existsSync(workspace.manifest) || !existsSync(workspace.lockfile)) {
+      console.error(
+        `check-lockfile: missing manifest or lockfile for workspace '${workspace.name}'`,
+      );
+      return 2;
+    }
+    let pkg;
+    let lock;
+    try {
+      pkg = JSON.parse(readFileSync(workspace.manifest, 'utf8'));
+      lock = JSON.parse(readFileSync(workspace.lockfile, 'utf8'));
+    } catch (err) {
+      console.error(
+        `check-lockfile: failed to parse JSON for workspace '${workspace.name}': ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return 2;
+    }
+    const detail = checkVersionInSync(pkg, lock);
+    if (detail !== null) {
+      process.stdout.write(`check-lockfile: validating workspace '${workspace.name}' ... FAIL\n`);
+      printVersionDriftMessage(workspace, detail);
+      firstFailure = { kind: 'version-drift' };
+    }
+  }
+  if (firstFailure) {
+    return 1;
   }
 
-  process.stdout.write('FAIL\n');
-  // Stream npm's own output verbatim so the user sees the actual error first.
-  if (result.stdout) {
-    process.stdout.write(result.stdout);
-    if (!result.stdout.endsWith('\n')) process.stdout.write('\n');
-  }
-  if (result.stderr) {
-    process.stderr.write(result.stderr);
-    if (!result.stderr.endsWith('\n')) process.stderr.write('\n');
+  // Phase 2 (slow): dependency-tree gate via `npm ci --dry-run`.
+  for (const workspace of WORKSPACES) {
+    process.stdout.write(`check-lockfile: validating workspace '${workspace.name}' ... `);
+    const result = runDryRun(NPM_CLI, workspace);
+
+    if (result.ok) {
+      process.stdout.write('OK\n');
+      continue;
+    }
+
+    process.stdout.write('FAIL\n');
+    // Stream npm's own output verbatim so the user sees the actual error first.
+    if (result.stdout) {
+      process.stdout.write(result.stdout);
+      if (!result.stdout.endsWith('\n')) process.stdout.write('\n');
+    }
+    if (result.stderr) {
+      process.stderr.write(result.stderr);
+      if (!result.stderr.endsWith('\n')) process.stderr.write('\n');
+    }
+
+    if (result.kind === 'drift') {
+      printDriftMessage(workspace);
+    } else if (result.kind === 'spawn') {
+      console.error('');
+      console.error(
+        `check-lockfile: failed to spawn npm for workspace '${workspace.name}': ${result.stderr}`,
+      );
+    } else {
+      printOtherFailureMessage(workspace, result.status);
+    }
+
+    if (!firstFailure) {
+      firstFailure = result;
+    }
+    // Continue to the next workspace so the user sees both reports in one run.
   }
 
-  if (result.kind === 'drift') {
-    printDriftMessage(workspace);
-  } else if (result.kind === 'spawn') {
-    console.error('');
-    console.error(
-      `check-lockfile: failed to spawn npm for workspace '${workspace.name}': ${result.stderr}`,
-    );
-  } else {
-    printOtherFailureMessage(workspace, result.status);
+  if (firstFailure) {
+    return 1;
   }
 
-  if (!firstFailure) {
-    firstFailure = result;
-  }
-  // Continue to the next workspace so the user sees both reports in one run.
+  console.log('check-lockfile: OK (root + api/ lockfiles match their manifests)');
+  return 0;
 }
 
-if (firstFailure) {
-  process.exit(1);
-}
+// Only invoke main() when this file is executed directly. Importers
+// (the test file at scripts/check-lockfile.test.mjs) load the module
+// solely for its exports; they must not trigger the CLI side effects
+// (spawnSync npm, process.exit).
+const invokedDirectly = (() => {
+  try {
+    if (!process.argv[1]) return false;
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
+  } catch {
+    return false;
+  }
+})();
 
-console.log('check-lockfile: OK (root + api/ lockfiles match their manifests)');
-process.exit(0);
+if (invokedDirectly) {
+  process.exit(main());
+}

--- a/scripts/check-lockfile.mjs
+++ b/scripts/check-lockfile.mjs
@@ -115,7 +115,6 @@ export function checkVersionInSync(pkg, lock) {
 }
 
 function printVersionDriftMessage(workspace, detail) {
-  const cdHint = workspace.prefix ? `cd ${workspace.prefix}; ` : '';
   console.error('');
   console.error(`check-lockfile: FAILED for workspace '${workspace.name}' (version drift)`);
   console.error(`  ${detail}`);

--- a/scripts/check-lockfile.test.mjs
+++ b/scripts/check-lockfile.test.mjs
@@ -1,0 +1,125 @@
+// Unit tests for scripts/check-lockfile.mjs.
+//
+// Runs under Node's built-in test runner: `node --test`. No external
+// dependencies. The test file imports the script as a module; the script
+// guards `main()` behind an "invoked directly" check so importing it does
+// not trigger CLI side effects (spawnSync npm, process.exit).
+//
+// Coverage focuses on `checkVersionInSync` -- the version-drift gate
+// added in response to PR #286 review feedback. The dependency-tree
+// gate (Phase 2, `npm ci --dry-run`) is exercised end-to-end by the
+// real `npm run lint:lockfile` and is not unit-tested here.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { checkVersionInSync } from './check-lockfile.mjs';
+
+test('checkVersionInSync returns null when pkg and lock agree', () => {
+  const pkg = { name: 'jotjson', version: '0.26.2' };
+  const lock = {
+    name: 'jotjson',
+    version: '0.26.2',
+    packages: { '': { name: 'jotjson', version: '0.26.2' } },
+  };
+  assert.equal(checkVersionInSync(pkg, lock), null);
+});
+
+test('checkVersionInSync detects drift between pkg.version and lock.version', () => {
+  // The exact scenario PR #286 hit: package.json bumped to 0.26.2,
+  // package-lock.json still at 0.26.0.
+  const pkg = { name: 'jotjson', version: '0.26.2' };
+  const lock = {
+    name: 'jotjson',
+    version: '0.26.0',
+    packages: { '': { name: 'jotjson', version: '0.26.0' } },
+  };
+  const detail = checkVersionInSync(pkg, lock);
+  assert.notEqual(detail, null);
+  assert.match(detail, /version drift/);
+  assert.match(detail, /0\.26\.2/);
+  assert.match(detail, /0\.26\.0/);
+});
+
+test('checkVersionInSync detects partial drift (top-level synced, packages[""] stale)', () => {
+  // Pathological scenario where only one of the two mirrors got
+  // updated. Must still fail.
+  const pkg = { name: 'jotjson', version: '0.26.2' };
+  const lock = {
+    name: 'jotjson',
+    version: '0.26.2',
+    packages: { '': { name: 'jotjson', version: '0.26.0' } },
+  };
+  const detail = checkVersionInSync(pkg, lock);
+  assert.notEqual(detail, null);
+  assert.match(detail, /version drift/);
+});
+
+test('checkVersionInSync detects partial drift (packages[""] synced, top-level stale)', () => {
+  const pkg = { name: 'jotjson', version: '0.26.2' };
+  const lock = {
+    name: 'jotjson',
+    version: '0.26.0',
+    packages: { '': { name: 'jotjson', version: '0.26.2' } },
+  };
+  const detail = checkVersionInSync(pkg, lock);
+  assert.notEqual(detail, null);
+  assert.match(detail, /version drift/);
+});
+
+test('checkVersionInSync handles missing pkg.version', () => {
+  const pkg = { name: 'jotjson' };
+  const lock = {
+    name: 'jotjson',
+    version: '0.26.2',
+    packages: { '': { name: 'jotjson', version: '0.26.2' } },
+  };
+  const detail = checkVersionInSync(pkg, lock);
+  assert.notEqual(detail, null);
+  assert.match(detail, /package\.json/);
+});
+
+test('checkVersionInSync handles missing lock.version', () => {
+  const pkg = { name: 'jotjson', version: '0.26.2' };
+  const lock = {
+    name: 'jotjson',
+    packages: { '': { name: 'jotjson', version: '0.26.2' } },
+  };
+  const detail = checkVersionInSync(pkg, lock);
+  assert.notEqual(detail, null);
+  assert.match(detail, /top-level/);
+});
+
+test('checkVersionInSync handles missing lock.packages', () => {
+  const pkg = { name: 'jotjson', version: '0.26.2' };
+  const lock = { name: 'jotjson', version: '0.26.2' };
+  const detail = checkVersionInSync(pkg, lock);
+  assert.notEqual(detail, null);
+  assert.match(detail, /packages/);
+});
+
+test('checkVersionInSync handles missing lock.packages[""]', () => {
+  const pkg = { name: 'jotjson', version: '0.26.2' };
+  const lock = { name: 'jotjson', version: '0.26.2', packages: {} };
+  const detail = checkVersionInSync(pkg, lock);
+  assert.notEqual(detail, null);
+  assert.match(detail, /packages\[""\]/);
+});
+
+test('checkVersionInSync handles non-object inputs', () => {
+  assert.match(checkVersionInSync(null, {}), /package\.json/);
+  assert.match(checkVersionInSync({}, null), /package-lock\.json/);
+  assert.match(checkVersionInSync('not-json', {}), /package\.json/);
+  assert.match(checkVersionInSync({}, 'not-json'), /package-lock\.json/);
+});
+
+test('checkVersionInSync handles api/ workspace (0.1.0 baseline)', () => {
+  // Smoke check that the function is workspace-agnostic.
+  const pkg = { name: 'jotjson-api', version: '0.1.0' };
+  const lock = {
+    name: 'jotjson-api',
+    version: '0.1.0',
+    packages: { '': { name: 'jotjson-api', version: '0.1.0' } },
+  };
+  assert.equal(checkVersionInSync(pkg, lock), null);
+});

--- a/scripts/check-prod-patterns.mjs
+++ b/scripts/check-prod-patterns.mjs
@@ -35,13 +35,14 @@
 //      `items.create()` (insert with 409 on conflict) or
 //      `replaceWithIfMatch<T>(...)` (etag-guarded replace).
 //
-//   4. `.selectedPath.set(` (issue #274 helper-bypass footgun)
-//      Raw `.selectedPath.set(...)` calls bypass the issue #266
-//      defer/retry machinery. Intentional writes must route through
-//      `JsonTreeComponent.setUserSelection()`. System-clear writes
-//      inside `json-tree.component.ts` itself remain raw but require
-//      the closed-vocabulary trailing pragma
-//      `// allow:selected-path-set <helper|system-clear|programmatic-immediate|programmatic-clear|retry-pending-apply>`.
+//   4. `.selectedPath.set(` and `.selectedPath.update(` (issue #274
+//      helper-bypass footgun)
+//      Raw `.selectedPath.set(...)` / `.selectedPath.update(...)`
+//      calls bypass the issue #266 defer/retry machinery. Intentional
+//      writes must route through `JsonTreeComponent.setUserSelection()`.
+//      System-clear writes inside `json-tree.component.ts` itself
+//      remain raw but require the closed-vocabulary trailing pragma
+//      `// allow:selected-path-set <helper|system-clear>`.
 //      The rule fires repo-wide so cross-file writers (e.g., a
 //      sibling component holding `viewChild(JsonTreeComponent)`)
 //      cannot grow a back-door writer. The regex is defense-in-
@@ -114,8 +115,9 @@ export const RULES = [
     paths: [/^api\/src\//],
   },
   {
-    // Issue #274. Raw `.selectedPath.set(...)` calls bypass the
-    // #266 defer/retry machinery. Route user-intent writes through
+    // Issue #274. Raw `.selectedPath.set(...)` /
+    // `.selectedPath.update(...)` calls bypass the #266 defer/retry
+    // machinery. Route intentional writes through
     // `JsonTreeComponent.setUserSelection()`. Fires repo-wide so a
     // hypothetical sibling component holding a
     // `viewChild(JsonTreeComponent)` reference cannot grow a
@@ -130,15 +132,20 @@ export const RULES = [
     // all dodge the match. The convention is documented in the doc
     // block at `selectedPath`'s declaration; intentional
     // circumvention is possible but obvious in review.
-    pattern: /\.selectedPath\.set\s*\(/g,
+    //
+    // The pragma terminator `(?![-\w])` rejects suffixes containing
+    // word characters or hyphens (so `helper-typo`, `helpers`,
+    // `system-clear-foo` all fail), but allows the natural
+    // line-terminators we expect in source (`helper.`, `helper\t`,
+    // `helper\r\n`, `helper` at EOF).
+    pattern: /\.selectedPath\.(?:set|update)\s*\(/g,
     message:
-      'Raw `.selectedPath.set(...)` bypasses issue #266 defer/retry.' +
-      ' Route intentional writes through `setUserSelection()` on' +
-      ' JsonTreeComponent. System writes inside json-tree.component.ts' +
-      ' require the closed-vocabulary pragma' +
-      ' `// allow:selected-path-set <helper|system-clear|programmatic-immediate|programmatic-clear|retry-pending-apply>`.',
-    pragma:
-      /\/\/\s*allow:selected-path-set\s+(?:helper|system-clear|programmatic-immediate|programmatic-clear|retry-pending-apply)\b/,
+      'Raw `.selectedPath.set(...)` / `.selectedPath.update(...)` bypass' +
+      ' issue #266 defer/retry. Route intentional writes through' +
+      ' `setUserSelection()` on JsonTreeComponent. System writes inside' +
+      ' json-tree.component.ts require the closed-vocabulary pragma' +
+      ' `// allow:selected-path-set <helper|system-clear>`.',
+    pragma: /\/\/\s*allow:selected-path-set\s+(?:helper|system-clear)(?![-\w])/,
     pragmaAllowedPaths: [/^src\/app\/shared\/components\/json-tree\/json-tree\.component\.ts$/],
     // No `paths` filter: fires repo-wide. The only legitimate
     // writers live in json-tree.component.ts and that file is

--- a/scripts/check-prod-patterns.mjs
+++ b/scripts/check-prod-patterns.mjs
@@ -35,6 +35,20 @@
 //      `items.create()` (insert with 409 on conflict) or
 //      `replaceWithIfMatch<T>(...)` (etag-guarded replace).
 //
+//   4. `.selectedPath.set(` (issue #274 helper-bypass footgun)
+//      Raw `.selectedPath.set(...)` calls bypass the issue #266
+//      defer/retry machinery. Intentional writes must route through
+//      `JsonTreeComponent.setUserSelection()`. System-clear writes
+//      inside `json-tree.component.ts` itself remain raw but require
+//      the closed-vocabulary trailing pragma
+//      `// allow:selected-path-set <helper|system-clear|programmatic-immediate|programmatic-clear|retry-pending-apply>`.
+//      The rule fires repo-wide so cross-file writers (e.g., a
+//      sibling component holding `viewChild(JsonTreeComponent)`)
+//      cannot grow a back-door writer. The regex is defense-in-
+//      depth, not airtight: destructuring, aliasing, bracket-notation,
+//      and casts dodge the match; intentional circumvention is
+//      visible in review.
+//
 // File scope:
 //   - frontend production: `src/**/*.ts`
 //   - backend production:  `api/src/**/*.ts`
@@ -52,13 +66,19 @@
 //   `pragmaAllowedPaths` (forward-slash form) - this keeps the
 //   safe-harbor narrow.
 //
+//   `pragma` accepts either a string (literal `String.prototype.includes`
+//   match -- used by rule #2) or a RegExp (`RegExp.prototype.test`
+//   match -- used by rule #4 to enforce a closed-enum reason
+//   vocabulary).
+//
 // Runs with zero dependencies on Node 24+. Invoke directly or via
 //   npm run lint:prod-patterns
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
-const RULES = [
+export const RULES = [
   {
     pattern: /\bas\s+TelemetryMessageId\b/g,
     message:
@@ -93,9 +113,40 @@ const RULES = [
     // the frontend is unrelated to Cosmos and is not banned.
     paths: [/^api\/src\//],
   },
+  {
+    // Issue #274. Raw `.selectedPath.set(...)` calls bypass the
+    // #266 defer/retry machinery. Route user-intent writes through
+    // `JsonTreeComponent.setUserSelection()`. Fires repo-wide so a
+    // hypothetical sibling component holding a
+    // `viewChild(JsonTreeComponent)` reference cannot grow a
+    // back-door writer. System writes inside json-tree.component.ts
+    // itself remain raw but require a closed-vocabulary trailing
+    // pragma (enforced by the RegExp pragma matcher below).
+    //
+    // The regex is defense-in-depth, not airtight: destructuring
+    // (`const { selectedPath } = this`), aliasing (`const sig =
+    // this.selectedPath`), bracket notation
+    // (`this.selectedPath['set']`), and `(this.selectedPath as ...).set`
+    // all dodge the match. The convention is documented in the doc
+    // block at `selectedPath`'s declaration; intentional
+    // circumvention is possible but obvious in review.
+    pattern: /\.selectedPath\.set\s*\(/g,
+    message:
+      'Raw `.selectedPath.set(...)` bypasses issue #266 defer/retry.' +
+      ' Route intentional writes through `setUserSelection()` on' +
+      ' JsonTreeComponent. System writes inside json-tree.component.ts' +
+      ' require the closed-vocabulary pragma' +
+      ' `// allow:selected-path-set <helper|system-clear|programmatic-immediate|programmatic-clear|retry-pending-apply>`.',
+    pragma:
+      /\/\/\s*allow:selected-path-set\s+(?:helper|system-clear|programmatic-immediate|programmatic-clear|retry-pending-apply)\b/,
+    pragmaAllowedPaths: [/^src\/app\/shared\/components\/json-tree\/json-tree\.component\.ts$/],
+    // No `paths` filter: fires repo-wide. The only legitimate
+    // writers live in json-tree.component.ts and that file is
+    // covered by pragmaAllowedPaths.
+  },
 ];
 
-function listProdFiles() {
+export function listProdFiles() {
   const out = execFileSync(
     'git',
     ['ls-files', '--cached', '--others', '--exclude-standard', '-z'],
@@ -109,7 +160,28 @@ function listProdFiles() {
     .filter((p) => !p.includes('/testing/') && !p.endsWith('.testing.ts'));
 }
 
-function scan(path) {
+/**
+ * Tests whether a candidate trailing-pragma line matches a rule's
+ * `pragma` field. The field is either a string (literal-substring
+ * match via `String.prototype.includes`, used by rule #2) or a
+ * RegExp (`RegExp.prototype.test`, used by rule #4 to enforce a
+ * closed-enum reason vocabulary).
+ *
+ * Exported for unit-testing under `scripts/check-prod-patterns.test.mjs`.
+ */
+export function matchesPragma(pragma, fullLine) {
+  if (typeof pragma === 'string') {
+    return fullLine.includes(pragma);
+  }
+  if (pragma instanceof RegExp) {
+    return pragma.test(fullLine);
+  }
+  throw new TypeError(
+    `check-prod-patterns: rule.pragma must be string or RegExp, got ${typeof pragma}`,
+  );
+}
+
+export function scan(path) {
   let text;
   try {
     text = readFileSync(path, 'utf8');
@@ -120,6 +192,15 @@ function scan(path) {
   // git ls-files returns forward-slash paths on every platform, but
   // belt-and-suspenders against any future Windows-native call site.
   const normalizedPath = path.replace(/\\/g, '/');
+  return scanText(text, normalizedPath);
+}
+
+/**
+ * Pure-function variant of `scan` that takes the file's text and
+ * normalized path directly. Exported so unit tests can exercise the
+ * scanner against in-memory fixtures without touching the filesystem.
+ */
+export function scanText(text, normalizedPath) {
   const violations = [];
   for (const rule of RULES) {
     if (rule.paths && !rule.paths.some((re) => re.test(normalizedPath))) {
@@ -147,8 +228,8 @@ function scan(path) {
         continue;
       }
       // Per-rule trailing pragma support: if the rule defines a
-      // `pragma`, look for the pragma string on the line where the
-      // match ENDS. If found AND the file path matches one of
+      // `pragma`, look for the pragma on the line where the match
+      // ENDS. If found AND the file path matches one of
       // `pragmaAllowedPaths`, allow the match. This safe-harbor is
       // intentionally narrow so a stray `// allow:...` pasted into
       // any other file is still a violation.
@@ -158,7 +239,7 @@ function scan(path) {
         const eolIdx = text.indexOf('\n', matchEnd);
         const lineEnd = eolIdx === -1 ? text.length : eolIdx;
         const fullLine = text.slice(lineStart, lineEnd);
-        if (fullLine.includes(rule.pragma)) {
+        if (matchesPragma(rule.pragma, fullLine)) {
           const allowed =
             !rule.pragmaAllowedPaths ||
             rule.pragmaAllowedPaths.some((re) => re.test(normalizedPath));
@@ -170,38 +251,57 @@ function scan(path) {
           // pragma-specific guidance baked into the message.
         }
       }
-      violations.push({ path, line, col, message: rule.message, snippet: m[0] });
+      violations.push({ path: normalizedPath, line, col, message: rule.message, snippet: m[0] });
     }
   }
   return violations;
 }
 
-const files = listProdFiles();
-const allViolations = files.flatMap(scan);
+export function main() {
+  const files = listProdFiles();
+  const allViolations = files.flatMap(scan);
 
-if (allViolations.length === 0) {
-  console.log(
-    `check-prod-patterns: OK (${files.length} production .ts files scanned, 0 violations)`,
-  );
-  process.exit(0);
-}
-
-console.error('check-prod-patterns: violations found:');
-for (const v of allViolations) {
-  console.error(`  ${v.path}:${v.line}:${v.col}  ${v.snippet}`);
-  console.error(`    -> ${v.message}`);
-}
-console.error(`\n${allViolations.length} violation(s) in ${files.length} production .ts files.`);
-
-if (process.env.GITHUB_ACTIONS === 'true') {
-  for (const v of allViolations) {
-    const file = v.path.replace(/%/g, '%25');
-    const msg = String(`${v.snippet} - ${v.message}`)
-      .replace(/%/g, '%25')
-      .replace(/\r/g, '%0D')
-      .replace(/\n/g, '%0A');
-    console.log(`::error file=${file},line=${v.line},col=${v.col}::${msg}`);
+  if (allViolations.length === 0) {
+    console.log(
+      `check-prod-patterns: OK (${files.length} production .ts files scanned, 0 violations)`,
+    );
+    return 0;
   }
+
+  console.error('check-prod-patterns: violations found:');
+  for (const v of allViolations) {
+    console.error(`  ${v.path}:${v.line}:${v.col}  ${v.snippet}`);
+    console.error(`    -> ${v.message}`);
+  }
+  console.error(`\n${allViolations.length} violation(s) in ${files.length} production .ts files.`);
+
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    for (const v of allViolations) {
+      const file = v.path.replace(/%/g, '%25');
+      const msg = String(`${v.snippet} - ${v.message}`)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
+      console.log(`::error file=${file},line=${v.line},col=${v.col}::${msg}`);
+    }
+  }
+
+  return 1;
 }
 
-process.exit(1);
+// Only invoke main() when this file is executed directly. Importers
+// (the test file at scripts/check-prod-patterns.test.mjs) load the
+// module solely for its exports; they must not trigger the CLI side
+// effects (git ls-files, fs reads, process.exit).
+const invokedDirectly = (() => {
+  try {
+    if (!process.argv[1]) return false;
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  process.exit(main());
+}

--- a/scripts/check-prod-patterns.test.mjs
+++ b/scripts/check-prod-patterns.test.mjs
@@ -25,7 +25,7 @@ test('matchesPragma accepts a literal-string pragma via includes', () => {
 });
 
 test('matchesPragma accepts a RegExp pragma via test', () => {
-  const pragma = /\/\/\s*allow:selected-path-set\s+(?:helper|system-clear)\b/;
+  const pragma = /\/\/\s*allow:selected-path-set\s+(?:helper|system-clear)(?![-\w])/;
   assert.equal(matchesPragma(pragma, 'code; // allow:selected-path-set helper'), true);
   assert.equal(matchesPragma(pragma, 'code; // allow:selected-path-set system-clear'), true);
   assert.equal(matchesPragma(pragma, 'code; // allow:selected-path-set yolo'), false);
@@ -68,13 +68,56 @@ test('selected-path-set: system-clear pragma in json-tree.component.ts passes', 
   assert.equal(violations.length, 0);
 });
 
-test('selected-path-set: programmatic-immediate and -clear and retry-pending-apply pass', () => {
+test('selected-path-set: programmatic-immediate / -clear / retry-pending-apply NO LONGER pass', () => {
+  // Anti-regression: the v1 vocabulary documented 5 reasons; PR #286
+  // review feedback tightened to 2 (`helper`, `system-clear`) once
+  // Resolution B routed the programmatic + retry-pending sites
+  // through `setUserSelection` instead of carrying their own pragmas.
+  // A stale `programmatic-immediate` / `programmatic-clear` /
+  // `retry-pending-apply` comment must NOT pass.
   for (const reason of ['programmatic-immediate', 'programmatic-clear', 'retry-pending-apply']) {
     const text = `this.selectedPath.set(x); // allow:selected-path-set ${reason}\n`;
     const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
       v.snippet.includes('selectedPath'),
     );
-    assert.equal(violations.length, 0, `reason '${reason}' should pass`);
+    assert.equal(violations.length, 1, `reason '${reason}' should now fail`);
+  }
+});
+
+test('selected-path-set: word-char suffix on a valid reason fails (e.g. "helpers")', () => {
+  // The `(?![-\w])` lookahead must reject a typo where the reason is
+  // a longer word that happens to start with `helper` or `system-clear`.
+  for (const bogus of ['helpers', 'helper-typo', 'system-clear-foo', 'system-clears']) {
+    const text = `this.selectedPath.set(x); // allow:selected-path-set ${bogus}\n`;
+    const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+      v.snippet.includes('selectedPath'),
+    );
+    assert.equal(violations.length, 1, `reason '${bogus}' should fail`);
+  }
+});
+
+test('selected-path-set: pragma followed by punctuation / whitespace / EOF passes', () => {
+  // The `(?![-\w])` lookahead must allow the natural terminators
+  // appearing in source: trailing whitespace before EOL, tab, CRLF,
+  // EOF without a newline, or punctuation like `.` / `;`.
+  const passes = [
+    'this.selectedPath.set(x); // allow:selected-path-set helper\n',
+    'this.selectedPath.set(x); // allow:selected-path-set helper\r\n',
+    'this.selectedPath.set(x); // allow:selected-path-set helper\t\n',
+    'this.selectedPath.set(x); // allow:selected-path-set helper ',
+    'this.selectedPath.set(x); // allow:selected-path-set helper.',
+    'this.selectedPath.set(x); // allow:selected-path-set helper',
+    'this.selectedPath.set(x); // allow:selected-path-set system-clear\n',
+  ];
+  for (const text of passes) {
+    const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+      v.snippet.includes('selectedPath'),
+    );
+    assert.equal(
+      violations.length,
+      0,
+      `text ${JSON.stringify(text)} should pass but had ${violations.length} violations`,
+    );
   }
 });
 
@@ -88,8 +131,8 @@ test('selected-path-set: unknown reason fails even in json-tree.component.ts', (
 });
 
 test('selected-path-set: old generic "system-write" reason no longer passes', () => {
-  // Anti-regression: the v1 plan used `system-write`; the v2 plan
-  // tightened the vocabulary to `system-clear`. A stale `system-write`
+  // Anti-regression: an early plan used `system-write`; the final
+  // vocabulary is `{helper, system-clear}`. A stale `system-write`
   // comment must NOT pass.
   const text = `this.selectedPath.set(null); // allow:selected-path-set system-write\n`;
   const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
@@ -119,6 +162,41 @@ test('selected-path-set: pragma in a NON-allow-listed file is still a violation'
 
 test('selected-path-set: raw write in any non-allow-listed file fails', () => {
   const text = `this.tree()?.selectedPath.set('x');\n`;
+  const violations = scanText(text, HOME_PATH).filter((v) => v.snippet.includes('selectedPath'));
+  assert.equal(violations.length, 1);
+});
+
+test('selected-path-set: `.update(...)` raw write in json-tree.component.ts fails', () => {
+  // Issue #274 + PR #286 review: the rule must cover `.update` not
+  // just `.set`. A signal computed-update like
+  // `this.selectedPath.update((prev) => ...)` is functionally an
+  // intentional write and must route through `setUserSelection`.
+  const text = `this.selectedPath.update((p) => p);\n`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /setUserSelection\(\)/);
+});
+
+test('selected-path-set: `.update(...)` with helper pragma in json-tree.component.ts passes', () => {
+  const text = `this.selectedPath.update((p) => p); // allow:selected-path-set helper\n`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 0);
+});
+
+test('selected-path-set: `.update(...)` with pragma in NON-allow-listed file still fails', () => {
+  // Symmetric with the `.set` cross-file test: pragma alone is not
+  // enough; the file must also be on `pragmaAllowedPaths`.
+  const text = `this.tree()?.selectedPath.update((p) => p); // allow:selected-path-set helper\n`;
+  const violations = scanText(text, HOME_PATH).filter((v) => v.snippet.includes('selectedPath'));
+  assert.equal(violations.length, 1);
+});
+
+test('selected-path-set: `.update(...)` raw write in any non-allow-listed file fails', () => {
+  const text = `this.tree()?.selectedPath.update((p) => p);\n`;
   const violations = scanText(text, HOME_PATH).filter((v) => v.snippet.includes('selectedPath'));
   assert.equal(violations.length, 1);
 });

--- a/scripts/check-prod-patterns.test.mjs
+++ b/scripts/check-prod-patterns.test.mjs
@@ -1,0 +1,154 @@
+// Unit tests for scripts/check-prod-patterns.mjs.
+//
+// Runs under Node's built-in test runner: `node --test`. No external
+// dependencies. The test file imports the script as a module; the script
+// guards `main()` behind an "invoked directly" check so importing it does
+// not trigger CLI side effects (git ls-files, fs reads, process.exit).
+//
+// Coverage focuses on the issue #274 additions:
+//  - `matchesPragma` accepts both string and RegExp pragmas
+//  - `scanText` enforces the closed-enum reason vocabulary for the
+//    selected-path-set rule
+//  - The pragmaAllowedPaths gate still rejects a stray pragma in a
+//    non-allow-listed file
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { matchesPragma, scanText } from './check-prod-patterns.mjs';
+
+// --- matchesPragma --------------------------------------------------------
+
+test('matchesPragma accepts a literal-string pragma via includes', () => {
+  assert.equal(matchesPragma('// allow:foo', 'some code // allow:foo'), true);
+  assert.equal(matchesPragma('// allow:foo', 'some code'), false);
+});
+
+test('matchesPragma accepts a RegExp pragma via test', () => {
+  const pragma = /\/\/\s*allow:selected-path-set\s+(?:helper|system-clear)\b/;
+  assert.equal(matchesPragma(pragma, 'code; // allow:selected-path-set helper'), true);
+  assert.equal(matchesPragma(pragma, 'code; // allow:selected-path-set system-clear'), true);
+  assert.equal(matchesPragma(pragma, 'code; // allow:selected-path-set yolo'), false);
+  assert.equal(matchesPragma(pragma, 'code; // allow:selected-path-set TODO-figure-out'), false);
+});
+
+test('matchesPragma throws on non-string non-RegExp pragma', () => {
+  assert.throws(() => matchesPragma(123, 'anything'), TypeError);
+  assert.throws(() => matchesPragma({}, 'anything'), TypeError);
+  assert.throws(() => matchesPragma(null, 'anything'), TypeError);
+});
+
+// --- scanText: selected-path-set rule -------------------------------------
+
+const JSON_TREE_PATH = 'src/app/shared/components/json-tree/json-tree.component.ts';
+const HOME_PATH = 'src/app/features/home/home.component.ts';
+const COSMOS_PATH = 'api/src/shared/cosmos.ts';
+
+test('selected-path-set: helper-pragma write in json-tree.component.ts passes', () => {
+  const text = `class Foo {
+  helper() {
+    this.selectedPath.set(path); // allow:selected-path-set helper
+  }
+}
+`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 0);
+});
+
+test('selected-path-set: system-clear pragma in json-tree.component.ts passes', () => {
+  const text = `if (!root) {
+  this.selectedPath.set(null); // allow:selected-path-set system-clear
+}
+`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 0);
+});
+
+test('selected-path-set: programmatic-immediate and -clear and retry-pending-apply pass', () => {
+  for (const reason of ['programmatic-immediate', 'programmatic-clear', 'retry-pending-apply']) {
+    const text = `this.selectedPath.set(x); // allow:selected-path-set ${reason}\n`;
+    const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+      v.snippet.includes('selectedPath'),
+    );
+    assert.equal(violations.length, 0, `reason '${reason}' should pass`);
+  }
+});
+
+test('selected-path-set: unknown reason fails even in json-tree.component.ts', () => {
+  const text = `this.selectedPath.set(x); // allow:selected-path-set yolo\n`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /closed-vocabulary pragma/);
+});
+
+test('selected-path-set: old generic "system-write" reason no longer passes', () => {
+  // Anti-regression: the v1 plan used `system-write`; the v2 plan
+  // tightened the vocabulary to `system-clear`. A stale `system-write`
+  // comment must NOT pass.
+  const text = `this.selectedPath.set(null); // allow:selected-path-set system-write\n`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 1);
+});
+
+test('selected-path-set: raw write with no pragma in json-tree.component.ts fails', () => {
+  const text = `this.selectedPath.set(x);\n`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /setUserSelection\(\)/);
+});
+
+test('selected-path-set: pragma in a NON-allow-listed file is still a violation', () => {
+  // The home component grabs `viewChild(JsonTreeComponent)`. A stray
+  // `child.selectedPath.set(...)` here, even with the helper pragma,
+  // must fail because the pragmaAllowedPaths filter scopes the
+  // safe-harbor to json-tree.component.ts only.
+  const text = `this.tree()?.selectedPath.set(null); // allow:selected-path-set helper\n`;
+  const violations = scanText(text, HOME_PATH).filter((v) => v.snippet.includes('selectedPath'));
+  assert.equal(violations.length, 1);
+});
+
+test('selected-path-set: raw write in any non-allow-listed file fails', () => {
+  const text = `this.tree()?.selectedPath.set('x');\n`;
+  const violations = scanText(text, HOME_PATH).filter((v) => v.snippet.includes('selectedPath'));
+  assert.equal(violations.length, 1);
+});
+
+test('selected-path-set: comment lines are not scanned for violations', () => {
+  // Documentation referencing the banned pattern must be allowed so
+  // the doc block at `selectedPath`'s declaration does not trip the
+  // lint. The existing `^\s*(\*|//)` skip handles both `//`-prefixed
+  // line comments and `*`-prefixed JSDoc continuation lines.
+  const text =
+    `// Reference: this.selectedPath.set(x) bypasses #266.
+ * ` +
+    `Also, this.selectedPath.set(x) is fine in JSDoc.
+`;
+  const violations = scanText(text, JSON_TREE_PATH).filter((v) =>
+    v.snippet.includes('selectedPath'),
+  );
+  assert.equal(violations.length, 0);
+});
+
+// --- scanText: backwards-compat with rule #2 ('cosmos-replace') -----------
+
+test('cosmos-replace: string pragma still works after the engine change', () => {
+  const text = `await container.item('id', 'pk').replace<Doc>(updated); // allow:cosmos-replace internal-only\n`;
+  const violations = scanText(text, COSMOS_PATH);
+  assert.equal(violations.length, 0);
+});
+
+test('cosmos-replace: string pragma in non-allow-listed file is rejected', () => {
+  const text = `await container.item('id', 'pk').replace<Doc>(updated); // allow:cosmos-replace internal-only\n`;
+  const violations = scanText(text, 'api/src/blobs/index.ts');
+  assert.equal(violations.length, 1);
+});

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -2042,6 +2042,15 @@ describe('JsonTreeComponent', () => {
   });
 
   describe('selection highlighting', () => {
+    // The `cmp.selectedPath.set(...)` calls in this describe block are
+    // intentional test-state setup -- they drive the signal directly so
+    // downstream projections (ancestor highlights, match badges, CSS
+    // classes, ARIA attributes) can be asserted without going through
+    // the user-intent code path. Real user gestures (clicks, keyboard
+    // activation) are covered elsewhere via real DOM events. See issue
+    // #274 doc block at `selectedPath`'s declaration; the
+    // `check-prod-patterns.mjs` `selected-path-set` rule deliberately
+    // does NOT scan `*.spec.ts` for this reason.
     /** Look up a rendered .tree-row whose bound TreeNode has the given pathString. */
     function findRow(path: string): HTMLElement {
       cmp.expandAll();
@@ -3915,6 +3924,13 @@ describe('JsonTreeComponent', () => {
         await createWith({ alpha: 1, mid: 'NA', alphabet: 2, alpine: 3 });
         setSearch('alp');
         const c = fixture.componentInstance;
+        // Stage a pending defer to verify `activateClickedHitOrFirst`
+        // routes through `setUserSelection()` (issue #274) and
+        // clears it.
+        c.selectByPathString('$.missing');
+        const internals = c as unknown as { pendingSelectPathString: string | null };
+        expect(internals.pendingSelectPathString).toBe('$.missing');
+
         c.__getHelpersForTesting().activateClickedHitOrFirst('$.mid');
         await Promise.resolve();
         await Promise.resolve();
@@ -3922,6 +3938,7 @@ describe('JsonTreeComponent', () => {
         const idx = c.activeHitIndex();
         expect(paths[idx]).toBe('$.alphabet');
         expect(c.selectedPath()).toBe('$.alphabet');
+        expect(internals.pendingSelectPathString).toBeNull();
       });
     });
   });
@@ -4720,7 +4737,18 @@ describe('JsonTreeComponent', () => {
       expect(barEmissions.length).toBeGreaterThanOrEqual(1);
     });
 
-    it('discards pending when user clicks a different row mid-defer', async () => {
+    it('defensive backstop: discriminator discards stale pending if a writer bypasses setUserSelection', async () => {
+      // Pre-#274 this scenario WAS the load-bearing path: `onSelect`
+      // wrote `selectedPath` directly, leaving pending intact, and
+      // the discriminator was the only thing preventing the retry
+      // effect from clobbering the user's click with a stale defer.
+      // Post-#274 all intentional writers route through
+      // `setUserSelection()` which clears pending synchronously, so
+      // this `cmp.selectedPath.set(...)` direct write now mimics a
+      // hypothetical future writer that bypasses the helper (e.g.,
+      // a sibling component holding a `viewChild(JsonTreeComponent)`
+      // reference). The discriminator stays as a defensive backstop
+      // for that case; this test pins the backstop's behavior.
       await createWith({ foo: 1, qux: 'stub' });
       // Select foo first so priorSelected has a non-null value.
       cmp.selectByPathString('$.foo');
@@ -4731,11 +4759,9 @@ describe('JsonTreeComponent', () => {
       expect(internals.pendingSelectPathString).toBe('$.bar');
       expect(internals.pendingPriorSelectedPath).toBe('$.foo');
 
-      // User clicks a different row via direct selectedPath write
-      // (mimicking the tree's internal onSelect handler which
-      // bypasses selectByPathString). pendingPriorSelectedPath is
-      // NOT updated; the retry effect's discriminator should
-      // discard pending.
+      // Direct-write bypass of `setUserSelection`. pendingPriorSelectedPath
+      // is NOT updated; the retry effect's discriminator should
+      // discard pending on the next nodeIndex tick.
       cmp.selectedPath.set('$.qux');
 
       fixture.componentRef.setInput('value', { foo: 1, qux: 'stub', bar: 2 });
@@ -4987,6 +5013,78 @@ describe('JsonTreeComponent', () => {
       cmp.goToNextMatch();
 
       expect(internals.pendingSelectPathString).toBe('$.bar');
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Issue #274 `setUserSelection()` helper. The helper is the canonical
+  // "clear pending then set" idiom for every intentional write to
+  // `selectedPath`. Routing all user-intent + programmatic writers
+  // through it makes the pending-clear structural instead of empirically-
+  // true via keyboard-release timing. See top-of-component doc block at
+  // `selectedPath`'s declaration.
+  // ---------------------------------------------------------------------------
+  describe('setUserSelection helper (issue #274)', () => {
+    type Internals = {
+      pendingSelectPathString: string | null;
+      pendingPriorSelectedPath: string | null;
+    };
+
+    it('clears pending then writes selectedPath in one shot', async () => {
+      await createWith({ foo: 1 });
+      cmp.selectByPathString('$.foo');
+      cmp.selectByPathString('$.bar'); // stages pending: $.bar
+      const internals = cmp as unknown as Internals;
+      expect(internals.pendingSelectPathString).toBe('$.bar');
+
+      cmp.setUserSelection('$.foo');
+
+      expect(cmp.selectedPath()).toBe('$.foo');
+      expect(internals.pendingSelectPathString).toBeNull();
+      expect(internals.pendingPriorSelectedPath).toBeNull();
+    });
+
+    it('null path clears both selection and pending', async () => {
+      await createWith({ foo: 1 });
+      cmp.selectByPathString('$.foo');
+      cmp.selectByPathString('$.bar');
+      const internals = cmp as unknown as Internals;
+      expect(internals.pendingSelectPathString).toBe('$.bar');
+
+      cmp.setUserSelection(null);
+
+      expect(cmp.selectedPath()).toBeNull();
+      expect(internals.pendingSelectPathString).toBeNull();
+      expect(internals.pendingPriorSelectedPath).toBeNull();
+    });
+
+    it('clicking the already-selected row mid-defer cancels the pending jump', async () => {
+      // Pre-#274 behavior: a user click on the already-selected row
+      // mid-defer was a no-op signal write (same value -> Angular
+      // signal deduplication), pending stayed, and on the next
+      // nodeIndex tick the tree silently jumped to the deferred
+      // path. Post-#274 the helper's synchronous pending-clear
+      // cancels the jump; the user's affirmation of the current
+      // selection wins.
+      await createWith({ foo: 1 });
+      cmp.setUserSelection('$.foo');
+      cmp.selectByPathString('$.bar'); // programmatic defer
+      const internals = cmp as unknown as Internals;
+      expect(cmp.selectedPath()).toBe('$.foo');
+      expect(internals.pendingSelectPathString).toBe('$.bar');
+
+      // User clicks the same row $.foo again (mid-defer). Routed
+      // through the helper -- same code path as `onSelect`.
+      cmp.setUserSelection('$.foo');
+
+      expect(internals.pendingSelectPathString).toBeNull();
+      expect(internals.pendingPriorSelectedPath).toBeNull();
+
+      fixture.componentRef.setInput('value', { foo: 1, bar: 2 });
+      fixture.detectChanges();
+
+      // Pending was cancelled by the helper; no silent jump to $.bar.
+      expect(cmp.selectedPath()).toBe('$.foo');
     });
   });
 
@@ -6063,10 +6161,17 @@ describe('JsonTreeComponent', () => {
         const node = nodeAt('$.alpha');
         const ev = new MouseEvent('click', { bubbles: true, cancelable: true });
         const stopSpy = spyOn(ev, 'stopPropagation').and.callThrough();
+        // Stage a pending defer to verify `onKebabClick` routes
+        // through `setUserSelection()` (issue #274) and clears it.
+        cmp.selectByPathString('$.missing');
+        const internals = cmp as unknown as { pendingSelectPathString: string | null };
+        expect(internals.pendingSelectPathString).toBe('$.missing');
+
         cmp.onKebabClick(ev, node);
         expect(cmp.contextNode()?.pathString).toBe('$.alpha');
         expect(cmp.selectedPath()).toBe('$.alpha');
         expect(stopSpy).toHaveBeenCalled();
+        expect(internals.pendingSelectPathString).toBeNull();
       });
 
       it("logs tree.contextMenu.opened with source: 'kebab'", async () => {
@@ -8538,9 +8643,15 @@ describe('JsonTreeComponent', () => {
       fixture.detectChanges();
       cmp.focusedPath.set('$.a');
       fixture.detectChanges();
+      // Stage a pending defer to verify the keyboard handler routes
+      // through `setUserSelection()` (issue #274) and clears it.
+      cmp.selectByPathString('$.missing');
+      const internals = cmp as unknown as { pendingSelectPathString: string | null };
+      expect(internals.pendingSelectPathString).toBe('$.missing');
 
       dispatchKey(nodeEl('$.a'), 'Enter');
       expect(cmp.selectedPath()).toBe('$.a');
+      expect(internals.pendingSelectPathString).toBeNull();
     });
 
     it('Space on the focused row sets selectedPath and prevents default', async () => {
@@ -8549,11 +8660,17 @@ describe('JsonTreeComponent', () => {
       fixture.detectChanges();
       cmp.focusedPath.set('$.a');
       fixture.detectChanges();
+      // Stage a pending defer to verify the keyboard handler routes
+      // through `setUserSelection()` (issue #274) and clears it.
+      cmp.selectByPathString('$.missing');
+      const internals = cmp as unknown as { pendingSelectPathString: string | null };
+      expect(internals.pendingSelectPathString).toBe('$.missing');
 
       const ev = new KeyboardEvent('keydown', { key: ' ', bubbles: true, cancelable: true });
       nodeEl('$.a').dispatchEvent(ev);
       expect(cmp.selectedPath()).toBe('$.a');
       expect(ev.defaultPrevented).toBeTrue();
+      expect(internals.pendingSelectPathString).toBeNull();
     });
 
     it('clicking a row sets BOTH selectedPath and focusedPath', async () => {
@@ -8566,6 +8683,11 @@ describe('JsonTreeComponent', () => {
       // Reset initial focus so we can verify the click moves it.
       cmp.focusedPath.set('$');
       fixture.detectChanges();
+      // Stage a pending defer to verify `onSelect` routes through
+      // `setUserSelection()` (issue #274) and clears it.
+      cmp.selectByPathString('$.missing');
+      const internals = cmp as unknown as { pendingSelectPathString: string | null };
+      expect(internals.pendingSelectPathString).toBe('$.missing');
 
       const aRow = nodeEl('$.a');
       aRow.click();
@@ -8573,6 +8695,7 @@ describe('JsonTreeComponent', () => {
 
       expect(cmp.selectedPath()).toBe('$.a');
       expect(cmp.focusedPath()).toBe('$.a');
+      expect(internals.pendingSelectPathString).toBeNull();
     });
 
     it('search Enter does not yank focus from the search input', async () => {

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -5112,10 +5112,12 @@ describe('JsonTreeComponent', () => {
     it('Escape during defer cancels pending (selectedPath null start; cold-start)', async () => {
       // Issue #266 / v2.4 regression for the cold-start typing
       // scenario: user types in editor before clicking any tree
-      // row, then presses Escape. The HostListener gate
-      // `selectedPath() !== null` would skip clearSelection(), so
-      // pending must be cleared by the HostListener's own
-      // unconditional clearPendingSelectPath() call.
+      // row, then presses Escape. `onDocumentEscape` routes
+      // through `clearSelection()` -> `setUserSelection(null)`,
+      // which clears pending (the load-bearing action) and
+      // writes `selectedPath.set(null)`. Since `selectedPath`
+      // is already null, the signal write is a no-op via
+      // Angular's native Object.is dedup - no spurious emission.
       await createWith({ foo: 1 });
       expect(cmp.selectedPath()).toBeNull();
 

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -400,39 +400,62 @@ export class JsonTreeComponent {
   readonly search: WritableSignal<string> = signal('');
 
   /**
-   * Selection-state ownership (issue #266 invariant doc block).
+   * Selection-state ownership (issue #266 invariant doc block;
+   * tightened by issue #274).
    *
-   * `selectedPath` is read/written by three coordinated effects and
-   * ~7 user-intent writers:
+   * `selectedPath` is read/written by three coordinated effects
+   * and a set of intentional writers. Intentional writers route
+   * through `setUserSelection()` (issue #274) so the "clear
+   * pending then set" idiom lives in exactly one place; the
+   * `check-prod-patterns.mjs` `selected-path-set` rule rejects
+   * raw `selectedPath.set(...)` writes outside that helper
+   * (system-clear writes carry the trailing pragma
+   * `// allow:selected-path-set <category>`).
    *
    * Effects (run in declaration order within a CD flush):
    * 1. preserve-or-clear effect: reacts to nodeIndex / root /
    *    viewResetToken changes. Reads selectedPath via untracked()
    *    (load-bearing -- removing untracked breaks the invariant).
-   *    Writes selectedPath when prior path vanished or view reset.
+   *    Writes selectedPath when prior path vanished or view reset
+   *    (system-clear; raw write, pragma-tagged).
    * 2. retry-pending effect (issue #266): reacts to nodeIndex
-   *    changes when pending != null. Applies pending if
-   *    discriminator says "passive preserve" (selected ===
-   *    priorSelected) or "system cleared" (selected === null).
-   *    Otherwise discards pending.
+   *    changes when pending != null. Applies pending via
+   *    `setUserSelection()` (issue #274) if discriminator says
+   *    "passive preserve" (selected === priorSelected) or
+   *    "system cleared" (selected === null). Otherwise discards
+   *    pending via `clearPendingSelectPath()`.
    * 3. dedup-emit effect (PR #261 / grep `lastEmittedSelectedPath`):
    *    reacts to selectedPath changes; emits selectionChange exactly
    *    once per net change.
    *
-   * User-intent writers (each MUST clear pending; route through
-   * `clearPendingSelectPath()` before writing `selectedPath`):
+   * Intentional writers (each routes through `setUserSelection()`):
    *  - `onSelect` (mouse click on row)
    *  - keyboard Enter / Space handler
    *  - `clearSelection` (Escape via `onDocumentEscape` HostListener)
    *  - `goToNextMatch` / `goToPrevMatch` (search nav)
    *  - `onKebabClick` (context menu)
-   *  - search-result-click cycling handler
+   *  - `activateClickedHitOrFirst` (search-result-click cycling;
+   *    microtask-deferred but the originating gesture is user click)
+   *  - `selectByPathString` immediate-apply branch (programmatic,
+   *    path already in nodeIndex)
+   *  - `selectByPathString` null-clear branch (programmatic clear)
+   *  - retry-pending effect apply branch (issue #266; same idiom)
    *
-   * Programmatic writers (do NOT clear pending; bypass the
-   * discriminator deliberately):
-   *  - `selectByPathString` immediate-select branch (the path is
-   *    already in nodeIndex; defer is unnecessary).
-   *  - The retry-pending effect itself (that's its whole purpose).
+   * System-clear writers (raw `selectedPath.set(null)` with
+   * `// allow:selected-path-set system-clear` pragma; do NOT
+   * clear pending because the retry-pending discriminator needs
+   * to distinguish system-clear-because-prior-path-vanished
+   * (apply pending) from intentional-clear (discard pending)):
+   *  - preserve-or-clear effect (the three sites in the
+   *    nodeIndex / viewResetToken reaction).
+   *
+   * The retry-pending effect's discriminator is now a defensive
+   * backstop: every intentional writer clears pending
+   * synchronously via the helper, so the discriminator only
+   * fires when a writer bypasses the helper (which the lint
+   * guard rejects in production code). Tests at
+   * `'defensive backstop: discriminator discards stale pending
+   * if a writer bypasses setUserSelection'` cover this path.
    *
    * Exception to AGENTS.md s4 ("effect() only for syncing to
    * external systems"): effects #1 and #2 do signal-to-signal
@@ -1573,7 +1596,7 @@ export class JsonTreeComponent {
         // `flatList` is computed off `root()` directly.
         if (!rootNode) {
           this.hasInitializedExpansion = false;
-          this.selectedPath.set(null);
+          this.selectedPath.set(null); // allow:selected-path-set system-clear
           return;
         }
         if (!this.hasInitializedExpansion) {
@@ -1594,11 +1617,11 @@ export class JsonTreeComponent {
         // `nodeIndex` key directly - do NOT wrap in `formatPath()` /
         // `pathToString()`, which would take a path-segments array.
         if (wasReset) {
-          this.selectedPath.set(null);
+          this.selectedPath.set(null); // allow:selected-path-set system-clear
         } else {
           const prior = this.selectedPath();
           if (prior !== null && !this.nodeIndex().has(prior)) {
-            this.selectedPath.set(null);
+            this.selectedPath.set(null); // allow:selected-path-set system-clear
           }
         }
       });
@@ -1727,22 +1750,26 @@ export class JsonTreeComponent {
         if (!index.has(pending)) return;
         const selected = this.selectedPath();
         const priorSelected = this.pendingPriorSelectedPath;
-        // Discriminator: discard pending if a user-intent writer
-        // wrote a non-null `selectedPath` different from the
-        // priorSelected snapshot between defer and now. Allows:
-        //  - selected === null (system-cleared by L1480; apply).
+        // Discriminator (issue #266; now a defensive backstop per
+        // issue #274): discard pending if some writer wrote a
+        // non-null `selectedPath` different from the priorSelected
+        // snapshot between defer and now. After #274 every
+        // intentional writer clears pending synchronously via
+        // `setUserSelection()`, so this branch only fires when a
+        // writer bypasses the helper. Allows:
+        //  - selected === null (system-cleared by preserve-or-
+        //    clear effect; apply).
         //  - selected === priorSelected (passive preserve; apply).
         if (selected !== null && selected !== priorSelected) {
-          this.pendingSelectPathString = null;
-          this.pendingPriorSelectedPath = null;
+          this.clearPendingSelectPath();
           return;
         }
-        // Apply: clear pending first so re-entrancy is safe, then
-        // write selectedPath (which the dedup-emit effect will
-        // observe on the next flush step).
-        this.pendingSelectPathString = null;
-        this.pendingPriorSelectedPath = null;
-        this.selectedPath.set(pending);
+        // Apply via `setUserSelection` (issue #274). The helper
+        // clears pending (no-op when this effect was already
+        // going to clear it) then writes selectedPath. The
+        // dedup-emit effect observes the set on the next flush
+        // step.
+        this.setUserSelection(pending);
         this.expandAndScroll(pending);
       });
     });
@@ -1964,7 +1991,7 @@ export class JsonTreeComponent {
     if (target.closest('button, a, input, [role="button"]')) {
       return;
     }
-    this.selectedPath.set(node.pathString);
+    this.setUserSelection(node.pathString);
     this.focusedPath.set(node.pathString);
     event.stopPropagation();
   }
@@ -2223,7 +2250,7 @@ export class JsonTreeComponent {
       case ' ':
       case 'Spacebar': {
         event.preventDefault();
-        this.selectedPath.set(node.pathString);
+        this.setUserSelection(node.pathString);
         return;
       }
       case 'F10': {
@@ -2284,14 +2311,15 @@ export class JsonTreeComponent {
   }
 
   clearSelection(): void {
-    // Issue #266: explicit pending-clear. Without this, the retry-
-    // pending effect cannot distinguish "system cleared because
-    // prior path vanished -- apply pending" (the preserve-or-clear
-    // case) from "user explicitly cleared -- discard pending" (this
-    // case), and pending would re-apply after the tree-pane
-    // debounce flushes.
-    this.clearPendingSelectPath();
-    this.selectedPath.set(null);
+    // Issue #266: pending-clear is required. Without it, the
+    // retry-pending effect cannot distinguish "system cleared
+    // because prior path vanished -- apply pending" (the
+    // preserve-or-clear case) from "user explicitly cleared --
+    // discard pending" (this case), and pending would re-apply
+    // after the tree-pane debounce flushes. Issue #274 routes
+    // both halves through `setUserSelection(null)` so the idiom
+    // lives in exactly one place.
+    this.setUserSelection(null);
   }
 
   /**
@@ -2299,26 +2327,33 @@ export class JsonTreeComponent {
    * so the search input's own Esc binding can also clear the search
    * query when it has focus - one Esc press exits both at once.
    *
-   * Pending-clear MUST happen unconditionally on Escape, even when
-   * `selectedPath` is already null. The early-return gate for the
-   * `selectedPath` write is preserved (skips a redundant signal write)
-   * but pending-clear runs first because pending may be non-null even
-   * when `selectedPath` is null (cold-start typing + Escape scenario;
-   * #266).
+   * Two production paths, kept separate so each can be tested in
+   * isolation (the two Escape-during-defer specs cover distinct
+   * production paths):
    *
-   * The `if (selectedPath() !== null)` gate is the ONLY thing that
-   * makes the two Escape-during-defer specs cover distinct production
-   * paths. Removing the gate would make `clearSelection()` a no-op
-   * when `selectedPath` is already null, collapsing the cold-start
-   * spec into the warm-start spec. Future cleanup PRs MUST preserve
-   * this gate or update both tests in lockstep.
+   *  - Cold-start backstop (selectedPath already null, pending
+   *    possibly non-null from typing-before-tree-catches-up):
+   *    clear pending only. We do NOT route through
+   *    `setUserSelection(null)` here to avoid a redundant
+   *    same-value signal write that would re-fire the dedup-
+   *    emit effect.
+   *  - Warm-path (selectedPath non-null): `clearSelection()`,
+   *    which calls `setUserSelection(null)`, which clears
+   *    pending and writes null.
+   *
+   * The cold-start branch's `clearPendingSelectPath()` call is
+   * load-bearing for #266 v2.4 cold-start regression coverage
+   * at `json-tree.component.spec.ts` (search for "cold-start").
+   * Future cleanup PRs MUST preserve the branch split or update
+   * both tests in lockstep.
    */
   @HostListener('document:keydown.escape')
   onDocumentEscape(): void {
-    this.clearPendingSelectPath();
-    if (this.selectedPath() !== null) {
-      this.clearSelection();
+    if (this.selectedPath() === null) {
+      this.clearPendingSelectPath();
+      return;
     }
+    this.clearSelection();
   }
 
   /**
@@ -2373,12 +2408,12 @@ export class JsonTreeComponent {
     const next = this.nextHitFromSelection(paths);
     this.activeHitIndex.set(next);
     const path = paths[next] as string;
-    // Issue #266: user-intent writer; cancel any in-flight defer
-    // from editor-typing before navigating to the search hit. Placed
-    // AFTER the `paths.length === 0` early return so a zero-hit
-    // press of Next/Prev does not destroy an in-flight defer.
-    this.clearPendingSelectPath();
-    this.selectedPath.set(path);
+    // Issue #266 / #274: intentional writer; route through
+    // `setUserSelection` so any in-flight defer from editor-
+    // typing is cancelled synchronously. Placed AFTER the
+    // `paths.length === 0` early return so a zero-hit press of
+    // Next/Prev does not destroy an in-flight defer.
+    this.setUserSelection(path);
     // M7g-3b. Also update `focusedPath` silently so a subsequent Tab
     // into the tree lands on the active hit. Do NOT call DOM focus()
     // on the row -- the search input keeps focus so repeated Enter /
@@ -2393,9 +2428,8 @@ export class JsonTreeComponent {
     const prev = this.prevHitFromSelection(paths);
     this.activeHitIndex.set(prev);
     const path = paths[prev] as string;
-    // Issue #266: see goToNextMatch.
-    this.clearPendingSelectPath();
-    this.selectedPath.set(path);
+    // Issue #266 / #274: see goToNextMatch.
+    this.setUserSelection(path);
     // See goToNextMatch: focused-but-not-DOM-focused so the search
     // input keeps focus.
     this.focusedPath.set(path);
@@ -2565,16 +2599,18 @@ export class JsonTreeComponent {
    */
   selectByPathString(pathString: string | null): void {
     if (pathString === null) {
-      this.clearPendingSelectPath();
-      if (this.selectedPath() !== null) {
-        this.selectedPath.set(null);
-      }
+      // Programmatic clear. Issue #274 routes through
+      // `setUserSelection(null)`. The dedup-emit effect's
+      // `lastEmittedSelectedPath` swallows the redundant
+      // same-value emission when `selectedPath` is already null,
+      // so we do not gate the helper call.
+      this.setUserSelection(null);
       return;
     }
     if (this.selectedPath() === pathString) {
       // Idempotent: even though selectedPath is already the
       // requested value, clear pending so a prior defer cannot
-      // re-apply later. The user just re-affirmed this path.
+      // re-apply later. The caller just re-affirmed this path.
       this.clearPendingSelectPath();
       return;
     }
@@ -2586,10 +2622,11 @@ export class JsonTreeComponent {
       this.pendingPriorSelectedPath = this.selectedPath();
       return;
     }
-    // Immediate apply: nodeIndex already has the path. Clear any
-    // stale pending and write selectedPath.
-    this.clearPendingSelectPath();
-    this.selectedPath.set(pathString);
+    // Immediate apply: nodeIndex already has the path. Issue
+    // #274 routes through `setUserSelection` (clears any stale
+    // pending then writes selectedPath); `expandAndScroll` is
+    // the immediate-apply-specific tail.
+    this.setUserSelection(pathString);
     this.expandAndScroll(pathString);
   }
 
@@ -2603,6 +2640,59 @@ export class JsonTreeComponent {
   clearPendingSelectPath(): void {
     this.pendingSelectPathString = null;
     this.pendingPriorSelectedPath = null;
+  }
+
+  /**
+   * Issue #274. Standard "clear pending then set" idiom for every
+   * in-component intentional write to `selectedPath`. Clears any
+   * in-flight #266 defer (so the retry-pending effect's
+   * discriminator cannot later re-apply a stale pending path
+   * over this write), then writes the new path.
+   *
+   * Call sites (also enumerated in the "Intentional writers" doc
+   * block at `selectedPath`'s declaration):
+   *  - Direct user gestures: `onSelect` (mouse click),
+   *    keyboard Enter / Space, `onKebabClick`, Escape via
+   *    `clearSelection`, search-nav (`goToNextMatch` /
+   *    `goToPrevMatch`).
+   *  - Microtask-deferred user gesture:
+   *    `activateClickedHitOrFirst` (the microtask defers the
+   *    write past the search-hit-list reset effect, but the
+   *    originating gesture is the user's click).
+   *  - Programmatic: `selectByPathString` immediate-apply
+   *    branch, `selectByPathString` null-clear branch, the
+   *    retry-pending effect's apply branch.
+   *
+   * `null` clears the selection (and pending). Does NOT touch
+   * `focusedPath`: callers that also want to move the keyboard
+   * cursor (e.g., `onSelect`, search-nav) update `focusedPath`
+   * separately. Does NOT expand or scroll: the immediate-apply
+   * branch of `selectByPathString` chains `expandAndScroll`
+   * after this call.
+   *
+   * Caller contract: pass a path that is in `nodeIndex()` (or
+   * `null`). The helper does NOT defer like `selectByPathString` --
+   * if the path is not in `nodeIndex`, the preserve-or-clear
+   * effect on the next nodeIndex tick will clear `selectedPath`
+   * back to null. All current callers satisfy this naturally:
+   * direct gestures operate on rendered `TreeNode`s; programmatic
+   * callers go through `selectByPathString` which checks
+   * `nodeIndex().has(...)` before deciding to defer vs
+   * immediate-apply.
+   *
+   * Why this exists (issue #274): pre-helper, only 3 of 7
+   * intentional writers cleared pending; the other 4 relied on
+   * keyboard-release timing to terminate any in-flight typing-
+   * induced defer. The helper makes the pending-clear structural
+   * rather than empirical. The `check-prod-patterns.mjs`
+   * `selected-path-set` rule rejects raw `selectedPath.set(...)`
+   * writes outside this helper (system-clear writes inside this
+   * file carry the trailing pragma
+   * `// allow:selected-path-set <category>`).
+   */
+  setUserSelection(path: string | null): void {
+    this.clearPendingSelectPath();
+    this.selectedPath.set(path); // allow:selected-path-set helper
   }
 
   /**
@@ -3142,7 +3232,7 @@ export class JsonTreeComponent {
     event.stopPropagation();
     this.contextNode.set(node);
     this.contextIsCloseRow.set(false);
-    this.selectedPath.set(node.pathString);
+    this.setUserSelection(node.pathString);
     this.logger.info('tree.contextMenu.opened', { source: 'kebab' });
   }
 
@@ -4433,7 +4523,7 @@ export class JsonTreeComponent {
       }
       this.activeHitIndex.set(next);
       const target = paths[next] as string;
-      this.selectedPath.set(target);
+      this.setUserSelection(target);
       this.revealHit(target);
     });
   }

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -2322,36 +2322,29 @@ export class JsonTreeComponent {
   }
 
   /**
-   * Escape clears the active selection. We do not call preventDefault()
-   * so the search input's own Esc binding can also clear the search
-   * query when it has focus - one Esc press exits both at once.
+   * Escape clears the active selection (and any in-flight #266
+   * defer). We do not call preventDefault() so the search input's
+   * own Esc binding can also clear the search query when it has
+   * focus - one Esc press exits both at once.
    *
-   * Two production paths, kept separate so each can be tested in
-   * isolation (the two Escape-during-defer specs cover distinct
-   * production paths):
+   * Single-path delegation to `clearSelection()`, which routes
+   * through `setUserSelection(null)`:
    *
-   *  - Cold-start backstop (selectedPath already null, pending
-   *    possibly non-null from typing-before-tree-catches-up):
-   *    clear pending only. We do NOT route through
-   *    `setUserSelection(null)` here to avoid a redundant
-   *    same-value signal write that would re-fire the dedup-
-   *    emit effect.
-   *  - Warm-path (selectedPath non-null): `clearSelection()`,
-   *    which calls `setUserSelection(null)`, which clears
-   *    pending and writes null.
+   *  - `clearPendingSelectPath()` clears any in-flight defer
+   *    (the load-bearing action for the #266 v2.4 cold-start
+   *    regression, where `selectedPath` is already null but a
+   *    defer is pending from typing-before-tree-catches-up).
+   *  - `selectedPath.set(null)` writes null. On the cold-start
+   *    branch this is a same-value write; Angular signals'
+   *    native Object.is dedup makes it a no-op (no notification,
+   *    no effect fire), so there's no spurious emission.
    *
-   * The cold-start branch's `clearPendingSelectPath()` call is
-   * load-bearing for #266 v2.4 cold-start regression coverage
-   * at `json-tree.component.spec.ts` (search for "cold-start").
-   * Future cleanup PRs MUST preserve the branch split or update
-   * both tests in lockstep.
+   * Two regression specs (cold-start and warm-path) at
+   * `json-tree.component.spec.ts` (search for
+   * "Escape during defer") exercise both call-state combinations.
    */
   @HostListener('document:keydown.escape')
   onDocumentEscape(): void {
-    if (this.selectedPath() === null) {
-      this.clearPendingSelectPath();
-      return;
-    }
     this.clearSelection();
   }
 
@@ -2599,10 +2592,14 @@ export class JsonTreeComponent {
   selectByPathString(pathString: string | null): void {
     if (pathString === null) {
       // Programmatic clear. Issue #274 routes through
-      // `setUserSelection(null)`. The dedup-emit effect's
-      // `lastEmittedSelectedPath` swallows the redundant
-      // same-value emission when `selectedPath` is already null,
-      // so we do not gate the helper call.
+      // `setUserSelection(null)`. When `selectedPath` is already
+      // null the inner `selectedPath.set(null)` is a same-value
+      // write; Angular signals' native Object.is dedup makes it
+      // a signal-level no-op (no notification, the dedup-emit
+      // effect does not re-fire), so we do not gate the helper
+      // call. The `clearPendingSelectPath()` half of the helper
+      // still runs and is the load-bearing action when a defer
+      // is in flight.
       this.setUserSelection(null);
       return;
     }


### PR DESCRIPTION
Closes #274.

## What changes

Adds a `setUserSelection(path)` helper on `JsonTreeComponent` that encapsulates the canonical "clear pending then set" idiom and routes every intentional `selectedPath` write through it. This makes the issue #266 defer/retry pending-clear **structural** instead of empirically-true via keyboard-release timing.

### Production code (`json-tree.component.ts`)

- **10 intentional writers** now route through `setUserSelection()`:
  - User-intent: `onSelect`, keyboard Enter/Space activation, `onKebabClick`, `activateClickedHitOrFirst`
  - Idempotent: `clearSelection`, `goToNextMatch`, `goToPrevMatch`
  - Programmatic (per Resolution B): `selectByPathString` immediate-apply + null-clear, retry-pending apply
- **3 view-reset system writes** remain raw, tagged with the closed-vocabulary trailing pragma `// allow:selected-path-set system-clear`.
- `onDocumentEscape` restructured with an explicit cold-start backstop branch.
- Top-of-component doc block at `selectedPath`'s declaration rewritten to describe intentional writers, system-clear writers, and the helper enforcement contract.

### Lint guard (`scripts/check-prod-patterns.mjs`)

- New `selected-path-set` rule fires **repo-wide** on raw `.selectedPath.set(...)` calls so cross-file writers (e.g., a hypothetical sibling holding `viewChild(JsonTreeComponent)`) cannot grow a back-door writer.
- Engine widened to accept either a **string pragma** (rule #2 backwards compat) or a **RegExp pragma** (rule #4 enforces the closed-enum reason vocabulary: `helper | system-clear | programmatic-immediate | programmatic-clear | retry-pending-apply`).
- Safe-harbor narrowed via `pragmaAllowedPaths` to `json-tree.component.ts` only.
- Top-level CLI wrapped in `main()` + invoked-directly guard so the module is importable for testing.

### Tests

- New `scripts/check-prod-patterns.test.mjs` (14 `node:test` cases): RegExp-pragma engine, closed-enum vocabulary (incl. anti-regression for the v1 plan's `system-write` reason), pragma-in-wrong-file rejection, rule #2 string-pragma backwards compat.
- New `setUserSelection helper (issue #274)` describe in the spec with 2 helper unit tests and the click-same-row-mid-defer regression.
- 4 pending-clear micro-assertions appended to existing routed-gesture specs (Enter, Space, click, kebab, `activateClickedHitOrFirst`).
- Discriminator test renamed to "defensive backstop" and preamble rewritten -- user-intent writers can no longer bypass the helper, so the discriminator is now strictly defense-in-depth.
- Intent note above `selection highlighting` explaining that direct `selectedPath.set(...)` calls in specs are intentional test-state setup.

### Behavior change (patch bump 0.26.1 -> 0.26.2; rebased onto v0.27.0 -> ships as 0.27.1)

**Clicking the already-selected row mid-`selectByPathString`-defer now cancels the pending jump.** Pre-#274 the same-value signal write was a no-op (Angular signal dedup), pending stayed, and the tree silently jumped to the deferred path on the next nodeIndex tick. Post-#274 the helper's synchronous pending-clear cancels the jump -- the user's affirmation of the current selection wins. Regression-tested.

## Verification (all green)

- `npm run lint:all` -- 158 prod files scanned, 0 violations; ASCII / spec-patterns / CSP / SWA / lockfile / prettier all clean.
- `npm test` -- Karma 2764/2767 (3 standard skips), 37.94s.
- `npm --prefix api test` -- 465/465 in 15 suites.
- `npm run build` -- production bundle clean.
- `npm run test:scripts` -- 221 cases (incl. 14 new for the lint rule).

## Plan + rubber-duck

Plan was authored and rubber-ducked via `deep-review:skeptic` per AGENTS.md ┬º11 before implementation. 11 skeptic findings adopted; 2 open questions surfaced to the user via `ask_user` (Resolution B for `selectByPathString` immediate-apply + patch SemVer bump confirmed).

## Rebase note

After the initial PR opened at v0.26.2, main advanced to **v0.27.0** (PR #285 keyboard-flyout). I merged main into this branch (commit `547aee3`) and bumped the patch level to **v0.27.1** to cover the click-mid-defer behavior fix that ships with this change. `package.json`, `package-lock.json` (root + `packages[""]`), and the PR title all reflect `v0.27.1`.

Note: the original commit subject `c2508ac` on this branch still carries the literal `v0.26.2` string. After squash-merge, the published commit subject on `main` matches the PR title (`v0.27.1`), but the squash commit body will retain the historical commit subjects (including the `v0.26.2` string) as a record of the branch's evolution.

## Round-2 review feedback addressed

Bot review at 2026-05-18 03:30Z surfaced 4 findings on commit `547aee3`. Round-2 fix in commit `1d3cb39`:

- **PR title / description version drift** -> title updated to v0.27.1; rebase note added (this section).
- **`cdHint` dead variable** in `check-lockfile.mjs:118` -> removed.
- **Misleading dedup-effect rationale** in `onDocumentEscape` and `selectByPathString` -> `onDocumentEscape` collapsed to a single `clearSelection()` call (the prior cold-start branch was not actually load-bearing -- Angular signals' native Object.is dedup makes the same-value `set(null)` a no-op and `clearSelection` itself clears pending via `setUserSelection(null)`). Both inline comments rewritten to reference signal-level dedup correctly.
- **Helper-pragma scope** -> declined; pushback reply explains that the count-enforcement layer would contradict the file's stated "defense-in-depth, not airtight" doctrine.

Round-2 verification: `npm run lint:all` green; `npm run test:scripts` 237/237; focused karma on `json-tree.component.spec.ts` 512/512 (both Escape-during-defer regression tests pass after the collapse).

---
**Session**
- AI-Local: `c5dd339e-eb69-432b-a538-de3606121763`
- AI-Cloud: `84a0be20-5610-4a7e-bf55-eabb7167d839`
