### PR TITLE
Honor editorTabSize preference in JSON extractor (#253, v0.27.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.27.1",
+      "version": "0.27.2",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.27.1",
+  "version": "0.27.2",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/core/json/json-extractor.core.spec.ts
+++ b/src/app/core/json/json-extractor.core.spec.ts
@@ -1,6 +1,6 @@
 import type { ParseError } from 'jsonc-parser';
 import { parse } from 'jsonc-parser';
-import type { ExtractedJson, ParseJsonCandidate } from './json-extractor.core';
+import type { ExtractedJson, IndentSize, ParseJsonCandidate } from './json-extractor.core';
 import { extractFromMixedText } from './json-extractor.core';
 
 const parseJsonCandidate: ParseJsonCandidate = (candidateText: string) => {
@@ -185,10 +185,67 @@ describe('extractFromMixedText core', () => {
     expect(wrapper['suffix']).toBe(' post');
     expect(extracted.proseSegments).toBe(4);
   });
+
+  // Issue #253: `editorTabSize` is honored across all four output shapes.
+  describe('honors tabSize parameter', () => {
+    it('formats a bare single block at tabSize 4', () => {
+      const extracted = extractRequired('{"a":1,"b":{"c":2}}', 4);
+      expect(extracted.proseSegments).toBe(0);
+      expect(extracted.blockCount).toBe(1);
+      // 4-space indent on the nested key.
+      expect(extracted.text).toContain('\n    "a"');
+      expect(extracted.text).toContain('\n    "b"');
+      // No 2-space-only indentation should leak through.
+      expect(extracted.text).not.toMatch(/\n  "[ab]"/);
+    });
+
+    it('formats a bare multi-block array at tabSize 4', () => {
+      const extracted = extractRequired('{"a":1}{"b":2}', 4);
+      expect(extracted.proseSegments).toBe(0);
+      expect(extracted.blockCount).toBe(2);
+      expect(parseJsoncText(extracted.text)).toEqual([{ a: 1 }, { b: 2 }]);
+      // JSON.stringify with indent 4 -> 4-space indent on array elements.
+      expect(extracted.text).toContain('\n    {');
+    });
+
+    it('formats a single-block prose wrapper at tabSize 4', () => {
+      const extracted = extractRequired('before {"a":1} after', 4);
+      const wrapper = expectJsoncRecord(extracted.text);
+
+      expect(wrapper['prefix']).toBe('before ');
+      expect(wrapper['json']).toEqual({ a: 1 });
+      expect(wrapper['suffix']).toBe(' after');
+      // 4-space indent on top-level wrapper keys.
+      expect(extracted.text).toContain('\n    "prefix"');
+      expect(extracted.text).toContain('\n    "json"');
+    });
+
+    it('formats a multi-block prose wrapper at tabSize 4', () => {
+      const extracted = extractRequired('pre {"a":1} mid {"b":2} post', 4);
+      const wrapper = expectJsoncRecord(extracted.text);
+
+      expect(wrapper['prefix']).toBe('pre ');
+      expect(wrapper['json1']).toEqual({ a: 1 });
+      expect(wrapper['between_1_and_2']).toBe(' mid ');
+      expect(wrapper['json2']).toEqual({ b: 2 });
+      expect(wrapper['suffix']).toBe(' post');
+      // 4-space indent on top-level wrapper keys.
+      expect(extracted.text).toContain('\n    "prefix"');
+      expect(extracted.text).toContain('\n    "json1"');
+    });
+
+    it('defaults to 2-space indent when extractRequired is called without tabSize', () => {
+      const extracted = extractRequired('{"a":1,"b":2}');
+      // 2-space indent on top-level keys.
+      expect(extracted.text).toContain('\n  "a"');
+      // No 4-space indent should appear.
+      expect(extracted.text).not.toContain('\n    "a"');
+    });
+  });
 });
 
-function extractRequired(input: string): ExtractedJson {
-  const extracted = extractFromMixedText(input, parseJsonCandidate);
+function extractRequired(input: string, tabSize: IndentSize = 2): ExtractedJson {
+  const extracted = extractFromMixedText(input, parseJsonCandidate, tabSize);
   if (extracted === null) {
     throw new Error(`Expected extraction for ${input}`);
   }

--- a/src/app/core/json/json-extractor.core.ts
+++ b/src/app/core/json/json-extractor.core.ts
@@ -1,5 +1,14 @@
 import { applyEdits, format as formatJsonc } from 'jsonc-parser';
 
+/**
+ * Indent size honored by the JSON extractor's formatted output. Mirrors
+ * `UserPreferences.editorTabSize` (`src/app/core/api/models.ts`). Threaded
+ * as a parameter through every output-shaping function so the worker
+ * (which has no Angular DI access) can honor the preference without
+ * reading global state.
+ */
+export type IndentSize = 2 | 4;
+
 export interface ExtractedJson {
   text: string;
   blockCount: number;
@@ -96,6 +105,7 @@ const CHARACTER_LINE_FEED = 0x0a; // \n
 export function extractFromMixedText(
   input: string,
   parseJsonCandidate: ParseJsonCandidate,
+  tabSize: IndentSize,
 ): ExtractedJson | null {
   if (!input) return null;
   if (input.length > MAX_INPUT_LENGTH) return null;
@@ -103,12 +113,13 @@ export function extractFromMixedText(
   const candidates = scan(input, parseJsonCandidate);
   if (candidates.length === 0) return null;
 
-  return buildResult(input, candidates);
+  return buildResult(input, candidates, tabSize);
 }
 
 function buildResult(
   input: string,
   candidates: readonly JsonExtractorCandidate[],
+  tabSize: IndentSize,
 ): ExtractedJson | null {
   if (candidates.length === 1) {
     const candidate = candidates[0];
@@ -116,11 +127,11 @@ function buildResult(
 
     const proseSegments = countSingleBlockProseSegments(input, candidate);
     if (proseSegments === 0) {
-      return buildBareResult(candidates);
+      return buildBareResult(candidates, tabSize);
     }
 
     return {
-      text: buildSingleBlockProseWrapper(input, candidate),
+      text: buildSingleBlockProseWrapper(input, candidate, tabSize),
       blockCount: 1,
       preservesComments: true,
       proseSegments,
@@ -130,11 +141,11 @@ function buildResult(
 
   const proseSegments = countMultiBlockProseSegments(input, candidates);
   if (proseSegments === 0) {
-    return buildBareResult(candidates);
+    return buildBareResult(candidates, tabSize);
   }
 
   return {
-    text: buildMultiBlockProseWrapper(input, candidates),
+    text: buildMultiBlockProseWrapper(input, candidates, tabSize),
     blockCount: candidates.length,
     preservesComments: false,
     proseSegments,
@@ -142,13 +153,16 @@ function buildResult(
   };
 }
 
-function buildBareResult(candidates: readonly JsonExtractorCandidate[]): ExtractedJson | null {
+function buildBareResult(
+  candidates: readonly JsonExtractorCandidate[],
+  tabSize: IndentSize,
+): ExtractedJson | null {
   if (candidates.length === 1) {
     const candidate = candidates[0];
     if (candidate === undefined) return null;
 
     return {
-      text: formatExtractedJson(candidate.slice),
+      text: formatExtractedJson(candidate.slice, tabSize),
       blockCount: 1,
       preservesComments: true,
       proseSegments: 0,
@@ -160,7 +174,7 @@ function buildBareResult(candidates: readonly JsonExtractorCandidate[]): Extract
     text: JSON.stringify(
       candidates.map((candidate) => candidate.value),
       null,
-      2,
+      tabSize,
     ),
     blockCount: candidates.length,
     preservesComments: false,
@@ -169,19 +183,24 @@ function buildBareResult(candidates: readonly JsonExtractorCandidate[]): Extract
   };
 }
 
-function buildSingleBlockProseWrapper(input: string, candidate: JsonExtractorCandidate): string {
+function buildSingleBlockProseWrapper(
+  input: string,
+  candidate: JsonExtractorCandidate,
+  tabSize: IndentSize,
+): string {
   const parts: string[] = [];
   const prefix = input.slice(0, candidate.startIndex);
   addProsePart(parts, 'prefix', prefix);
-  parts.push(`"json": ${formatExtractedJson(candidate.slice)}`);
+  parts.push(`"json": ${formatExtractedJson(candidate.slice, tabSize)}`);
   const suffix = input.slice(candidate.endIndex);
   addProsePart(parts, 'suffix', suffix);
-  return formatExtractedJson(`{\n${parts.join(',\n')}\n}`);
+  return formatExtractedJson(`{\n${parts.join(',\n')}\n}`, tabSize);
 }
 
 function buildMultiBlockProseWrapper(
   input: string,
   candidates: readonly JsonExtractorCandidate[],
+  tabSize: IndentSize,
 ): string {
   const parts: string[] = [];
   const firstCandidate = candidates[0];
@@ -209,7 +228,7 @@ function buildMultiBlockProseWrapper(
     }
   }
   addProsePart(parts, 'suffix', input.slice(lastCandidate.endIndex));
-  return formatExtractedJson(`{\n${parts.join(',\n')}\n}`);
+  return formatExtractedJson(`{\n${parts.join(',\n')}\n}`, tabSize);
 }
 
 function countSingleBlockProseSegments(input: string, candidate: JsonExtractorCandidate): number {
@@ -312,9 +331,9 @@ export function scan(
   return candidates;
 }
 
-export function formatExtractedJson(slice: string): string {
+export function formatExtractedJson(slice: string, tabSize: IndentSize): string {
   const edits = formatJsonc(slice, undefined, {
-    tabSize: 2,
+    tabSize,
     insertSpaces: true,
   });
   return applyEdits(slice, edits);

--- a/src/app/core/json/json-extractor.service.spec.ts
+++ b/src/app/core/json/json-extractor.service.spec.ts
@@ -11,38 +11,38 @@ describe('JsonExtractorService', () => {
 
   describe('non-extracting inputs', () => {
     it('returns null for empty input', () => {
-      expect(svc.extractFromMixedText('')).toBeNull();
+      expect(svc.extractFromMixedText('', 2)).toBeNull();
     });
 
     it('returns null for whitespace-only input', () => {
-      expect(svc.extractFromMixedText('   \n\t  ')).toBeNull();
+      expect(svc.extractFromMixedText('   \n\t  ', 2)).toBeNull();
     });
 
     it('returns null for pure prose with no braces', () => {
-      expect(svc.extractFromMixedText('hello world')).toBeNull();
+      expect(svc.extractFromMixedText('hello world', 2)).toBeNull();
     });
 
     it('returns null for a bare primitive number floating in prose', () => {
-      expect(svc.extractFromMixedText('Total cost is 42 dollars')).toBeNull();
+      expect(svc.extractFromMixedText('Total cost is 42 dollars', 2)).toBeNull();
     });
 
     it('returns null for a quoted string in prose (no { or [ trigger)', () => {
-      expect(svc.extractFromMixedText('Status: "OK"')).toBeNull();
+      expect(svc.extractFromMixedText('Status: "OK"', 2)).toBeNull();
     });
 
     it('returns null for an unbalanced { with no closing brace', () => {
-      expect(svc.extractFromMixedText('prefix { "a": 1 suffix no closer')).toBeNull();
+      expect(svc.extractFromMixedText('prefix { "a": 1 suffix no closer', 2)).toBeNull();
     });
 
     it('returns null when input length exceeds 1 MiB', () => {
       const big = 'a'.repeat(1_048_577);
-      expect(svc.extractFromMixedText(big)).toBeNull();
+      expect(svc.extractFromMixedText(big, 2)).toBeNull();
     });
   });
 
   describe('single-block extraction', () => {
     it('extracts a single object surrounded by prose', () => {
-      const r = svc.extractFromMixedText('before {"a":1} after');
+      const r = svc.extractFromMixedText('before {"a":1} after', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       expect(r!.preservesComments).toBeTrue();
@@ -53,7 +53,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('extracts a single array surrounded by prose', () => {
-      const r = svc.extractFromMixedText('prefix [1,2,3] suffix');
+      const r = svc.extractFromMixedText('prefix [1,2,3] suffix', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       expect(r!.preservesComments).toBeTrue();
@@ -64,7 +64,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('respects brace-balance when string contains a closing brace', () => {
-      const r = svc.extractFromMixedText('prose {"a": "}"} prose');
+      const r = svc.extractFromMixedText('prose {"a": "}"} prose', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       const wrapper = JSON.parse(r!.text) as Record<string, unknown>;
@@ -72,7 +72,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('respects backslash-escaped quotes inside strings', () => {
-      const r = svc.extractFromMixedText('{"a": "\\""}');
+      const r = svc.extractFromMixedText('{"a": "\\""}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       // No surrounding prose -> bare value
@@ -80,7 +80,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('does not treat // inside a string as a comment (URL case)', () => {
-      const r = svc.extractFromMixedText('{"url":"http://example.test/a//b"}');
+      const r = svc.extractFromMixedText('{"url":"http://example.test/a//b"}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       // No surrounding prose -> bare value
@@ -90,7 +90,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('does not treat /* */ inside a string as a comment', () => {
-      const r = svc.extractFromMixedText('{"pattern":"/* not a comment */"}');
+      const r = svc.extractFromMixedText('{"pattern":"/* not a comment */"}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       // No surrounding prose -> bare value
@@ -100,7 +100,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('does not extract JSON-looking text inside a string value', () => {
-      const r = svc.extractFromMixedText('{"s":"{nested:1}"}');
+      const r = svc.extractFromMixedText('{"s":"{nested:1}"}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       // No surrounding prose -> bare value
@@ -108,7 +108,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('extracts JSON when prose contains a URL with // before the block', () => {
-      const r = svc.extractFromMixedText('GET http://x.test {"ok":true}');
+      const r = svc.extractFromMixedText('GET http://x.test {"ok":true}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       const wrapper = JSON.parse(r!.text) as Record<string, unknown>;
@@ -117,7 +117,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('preserves a leading BOM in the prose prefix', () => {
-      const r = svc.extractFromMixedText('\uFEFFprefix {"a":1} suffix');
+      const r = svc.extractFromMixedText('\uFEFFprefix {"a":1} suffix', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       const wrapper = JSON.parse(r!.text) as Record<string, unknown>;
@@ -129,7 +129,7 @@ describe('JsonExtractorService', () => {
 
   describe('JSONC comments inside a single block', () => {
     it('accepts and preserves a // line comment inside the block', () => {
-      const r = svc.extractFromMixedText('{ // hello\n "a": 1 }');
+      const r = svc.extractFromMixedText('{ // hello\n "a": 1 }', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       expect(r!.preservesComments).toBeTrue();
@@ -137,7 +137,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('accepts and preserves a /* */ block comment inside the block', () => {
-      const r = svc.extractFromMixedText('{ /* hello */ "a": 1 }');
+      const r = svc.extractFromMixedText('{ /* hello */ "a": 1 }', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       expect(r!.preservesComments).toBeTrue();
@@ -147,7 +147,7 @@ describe('JsonExtractorService', () => {
 
   describe('multi-block extraction', () => {
     it('wraps two objects with surrounding prose into a prose-preserving object', () => {
-      const r = svc.extractFromMixedText('request {"a":1} response {"b":2}');
+      const r = svc.extractFromMixedText('request {"a":1} response {"b":2}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(2);
       expect(r!.preservesComments).toBeFalse();
@@ -159,7 +159,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('wraps three blocks of mixed shapes as a bare array when no prose surrounds them', () => {
-      const r = svc.extractFromMixedText('{"a":1} [1,2] {"c":3}');
+      const r = svc.extractFromMixedText('{"a":1} [1,2] {"c":3}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(3);
       expect(r!.preservesComments).toBeFalse();
@@ -168,7 +168,7 @@ describe('JsonExtractorService', () => {
     });
 
     it('drops malformed trailing block but keeps the leading valid block', () => {
-      const r = svc.extractFromMixedText('{"a":1} prose {"b": ');
+      const r = svc.extractFromMixedText('{"a":1} prose {"b": ', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       expect(r!.preservesComments).toBeTrue();
@@ -184,7 +184,7 @@ describe('JsonExtractorService', () => {
       // so the parser rejects it. The scanner must resume at start+1 (not
       // end+1) so the inner {"real":1} is still found. The rejected outer
       // text becomes prefix/suffix prose around the accepted inner block.
-      const r = svc.extractFromMixedText('debug { notJson: {"real":1} } end');
+      const r = svc.extractFromMixedText('debug { notJson: {"real":1} } end', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       expect(r!.preservesComments).toBeTrue();
@@ -197,25 +197,25 @@ describe('JsonExtractorService', () => {
 
   describe('hasComments detection', () => {
     it('reports hasComments: false for a single block with no comments', () => {
-      const r = svc.extractFromMixedText('before {"a":1} after');
+      const r = svc.extractFromMixedText('before {"a":1} after', 2);
       expect(r).not.toBeNull();
       expect(r!.hasComments).toBeFalse();
     });
 
     it('reports hasComments: true for a single block with a // line comment', () => {
-      const r = svc.extractFromMixedText('{ // hi\n "a": 1 }');
+      const r = svc.extractFromMixedText('{ // hi\n "a": 1 }', 2);
       expect(r).not.toBeNull();
       expect(r!.hasComments).toBeTrue();
     });
 
     it('reports hasComments: true for a single block with a /* */ block comment', () => {
-      const r = svc.extractFromMixedText('{ /* hi */ "a": 1 }');
+      const r = svc.extractFromMixedText('{ /* hi */ "a": 1 }', 2);
       expect(r).not.toBeNull();
       expect(r!.hasComments).toBeTrue();
     });
 
     it('does NOT count // inside a JSON string value as a comment', () => {
-      const r = svc.extractFromMixedText('see {"url": "https://example.com/path"} done');
+      const r = svc.extractFromMixedText('see {"url": "https://example.com/path"} done', 2);
       expect(r).not.toBeNull();
       expect(r!.hasComments).toBeFalse();
     });
@@ -224,20 +224,20 @@ describe('JsonExtractorService', () => {
       // The // appears in prose between the JSON candidate and end-of-string.
       // The outer scan loop only reacts to { and [, so prose // is invisible
       // to comment detection.
-      const r = svc.extractFromMixedText('{"a":1} // not really a comment');
+      const r = svc.extractFromMixedText('{"a":1} // not really a comment', 2);
       expect(r).not.toBeNull();
       expect(r!.hasComments).toBeFalse();
     });
 
     it('reports hasComments: true when any multi-block candidate has comments', () => {
-      const r = svc.extractFromMixedText('request {"a":1} response { /* trace */ "b": 2 }');
+      const r = svc.extractFromMixedText('request {"a":1} response { /* trace */ "b": 2 }', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(2);
       expect(r!.hasComments).toBeTrue();
     });
 
     it('reports hasComments: false when no multi-block candidate has comments', () => {
-      const r = svc.extractFromMixedText('request {"a":1} response {"b":2}');
+      const r = svc.extractFromMixedText('request {"a":1} response {"b":2}', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(2);
       expect(r!.hasComments).toBeFalse();
@@ -249,7 +249,7 @@ describe('JsonExtractorService', () => {
       // start+1 and accepts the inner `{"real":1}`, which has no comments.
       // The rejected outer's comment must NOT propagate into the result.
       // The rejected outer text becomes the prose prefix/suffix.
-      const r = svc.extractFromMixedText('log { /* nope */ notJson: {"real":1} } end');
+      const r = svc.extractFromMixedText('log { /* nope */ notJson: {"real":1} } end', 2);
       expect(r).not.toBeNull();
       expect(r!.blockCount).toBe(1);
       const wrapper = JSON.parse(r!.text) as Record<string, unknown>;
@@ -259,6 +259,27 @@ describe('JsonExtractorService', () => {
       expect(r!.hasComments)
         .withContext('rejected outer wrapper must not leak its comment flag')
         .toBeFalse();
+    });
+  });
+
+  // Issue #253: service threads its `tabSize` argument through to the
+  // formatter. Spec-level coverage on the service ensures the public
+  // signature stays honest end-to-end.
+  describe('tabSize plumbing', () => {
+    it('emits 4-space indent in the wrapper when tabSize is 4', () => {
+      const r = svc.extractFromMixedText('before {"a":1} after', 4);
+      expect(r).not.toBeNull();
+      // 4-space indent on top-level wrapper keys.
+      expect(r!.text).toContain('\n    "prefix"');
+      expect(r!.text).toContain('\n    "json"');
+      expect(r!.text).not.toMatch(/\n  "prefix"/);
+    });
+
+    it('emits 2-space indent in the wrapper when tabSize is 2', () => {
+      const r = svc.extractFromMixedText('before {"a":1} after', 2);
+      expect(r).not.toBeNull();
+      expect(r!.text).toContain('\n  "prefix"');
+      expect(r!.text).not.toContain('\n    "prefix"');
     });
   });
 });

--- a/src/app/core/json/json-extractor.service.ts
+++ b/src/app/core/json/json-extractor.service.ts
@@ -1,15 +1,19 @@
 import { Injectable, inject } from '@angular/core';
-import type { ExtractedJson } from './json-extractor.core';
+import type { ExtractedJson, IndentSize } from './json-extractor.core';
 import { extractFromMixedText } from './json-extractor.core';
 import { JsonParserService } from './json-parser.service';
 
-export type { ExtractedJson } from './json-extractor.core';
+export type { ExtractedJson, IndentSize } from './json-extractor.core';
 
 @Injectable({ providedIn: 'root' })
 export class JsonExtractorService {
   private readonly parser = inject(JsonParserService);
 
-  extractFromMixedText(input: string): ExtractedJson | null {
-    return extractFromMixedText(input, (candidateText) => this.parser.parse(candidateText));
+  extractFromMixedText(input: string, tabSize: IndentSize): ExtractedJson | null {
+    return extractFromMixedText(
+      input,
+      (candidateText) => this.parser.parse(candidateText),
+      tabSize,
+    );
   }
 }

--- a/src/app/core/json/json-extractor.worker.ts
+++ b/src/app/core/json/json-extractor.worker.ts
@@ -1,6 +1,7 @@
 /// <reference lib="webworker" />
 
 import { parse, ParseError } from 'jsonc-parser';
+import type { IndentSize } from './json-extractor.core';
 import { extractFromMixedText } from './json-extractor.core';
 
 // Message shapes - keep these in sync with the service.
@@ -8,6 +9,11 @@ export interface ScanRequest {
   type: 'scan';
   // Identifies the parse generation; service drops responses for stale versions.
   sourceVersion: number;
+  // Indent size to use when formatting extracted JSON output (2 | 4).
+  // Captured at chunk-dispatch time by the service so that a tabSize
+  // change between dispatch and response cannot cause stale cache
+  // entries.
+  tabSize: IndentSize;
   // Strings to scan. The service is responsible for de-duping before sending,
   // for size pre-screening, and for the {/[ pre-screen.
   strings: readonly string[];
@@ -36,7 +42,17 @@ addEventListener('message', (event: MessageEvent<ScanRequest>) => {
 
   const results = message.strings.map((value) => {
     try {
-      const extracted = extractFromMixedText(value, parseJsonCandidate);
+      // A missing/invalid tabSize is a wire-format skew bug (older queued
+      // worker request crossing a reload boundary, or a code-side type
+      // violation). Fail loudly per AGENTS.md "never swallow errors" --
+      // the surrounding try/catch turns this into a null result for that
+      // input, which the service treats as "not extractable". That is far
+      // better than silently producing 2-space indent under a user's
+      // 4-space preference (issue #253).
+      if (message.tabSize !== 2 && message.tabSize !== 4) {
+        throw new Error(`json-extractor.worker: invalid tabSize ${String(message.tabSize)}`);
+      }
+      const extracted = extractFromMixedText(value, parseJsonCandidate, message.tabSize);
       if (!extracted) return null;
       return {
         text: extracted.text,

--- a/src/app/core/json/json-extractor.worker.ts
+++ b/src/app/core/json/json-extractor.worker.ts
@@ -9,6 +9,14 @@ export interface ScanRequest {
   type: 'scan';
   // Identifies the parse generation; service drops responses for stale versions.
   sourceVersion: number;
+  // Per-chunk identifier assigned by the service. The worker echoes it
+  // unchanged in the response so the service can associate the result
+  // with the exact in-flight chunk (issue #289 PR review): if a tabSize
+  // flip mid-generation deletes a chunk and reposts a fresh one at the
+  // same sourceVersion, the OLD response's chunkId is no longer tracked
+  // and the response is dropped, instead of being misassociated with
+  // the NEW chunk and poisoning the cache.
+  chunkId: number;
   // Indent size to use when formatting extracted JSON output (2 | 4).
   // Captured at chunk-dispatch time by the service so that a tabSize
   // change between dispatch and response cannot cause stale cache
@@ -22,6 +30,9 @@ export interface ScanRequest {
 export interface ScanResultMessage {
   type: 'scanResult';
   sourceVersion: number;
+  // Echoes ScanRequest.chunkId so the service can look up the exact
+  // pending chunk this response belongs to. See ScanRequest.chunkId.
+  chunkId: number;
   // Mirrors the order of the request's `strings`. null means "not extractable".
   results: readonly (ExtractedJsonWireFormat | null)[];
 }
@@ -52,6 +63,14 @@ addEventListener('message', (event: MessageEvent<ScanRequest>) => {
       if (message.tabSize !== 2 && message.tabSize !== 4) {
         throw new Error(`json-extractor.worker: invalid tabSize ${String(message.tabSize)}`);
       }
+      // chunkId must be a finite integer; the service relies on it as a
+      // Map key to associate this response with the right pending chunk
+      // (PR #289 review). Fail loudly via the surrounding try/catch on
+      // any wire-format skew rather than silently emitting a response
+      // the service cannot route.
+      if (typeof message.chunkId !== 'number' || !Number.isInteger(message.chunkId)) {
+        throw new Error(`json-extractor.worker: invalid chunkId ${String(message.chunkId)}`);
+      }
       const extracted = extractFromMixedText(value, parseJsonCandidate, message.tabSize);
       if (!extracted) return null;
       return {
@@ -70,6 +89,7 @@ addEventListener('message', (event: MessageEvent<ScanRequest>) => {
   const response: ScanResultMessage = {
     type: 'scanResult',
     sourceVersion: message.sourceVersion,
+    chunkId: message.chunkId,
     results,
   };
   postMessage(response);

--- a/src/app/core/json/tree-string-extractor.service.spec.ts
+++ b/src/app/core/json/tree-string-extractor.service.spec.ts
@@ -1,6 +1,9 @@
+import { signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
+import type { UserPreferences } from '../api/models';
+import { DEFAULT_PREFERENCES, PreferencesService } from '../preferences/preferences.service';
 import { LoggerService } from '../telemetry/logger.service';
-import type { ExtractedJson } from './json-extractor.core';
+import type { ExtractedJson, IndentSize } from './json-extractor.core';
 import { MAX_INPUT_LENGTH } from './json-extractor.core';
 import {
   TREE_STRING_EXTRACTOR_BATCH_SIZE,
@@ -12,6 +15,7 @@ import {
 interface ScanRequest {
   type: 'scan';
   sourceVersion: number;
+  tabSize: IndentSize;
   strings: readonly string[];
 }
 
@@ -106,18 +110,38 @@ describe('TreeStringExtractorService', () => {
   let service: TreeStringExtractorService;
   let mockWorker: MockWorker;
   let logger: jasmine.SpyObj<LoggerService>;
+  let prefsSignal: ReturnType<typeof signal<UserPreferences>>;
+  let prefsStub: Pick<PreferencesService, 'prefs'>;
+
+  function createPrefsStub(initial: UserPreferences): {
+    signal: ReturnType<typeof signal<UserPreferences>>;
+    stub: Pick<PreferencesService, 'prefs'>;
+  } {
+    const stateSignal = signal<UserPreferences>(initial);
+    const stub = { prefs: stateSignal.asReadonly() } as Pick<PreferencesService, 'prefs'>;
+    return { signal: stateSignal, stub };
+  }
 
   beforeEach(() => {
     mockWorker = new MockWorker();
     logger = jasmine.createSpyObj<LoggerService>('LoggerService', ['warn']);
+    const created = createPrefsStub({ ...DEFAULT_PREFERENCES });
+    prefsSignal = created.signal;
+    prefsStub = created.stub;
     TestBed.configureTestingModule({
       providers: [
         { provide: WORKER_FACTORY, useValue: () => mockWorker.asWorker() },
         { provide: LoggerService, useValue: logger },
+        { provide: PreferencesService, useValue: prefsStub },
       ],
     });
     service = TestBed.inject(TreeStringExtractorService);
     service.beginGeneration();
+    // Flush the constructor's first-sync effect run so `lastObservedTabSize`
+    // captures the initial prefs value. Without this, the next
+    // `prefsSignal.set(...)` would be observed as the "first" tabSize and
+    // would not trigger a rescan.
+    TestBed.flushEffects();
   });
 
   it('rejects strings shorter than two characters', () => {
@@ -269,6 +293,7 @@ describe('TreeStringExtractorService', () => {
   it('marks the scanner unavailable when worker creation fails', () => {
     TestBed.resetTestingModule();
     logger = jasmine.createSpyObj<LoggerService>('LoggerService', ['warn']);
+    const fallbackPrefs = createPrefsStub({ ...DEFAULT_PREFERENCES });
     TestBed.configureTestingModule({
       providers: [
         {
@@ -278,6 +303,7 @@ describe('TreeStringExtractorService', () => {
           },
         },
         { provide: LoggerService, useValue: logger },
+        { provide: PreferencesService, useValue: fallbackPrefs.stub },
       ],
     });
     service = TestBed.inject(TreeStringExtractorService);
@@ -427,6 +453,98 @@ describe('TreeStringExtractorService', () => {
     expect(candidate?.proseSegments).toBe(1);
   });
 
+  describe('tabSize', () => {
+    // Issue #253: editor tab-size preference must propagate to the
+    // worker request and govern cache keying so visible indent
+    // matches the user's preference at all times.
+
+    it('posts the current prefs editorTabSize on each scan request', () => {
+      prefsSignal.set({ ...DEFAULT_PREFERENCES, editorTabSize: 4 });
+      TestBed.flushEffects();
+
+      service.beginGeneration();
+      service.enqueueScan([rawJsonString(70)]);
+
+      expect(mockWorker.requirePostedMessage(0).tabSize).toBe(4);
+    });
+
+    it('captures tabSize at dispatch so mid-flight pref flips do not corrupt the cache (TOCTOU regression)', () => {
+      const rawString = rawJsonString(71);
+
+      // Dispatch at tabSize=2.
+      service.enqueueScan([rawString]);
+      expect(mockWorker.requirePostedMessage(0).tabSize).toBe(2);
+
+      // Flip prefs to 4 BEFORE responding. The pending chunk must
+      // still cache the result under tabSize=2 because that is the
+      // tabSize the worker formatted at.
+      prefsSignal.set({ ...DEFAULT_PREFERENCES, editorTabSize: 4 });
+
+      mockWorker.respondToMessage(0);
+
+      // The flushed effect will trigger a re-scan at tabSize=4. The
+      // re-post must MISS the cache (different key) and dispatch a
+      // fresh worker request with tabSize=4.
+      TestBed.flushEffects();
+
+      expect(mockWorker.postedMessages.length).toBe(2);
+      expect(mockWorker.requirePostedMessage(1).tabSize).toBe(4);
+      expect(mockWorker.requirePostedMessage(1).strings).toEqual([rawString]);
+    });
+
+    it('flipping editorTabSize invalidates current-generation results and re-scans', () => {
+      const rawString = rawJsonString(72);
+
+      service.enqueueScan([rawString]);
+      mockWorker.respondToMessage(0);
+      expectCandidateText(rawString, rawString);
+
+      prefsSignal.set({ ...DEFAULT_PREFERENCES, editorTabSize: 4 });
+      TestBed.flushEffects();
+
+      // Stale results cleared until the new-tabSize chunk responds.
+      expect(service.candidates().size).toBe(0);
+      expect(mockWorker.postedMessages.length).toBe(2);
+      expect(mockWorker.requirePostedMessage(1).tabSize).toBe(4);
+    });
+
+    it('serves a cached tabSize-4 result on re-flip without re-posting', () => {
+      const rawString = rawJsonString(73);
+
+      // Cache an entry at tabSize=2.
+      service.enqueueScan([rawString]);
+      mockWorker.respondToMessage(0);
+
+      // Flip to 4: forces a re-scan at the new tabSize.
+      prefsSignal.set({ ...DEFAULT_PREFERENCES, editorTabSize: 4 });
+      TestBed.flushEffects();
+      mockWorker.respondToMessage(1);
+
+      // Flip back to 2: the tabSize=2 entry is still in the LRU,
+      // so no fresh worker post is needed.
+      prefsSignal.set({ ...DEFAULT_PREFERENCES, editorTabSize: 2 });
+      TestBed.flushEffects();
+
+      expect(mockWorker.postedMessages.length).toBe(2);
+      expectCandidateText(rawString, rawString);
+    });
+
+    it('pre-screen failures are tabSize-independent (no re-post after tabSize flip)', () => {
+      // Strings without `{` or `[` cannot have JSON regardless of
+      // tabSize. They go into definitelyNullStrings, not the cache.
+      service.enqueueScan(['plain text without delimiters']);
+      expect(mockWorker.postedMessages).toEqual([]);
+
+      prefsSignal.set({ ...DEFAULT_PREFERENCES, editorTabSize: 4 });
+      TestBed.flushEffects();
+
+      service.beginGeneration();
+      service.enqueueScan(['plain text without delimiters']);
+
+      expect(mockWorker.postedMessages).toEqual([]);
+    });
+  });
+
   function expectCandidateText(rawString: string, expectedText: string): void {
     const candidate = service.candidates().get(rawString);
     expect(candidate).toBeDefined();
@@ -456,11 +574,13 @@ function isScanRequest(value: unknown): value is ScanRequest {
   const candidate = value as {
     type?: unknown;
     sourceVersion?: unknown;
+    tabSize?: unknown;
     strings?: unknown;
   };
   return (
     candidate.type === 'scan' &&
     typeof candidate.sourceVersion === 'number' &&
+    (candidate.tabSize === 2 || candidate.tabSize === 4) &&
     Array.isArray(candidate.strings) &&
     candidate.strings.every((item) => typeof item === 'string')
   );

--- a/src/app/core/json/tree-string-extractor.service.spec.ts
+++ b/src/app/core/json/tree-string-extractor.service.spec.ts
@@ -15,6 +15,7 @@ import {
 interface ScanRequest {
   type: 'scan';
   sourceVersion: number;
+  chunkId: number;
   tabSize: IndentSize;
   strings: readonly string[];
 }
@@ -22,6 +23,7 @@ interface ScanRequest {
 interface ScanResultMessage {
   type: 'scanResult';
   sourceVersion: number;
+  chunkId: number;
   results: readonly (ExtractedJsonWireFormat | null)[];
 }
 
@@ -53,6 +55,7 @@ class MockWorker {
     this.emitScanResult({
       type: 'scanResult',
       sourceVersion: request.sourceVersion,
+      chunkId: request.chunkId,
       results: results ?? request.strings.map((rawString) => wireResultFor(rawString)),
     });
   }
@@ -246,6 +249,7 @@ describe('TreeStringExtractorService', () => {
     mockWorker.emitScanResult({
       type: 'scanResult',
       sourceVersion: oldRequest.sourceVersion,
+      chunkId: oldRequest.chunkId,
       results: [wireResultFor(oldString)],
     });
 
@@ -254,6 +258,7 @@ describe('TreeStringExtractorService', () => {
     mockWorker.emitScanResult({
       type: 'scanResult',
       sourceVersion: newRequest.sourceVersion,
+      chunkId: newRequest.chunkId,
       results: [wireResultFor(newString)],
     });
 
@@ -530,8 +535,14 @@ describe('TreeStringExtractorService', () => {
     });
 
     it('pre-screen failures are tabSize-independent (no re-post after tabSize flip)', () => {
-      // Strings without `{` or `[` cannot have JSON regardless of
-      // tabSize. They go into definitelyNullStrings, not the cache.
+      // shouldScan is pure and deterministic: it depends only on the
+      // raw string length and the presence of `{`/`[`. A string that
+      // fails the pre-screen at tabSize=2 will fail again at tabSize=4,
+      // so no worker request should be posted on either side of the
+      // flip. This regression protects against a future change that
+      // makes shouldScan tabSize-sensitive (e.g., a misguided
+      // "optimize by skipping comment characters" pass whose count
+      // would differ by indent).
       service.enqueueScan(['plain text without delimiters']);
       expect(mockWorker.postedMessages).toEqual([]);
 
@@ -542,6 +553,77 @@ describe('TreeStringExtractorService', () => {
       service.enqueueScan(['plain text without delimiters']);
 
       expect(mockWorker.postedMessages).toEqual([]);
+    });
+
+    it('drops a stale OLD-tabSize response arriving AFTER a rescan reposted at the new tabSize (chunkId TOCTOU regression)', () => {
+      // PR #289 review: previously, `rescanCurrentGenerationOnTabSizeChange`
+      // deleted the version-keyed queue entry and reposted a new chunk
+      // at the SAME sourceVersion. A late-arriving OLD-tabSize response
+      // would pass the sourceVersion guard, pop the NEW chunk via the
+      // FIFO queue, cache the OLD result under the NEW chunk's tabSize
+      // key (poisoning the cache), AND eat the NEW chunk's queue slot
+      // so the legitimate NEW response was silently dropped. With
+      // per-chunk ids the OLD response's chunkId is no longer tracked
+      // after the rescan and the response is dropped.
+      const rawString = rawJsonString(74);
+
+      // 1) Dispatch at tabSize=2. Capture chunkId 0 for the OLD chunk.
+      service.enqueueScan([rawString]);
+      const oldRequest = mockWorker.requirePostedMessage(0);
+      expect(oldRequest.tabSize).toBe(2);
+
+      // 2) Flip prefs and flush -- rescan deletes the OLD chunkId and
+      //    posts a NEW chunk (chunkId 1) at tabSize=4 / same sourceVersion.
+      prefsSignal.set({ ...DEFAULT_PREFERENCES, editorTabSize: 4 });
+      TestBed.flushEffects();
+      const newRequest = mockWorker.requirePostedMessage(1);
+      expect(newRequest.tabSize).toBe(4);
+      expect(newRequest.sourceVersion).toBe(oldRequest.sourceVersion);
+
+      // 3) Deliver the OLD chunkId's response. It must be dropped:
+      //    no candidate poisoning, no NEW chunk consumed.
+      mockWorker.emitScanResult({
+        type: 'scanResult',
+        sourceVersion: oldRequest.sourceVersion,
+        chunkId: oldRequest.chunkId,
+        results: [
+          {
+            text: 'OLD_TABSIZE_2_RESULT',
+            blockCount: 1,
+            preservesComments: true,
+            proseSegments: 0,
+            hasComments: false,
+          },
+        ],
+      });
+
+      expect(service.candidates().size).toBe(0);
+
+      // 4) Now deliver the NEW chunkId's response. It must land as the
+      //    visible candidate.
+      mockWorker.respondToMessage(1);
+
+      expectCandidateText(rawString, rawString);
+    });
+
+    it('handles out-of-order worker responses within a generation (chunkId lookup, not FIFO)', () => {
+      // PR #289 review: with the queue-based design, out-of-order
+      // delivery would misassociate strings. chunkId lookup tolerates
+      // any delivery order.
+      const firstString = rawJsonString(75);
+      const secondString = rawJsonString(76);
+
+      service.enqueueScan([firstString]);
+      service.enqueueScan([secondString]);
+
+      expect(mockWorker.postedMessages.length).toBe(2);
+
+      // Respond out of order: second chunk first, then first.
+      mockWorker.respondToMessage(1);
+      mockWorker.respondToMessage(0);
+
+      expectCandidateText(firstString, firstString);
+      expectCandidateText(secondString, secondString);
     });
   });
 
@@ -574,12 +656,15 @@ function isScanRequest(value: unknown): value is ScanRequest {
   const candidate = value as {
     type?: unknown;
     sourceVersion?: unknown;
+    chunkId?: unknown;
     tabSize?: unknown;
     strings?: unknown;
   };
   return (
     candidate.type === 'scan' &&
     typeof candidate.sourceVersion === 'number' &&
+    typeof candidate.chunkId === 'number' &&
+    Number.isInteger(candidate.chunkId) &&
     (candidate.tabSize === 2 || candidate.tabSize === 4) &&
     Array.isArray(candidate.strings) &&
     candidate.strings.every((item) => typeof item === 'string')

--- a/src/app/core/json/tree-string-extractor.service.ts
+++ b/src/app/core/json/tree-string-extractor.service.ts
@@ -22,6 +22,7 @@ export const WORKER_FACTORY = new InjectionToken<() => Worker>(
 interface ScanRequest {
   type: 'scan';
   sourceVersion: number;
+  chunkId: number;
   tabSize: IndentSize;
   strings: readonly string[];
 }
@@ -29,6 +30,7 @@ interface ScanRequest {
 interface ScanResultMessage {
   type: 'scanResult';
   sourceVersion: number;
+  chunkId: number;
   results: readonly (ExtractedJsonWireFormat | null)[];
 }
 
@@ -47,11 +49,14 @@ type ScannerUnavailableReason = 'factory' | 'postMessage' | 'error' | 'messageer
  * One pending chunk awaiting a worker response. We capture the tabSize
  * at chunk-dispatch time (not at response time) so that a tabSize change
  * between dispatch and response cannot poison the cache with a result
- * keyed under the wrong tabSize. See issue #253.
+ * keyed under the wrong tabSize. We also capture the sourceVersion so
+ * the worker-message handler can verify the chunk still belongs to the
+ * generation that issued it. See issue #253 and PR #289 review.
  */
 interface PendingChunk {
   strings: string[];
   tabSize: IndentSize;
+  sourceVersion: number;
 }
 
 @Injectable({ providedIn: 'root' })
@@ -63,22 +68,34 @@ export class TreeStringExtractorService {
    * LRU cache keyed by `${tabSize}:${rawString}`. tabSize is always the
    * captured-at-dispatch value, never a live read from prefs, so a
    * mid-flight tabSize toggle cannot land a result under the wrong key.
-   * Strings that fail `shouldScan` (length / no `{` or `[`) bypass this
-   * cache and use `definitelyNullStrings` instead, since that result is
-   * tabSize-independent.
    */
   private readonly cache = new Map<string, CachedExtraction>();
-  /**
-   * Strings that cannot contain any extractable JSON regardless of
-   * tabSize (too short, too long, or no `{`/`[` trigger). Tracked
-   * separately from the indent-keyed `cache` so a tabSize flip does
-   * not invalidate these mechanical-failure entries.
-   */
-  private readonly definitelyNullStrings = new Set<string>();
   private readonly currentGenerationStrings = new Set<string>();
   private readonly currentGenerationInFlight = new Set<string>();
   private readonly currentGenerationResults = new Map<string, ExtractedJson>();
-  private readonly pendingChunksByVersion = new Map<number, PendingChunk[]>();
+  /**
+   * Pending worker chunks keyed by per-chunk id. Replaced the prior
+   * version-keyed FIFO queue (PR #289 review): the queue allowed a
+   * stale OLD-tabSize response (arriving after `rescanCurrentGenerationOnTabSizeChange`
+   * had cleared the queue slot and reposted a NEW-tabSize chunk at the
+   * same sourceVersion) to misassociate with the NEW chunk -- poisoning
+   * the cache under the new tabSize key AND eating the legitimate new
+   * response. With per-chunk ids the stale response simply finds no
+   * matching chunk and is dropped.
+   *
+   * Invariant: every chunk in this Map has `sourceVersion ===
+   * currentVersionSignal()`. `beginGeneration` clears the map, and
+   * `rescanCurrentGenerationOnTabSizeChange` deletes the
+   * currentVersion entries before reposting.
+   */
+  private readonly pendingChunksById = new Map<number, PendingChunk>();
+  /**
+   * Per-version pending chunk count. Kept in sync with `pendingChunksById`
+   * so `refreshScanInFlight` can answer "any chunk for currentVersion?"
+   * in O(1) without iterating the id map. Required for the editor hot
+   * path where a large pasted blob can produce many chunks.
+   */
+  private readonly pendingChunkCountByVersion = new Map<number, number>();
   private readonly candidatesSignal: WritableSignal<ReadonlyMap<string, ExtractedJson>> = signal(
     new Map<string, ExtractedJson>(),
   );
@@ -87,6 +104,13 @@ export class TreeStringExtractorService {
   private readonly currentVersionSignal = signal(0);
   private worker: Worker | null = null;
   private nextVersion = 0;
+  /**
+   * Monotonic per-chunk identifier. NEVER reset by `beginGeneration` --
+   * cross-generation collisions would re-enable a worse variant of the
+   * bug fixed in PR #289 review. Number.MAX_SAFE_INTEGER (~9e15) is
+   * astronomically more than any plausible service lifetime can produce.
+   */
+  private nextChunkId = 0;
   /**
    * Tracks the last tabSize observed by the prefs-change effect so the
    * first synchronous run (during construction) does not invalidate a
@@ -130,7 +154,8 @@ export class TreeStringExtractorService {
     this.currentGenerationStrings.clear();
     this.currentGenerationInFlight.clear();
     this.currentGenerationResults.clear();
-    this.pendingChunksByVersion.clear();
+    this.pendingChunksById.clear();
+    this.pendingChunkCountByVersion.clear();
     this.scanInFlightSignal.set(false);
     this.candidatesSignal.set(new Map<string, ExtractedJson>());
     return sourceVersion;
@@ -149,11 +174,14 @@ export class TreeStringExtractorService {
     for (const rawString of new Set(strings)) {
       this.currentGenerationStrings.add(rawString);
 
+      // shouldScan is pure and deterministic over (rawString,
+      // MAX_INPUT_LENGTH) -- the same input always yields the same
+      // result. A prior memoization set was removed in the PR #289
+      // review: it was dead code (a string that fails shouldScan once
+      // would fail it on every subsequent call) and unbounded.
+      // shouldScan is O(string-length) with V8-optimized
+      // string.includes; recomputing is essentially free.
       if (!this.shouldScan(rawString)) {
-        this.definitelyNullStrings.add(rawString);
-        continue;
-      }
-      if (this.definitelyNullStrings.has(rawString)) {
         continue;
       }
 
@@ -267,10 +295,12 @@ export class TreeStringExtractorService {
     tabSize: IndentSize,
     chunk: readonly string[],
   ): void {
-    this.addPendingChunk(sourceVersion, tabSize, chunk);
+    const chunkId = this.nextChunkId++;
+    this.addPendingChunk(chunkId, sourceVersion, tabSize, chunk);
     const request: ScanRequest = {
       type: 'scan',
       sourceVersion,
+      chunkId,
       tabSize,
       strings: chunk,
     };
@@ -283,39 +313,38 @@ export class TreeStringExtractorService {
   }
 
   private addPendingChunk(
+    chunkId: number,
     sourceVersion: number,
     tabSize: IndentSize,
     chunk: readonly string[],
   ): void {
-    const existingChunks = this.pendingChunksByVersion.get(sourceVersion);
-    const ownedChunk: PendingChunk = { strings: [...chunk], tabSize };
-    if (existingChunks) {
-      existingChunks.push(ownedChunk);
-      return;
-    }
-    this.pendingChunksByVersion.set(sourceVersion, [ownedChunk]);
+    const ownedChunk: PendingChunk = { strings: [...chunk], tabSize, sourceVersion };
+    this.pendingChunksById.set(chunkId, ownedChunk);
+    const priorCount = this.pendingChunkCountByVersion.get(sourceVersion) ?? 0;
+    this.pendingChunkCountByVersion.set(sourceVersion, priorCount + 1);
     this.refreshScanInFlight();
   }
 
-  private shiftPendingChunk(sourceVersion: number): PendingChunk | undefined {
-    const pendingChunks = this.pendingChunksByVersion.get(sourceVersion);
-    if (!pendingChunks) {
+  private popPendingChunk(chunkId: number): PendingChunk | undefined {
+    const chunk = this.pendingChunksById.get(chunkId);
+    if (!chunk) {
       return undefined;
     }
-
-    const chunk = pendingChunks.shift();
-    if (pendingChunks.length === 0) {
-      this.pendingChunksByVersion.delete(sourceVersion);
+    this.pendingChunksById.delete(chunkId);
+    const priorCount = this.pendingChunkCountByVersion.get(chunk.sourceVersion) ?? 0;
+    if (priorCount <= 1) {
+      this.pendingChunkCountByVersion.delete(chunk.sourceVersion);
+    } else {
+      this.pendingChunkCountByVersion.set(chunk.sourceVersion, priorCount - 1);
     }
     this.refreshScanInFlight();
     return chunk;
   }
 
   private refreshScanInFlight(): void {
-    this.scanInFlightSignal.set(
-      !this.scannerUnavailableSignal() &&
-        this.pendingChunksByVersion.has(this.currentVersionSignal()),
-    );
+    const currentVersion = this.currentVersionSignal();
+    const pendingForCurrent = this.pendingChunkCountByVersion.get(currentVersion) ?? 0;
+    this.scanInFlightSignal.set(!this.scannerUnavailableSignal() && pendingForCurrent > 0);
   }
 
   private handleWorkerMessage(event: MessageEvent<unknown>): void {
@@ -328,7 +357,11 @@ export class TreeStringExtractorService {
       return;
     }
 
-    const chunk = this.shiftPendingChunk(message.sourceVersion);
+    // Per-chunk lookup: a stale response whose chunk was deleted (by
+    // beginGeneration, rescanCurrentGenerationOnTabSizeChange, or a
+    // worker failure) finds no matching entry and is dropped. This is
+    // the load-bearing guard against the PR #289 review TOCTOU bug.
+    const chunk = this.popPendingChunk(message.chunkId);
     if (!chunk) {
       return;
     }
@@ -372,6 +405,13 @@ export class TreeStringExtractorService {
    * immediately; misses repost to the worker. Stale results from the
    * prior tabSize are cleared so the visible candidates signal does
    * not show outdated indent.
+   *
+   * Pending chunks for the current sourceVersion are deleted before
+   * reposting. PR #289 review: this is the load-bearing invariant
+   * paired with per-chunk ids -- by removing the OLD chunkIds, a stale
+   * worker response arriving after rescan finds no matching entry in
+   * `pendingChunksById` and is dropped, instead of misassociating with
+   * a NEW chunk and poisoning the cache.
    */
   private rescanCurrentGenerationOnTabSizeChange(): void {
     if (this.currentGenerationStrings.size === 0) {
@@ -381,10 +421,22 @@ export class TreeStringExtractorService {
     this.currentGenerationStrings.clear();
     this.currentGenerationInFlight.clear();
     this.currentGenerationResults.clear();
-    this.pendingChunksByVersion.delete(this.currentVersionSignal());
+    this.clearPendingChunksForVersion(this.currentVersionSignal());
     this.refreshScanInFlight();
     this.candidatesSignal.set(new Map<string, ExtractedJson>());
     this.enqueueScan(strings);
+  }
+
+  private clearPendingChunksForVersion(sourceVersion: number): void {
+    // Invariant: only currentVersion chunks should be in the map (see
+    // pendingChunksById JSDoc). Walk defensively anyway in case a
+    // future change relaxes that invariant.
+    for (const [chunkId, chunk] of this.pendingChunksById) {
+      if (chunk.sourceVersion === sourceVersion) {
+        this.pendingChunksById.delete(chunkId);
+      }
+    }
+    this.pendingChunkCountByVersion.delete(sourceVersion);
   }
 
   private handleWorkerFailure(reason: ScannerUnavailableReason): void {
@@ -393,7 +445,8 @@ export class TreeStringExtractorService {
     }
     this.scannerUnavailableSignal.set(true);
     this.currentGenerationInFlight.clear();
-    this.pendingChunksByVersion.clear();
+    this.pendingChunksById.clear();
+    this.pendingChunkCountByVersion.clear();
     this.scanInFlightSignal.set(false);
   }
 }
@@ -406,11 +459,14 @@ function isScanResultMessage(value: unknown): value is ScanResultMessage {
   const candidate = value as {
     type?: unknown;
     sourceVersion?: unknown;
+    chunkId?: unknown;
     results?: unknown;
   };
   return (
     candidate.type === 'scanResult' &&
     typeof candidate.sourceVersion === 'number' &&
+    typeof candidate.chunkId === 'number' &&
+    Number.isInteger(candidate.chunkId) &&
     Array.isArray(candidate.results)
   );
 }

--- a/src/app/core/json/tree-string-extractor.service.ts
+++ b/src/app/core/json/tree-string-extractor.service.ts
@@ -1,7 +1,8 @@
 import type { Signal, WritableSignal } from '@angular/core';
-import { Injectable, InjectionToken, inject, signal } from '@angular/core';
+import { Injectable, InjectionToken, effect, inject, signal } from '@angular/core';
+import { PreferencesService } from '../preferences/preferences.service';
 import { LoggerService } from '../telemetry/logger.service';
-import type { ExtractedJson } from './json-extractor.core';
+import type { ExtractedJson, IndentSize } from './json-extractor.core';
 import { MAX_INPUT_LENGTH } from './json-extractor.core';
 
 export const TREE_STRING_EXTRACTOR_CACHE_CAPACITY = 10_000;
@@ -21,6 +22,7 @@ export const WORKER_FACTORY = new InjectionToken<() => Worker>(
 interface ScanRequest {
   type: 'scan';
   sourceVersion: number;
+  tabSize: IndentSize;
   strings: readonly string[];
 }
 
@@ -41,15 +43,42 @@ interface ExtractedJsonWireFormat {
 type CachedExtraction = ExtractedJson | null;
 type ScannerUnavailableReason = 'factory' | 'postMessage' | 'error' | 'messageerror';
 
+/**
+ * One pending chunk awaiting a worker response. We capture the tabSize
+ * at chunk-dispatch time (not at response time) so that a tabSize change
+ * between dispatch and response cannot poison the cache with a result
+ * keyed under the wrong tabSize. See issue #253.
+ */
+interface PendingChunk {
+  strings: string[];
+  tabSize: IndentSize;
+}
+
 @Injectable({ providedIn: 'root' })
 export class TreeStringExtractorService {
   private readonly logger = inject(LoggerService);
   private readonly workerFactory = inject(WORKER_FACTORY);
+  private readonly prefs = inject(PreferencesService);
+  /**
+   * LRU cache keyed by `${tabSize}:${rawString}`. tabSize is always the
+   * captured-at-dispatch value, never a live read from prefs, so a
+   * mid-flight tabSize toggle cannot land a result under the wrong key.
+   * Strings that fail `shouldScan` (length / no `{` or `[`) bypass this
+   * cache and use `definitelyNullStrings` instead, since that result is
+   * tabSize-independent.
+   */
   private readonly cache = new Map<string, CachedExtraction>();
+  /**
+   * Strings that cannot contain any extractable JSON regardless of
+   * tabSize (too short, too long, or no `{`/`[` trigger). Tracked
+   * separately from the indent-keyed `cache` so a tabSize flip does
+   * not invalidate these mechanical-failure entries.
+   */
+  private readonly definitelyNullStrings = new Set<string>();
   private readonly currentGenerationStrings = new Set<string>();
   private readonly currentGenerationInFlight = new Set<string>();
   private readonly currentGenerationResults = new Map<string, ExtractedJson>();
-  private readonly pendingChunksByVersion = new Map<number, string[][]>();
+  private readonly pendingChunksByVersion = new Map<number, PendingChunk[]>();
   private readonly candidatesSignal: WritableSignal<ReadonlyMap<string, ExtractedJson>> = signal(
     new Map<string, ExtractedJson>(),
   );
@@ -58,12 +87,42 @@ export class TreeStringExtractorService {
   private readonly currentVersionSignal = signal(0);
   private worker: Worker | null = null;
   private nextVersion = 0;
+  /**
+   * Tracks the last tabSize observed by the prefs-change effect so the
+   * first synchronous run (during construction) does not invalidate a
+   * brand-new generation. After the first read, any change triggers a
+   * fresh re-scan of the current generation under the new tabSize.
+   */
+  private lastObservedTabSize: IndentSize | null = null;
 
   readonly candidates: Signal<ReadonlyMap<string, ExtractedJson>> =
     this.candidatesSignal.asReadonly();
   readonly scannerUnavailable: Signal<boolean> = this.scannerUnavailableSignal.asReadonly();
   readonly scanInFlight: Signal<boolean> = this.scanInFlightSignal.asReadonly();
   readonly currentVersion: Signal<number> = this.currentVersionSignal.asReadonly();
+
+  constructor() {
+    // M-#253: when editorTabSize flips, the visible candidates signal
+    // continues to hold results indented at the prior tabSize until a
+    // fresh scan is issued. Re-scan the current generation so tree
+    // string previews reformat without requiring an editor edit. The
+    // LRU cache key includes the dispatched tabSize, so previously
+    // computed results at the new tabSize will still hit; otherwise
+    // we re-post to the worker with the new tabSize. Root-provided
+    // service lives for the app lifetime; no explicit cleanup needed.
+    effect(() => {
+      const tabSize = this.prefs.prefs().editorTabSize;
+      if (this.lastObservedTabSize === null) {
+        this.lastObservedTabSize = tabSize;
+        return;
+      }
+      if (this.lastObservedTabSize === tabSize) {
+        return;
+      }
+      this.lastObservedTabSize = tabSize;
+      this.rescanCurrentGenerationOnTabSizeChange();
+    });
+  }
 
   beginGeneration(): number {
     const sourceVersion = ++this.nextVersion;
@@ -83,6 +142,7 @@ export class TreeStringExtractorService {
     }
 
     const sourceVersion = this.currentVersionSignal();
+    const tabSize = this.prefs.prefs().editorTabSize;
     const queuedStrings: string[] = [];
     let hasImmediateCandidateChange = false;
 
@@ -90,11 +150,14 @@ export class TreeStringExtractorService {
       this.currentGenerationStrings.add(rawString);
 
       if (!this.shouldScan(rawString)) {
-        this.setCachedResult(rawString, null);
+        this.definitelyNullStrings.add(rawString);
+        continue;
+      }
+      if (this.definitelyNullStrings.has(rawString)) {
         continue;
       }
 
-      const cachedResult = this.getCachedResult(rawString);
+      const cachedResult = this.getCachedResult(rawString, tabSize);
       if (cachedResult !== undefined) {
         if (cachedResult !== null) {
           this.currentGenerationResults.set(rawString, cachedResult);
@@ -130,7 +193,7 @@ export class TreeStringExtractorService {
       startIndex += TREE_STRING_EXTRACTOR_BATCH_SIZE
     ) {
       const chunk = queuedStrings.slice(startIndex, startIndex + TREE_STRING_EXTRACTOR_BATCH_SIZE);
-      this.postChunk(worker, sourceVersion, chunk);
+      this.postChunk(worker, sourceVersion, tabSize, chunk);
       if (this.scannerUnavailableSignal()) {
         return;
       }
@@ -145,25 +208,31 @@ export class TreeStringExtractorService {
     );
   }
 
-  private getCachedResult(rawString: string): CachedExtraction | undefined {
-    if (!this.cache.has(rawString)) {
+  private cacheKey(rawString: string, tabSize: IndentSize): string {
+    return `${tabSize}:${rawString}`;
+  }
+
+  private getCachedResult(rawString: string, tabSize: IndentSize): CachedExtraction | undefined {
+    const key = this.cacheKey(rawString, tabSize);
+    if (!this.cache.has(key)) {
       return undefined;
     }
 
-    const cachedResult = this.cache.get(rawString);
-    this.cache.delete(rawString);
+    const cachedResult = this.cache.get(key);
+    this.cache.delete(key);
     if (cachedResult === undefined) {
       return undefined;
     }
-    this.cache.set(rawString, cachedResult);
+    this.cache.set(key, cachedResult);
     return cachedResult;
   }
 
-  private setCachedResult(rawString: string, result: CachedExtraction): void {
-    if (this.cache.has(rawString)) {
-      this.cache.delete(rawString);
+  private setCachedResult(rawString: string, tabSize: IndentSize, result: CachedExtraction): void {
+    const key = this.cacheKey(rawString, tabSize);
+    if (this.cache.has(key)) {
+      this.cache.delete(key);
     }
-    this.cache.set(rawString, result);
+    this.cache.set(key, result);
 
     while (this.cache.size > TREE_STRING_EXTRACTOR_CACHE_CAPACITY) {
       const oldestKey = this.cache.keys().next().value;
@@ -192,11 +261,17 @@ export class TreeStringExtractorService {
     }
   }
 
-  private postChunk(worker: Worker, sourceVersion: number, chunk: readonly string[]): void {
-    this.addPendingChunk(sourceVersion, chunk);
+  private postChunk(
+    worker: Worker,
+    sourceVersion: number,
+    tabSize: IndentSize,
+    chunk: readonly string[],
+  ): void {
+    this.addPendingChunk(sourceVersion, tabSize, chunk);
     const request: ScanRequest = {
       type: 'scan',
       sourceVersion,
+      tabSize,
       strings: chunk,
     };
 
@@ -207,9 +282,13 @@ export class TreeStringExtractorService {
     }
   }
 
-  private addPendingChunk(sourceVersion: number, chunk: readonly string[]): void {
+  private addPendingChunk(
+    sourceVersion: number,
+    tabSize: IndentSize,
+    chunk: readonly string[],
+  ): void {
     const existingChunks = this.pendingChunksByVersion.get(sourceVersion);
-    const ownedChunk = [...chunk];
+    const ownedChunk: PendingChunk = { strings: [...chunk], tabSize };
     if (existingChunks) {
       existingChunks.push(ownedChunk);
       return;
@@ -218,7 +297,7 @@ export class TreeStringExtractorService {
     this.refreshScanInFlight();
   }
 
-  private shiftPendingChunk(sourceVersion: number): string[] | undefined {
+  private shiftPendingChunk(sourceVersion: number): PendingChunk | undefined {
     const pendingChunks = this.pendingChunksByVersion.get(sourceVersion);
     if (!pendingChunks) {
       return undefined;
@@ -255,8 +334,8 @@ export class TreeStringExtractorService {
     }
 
     let hasCandidateChange = false;
-    for (let index = 0; index < chunk.length; index++) {
-      const rawString = chunk[index];
+    for (let index = 0; index < chunk.strings.length; index++) {
+      const rawString = chunk.strings[index];
       if (rawString === undefined) {
         continue;
       }
@@ -264,7 +343,7 @@ export class TreeStringExtractorService {
       this.currentGenerationInFlight.delete(rawString);
       const wireResult = message.results[index] ?? null;
       const result = wireResult ? toExtractedJson(wireResult) : null;
-      this.setCachedResult(rawString, result);
+      this.setCachedResult(rawString, chunk.tabSize, result);
       if (result && this.currentGenerationStrings.has(rawString)) {
         this.currentGenerationResults.set(rawString, result);
         hasCandidateChange = true;
@@ -284,6 +363,28 @@ export class TreeStringExtractorService {
       }
     }
     this.candidatesSignal.set(snapshot);
+  }
+
+  /**
+   * Issue #253: tabSize flipped. Re-run a scan over the current
+   * generation's strings under the new tabSize. Cache hits (if any
+   * already-formatted-at-this-tabSize entries exist) are served
+   * immediately; misses repost to the worker. Stale results from the
+   * prior tabSize are cleared so the visible candidates signal does
+   * not show outdated indent.
+   */
+  private rescanCurrentGenerationOnTabSizeChange(): void {
+    if (this.currentGenerationStrings.size === 0) {
+      return;
+    }
+    const strings = [...this.currentGenerationStrings];
+    this.currentGenerationStrings.clear();
+    this.currentGenerationInFlight.clear();
+    this.currentGenerationResults.clear();
+    this.pendingChunksByVersion.delete(this.currentVersionSignal());
+    this.refreshScanInFlight();
+    this.candidatesSignal.set(new Map<string, ExtractedJson>());
+    this.enqueueScan(strings);
   }
 
   private handleWorkerFailure(reason: ScannerUnavailableReason): void {

--- a/src/app/features/home/home.component.spec.ts
+++ b/src/app/features/home/home.component.spec.ts
@@ -4453,7 +4453,7 @@ describe('HomeComponent M7p extract-from-mixed-text', () => {
     });
 
     expect(extractSpy).toHaveBeenCalledTimes(1);
-    expect(extractSpy).toHaveBeenCalledWith('INFO log {"a":1}');
+    expect(extractSpy).toHaveBeenCalledWith('INFO log {"a":1}', 2);
     expect(component.extractBannerVisible()).toBe(true);
   });
 
@@ -4560,9 +4560,32 @@ describe('HomeComponent M7p extract-from-mixed-text', () => {
     await component.onUpload(file);
     await waitForDoubleAnimationFrame();
 
-    expect(extractor.extractFromMixedText).toHaveBeenCalledWith('INFO log {"a":1}');
+    expect(extractor.extractFromMixedText).toHaveBeenCalledWith('INFO log {"a":1}', 2);
     expect(component.extractBannerVisible()).toBe(true);
     expect(component.extractedCandidate()?.data.blockCount).toBe(1);
+  });
+
+  // Issue #253: editor tab-size preference reaches the extractor.
+  it('honors editorTabSize=4 when extracting from a mixed-text file', async () => {
+    const fixture = TestBed.createComponent(HomeComponent);
+    const component = fixture.componentInstance;
+    const prefs = TestBed.inject(PreferencesService);
+    prefs.update({ editorTabSize: 4 });
+    const extractor = TestBed.inject(JsonExtractorService);
+    spyOn(extractor, 'extractFromMixedText').and.returnValue({
+      text: '{ "a": 1 }',
+      blockCount: 1,
+      preservesComments: true,
+      hasComments: false,
+    });
+    const file = new File(['INFO log {"a":1}'], 'capture.log', {
+      type: 'text/plain',
+    });
+
+    await component.onUpload(file);
+    await waitForDoubleAnimationFrame();
+
+    expect(extractor.extractFromMixedText).toHaveBeenCalledWith('INFO log {"a":1}', 4);
   });
 
   it('file load with already-valid JSON does NOT show the extract banner', async () => {
@@ -5883,7 +5906,7 @@ describe('HomeComponent tree extract wiring (M7s)', () => {
     if (typeof rawParameterValue !== 'string') {
       throw new Error('Expected fixture Parameters[0].Value to be a string');
     }
-    const replacement = extractFromMixedTextCore(rawParameterValue, parseJsonCandidate);
+    const replacement = extractFromMixedTextCore(rawParameterValue, parseJsonCandidate, 2);
     if (replacement === null) {
       throw new Error('Expected fixture Parameters[0].Value to be extractable');
     }

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -52,7 +52,11 @@ import {
   ClipboardPollingService,
   type ClipboardGrantedReadResult,
 } from '../../core/clipboard/clipboard-polling.service';
-import { ExtractedJson, JsonExtractorService } from '../../core/json/json-extractor.service';
+import {
+  ExtractedJson,
+  IndentSize,
+  JsonExtractorService,
+} from '../../core/json/json-extractor.service';
 import { JsonParseResult, JsonParserService } from '../../core/json/json-parser.service';
 import { TreeStringExtractorService } from '../../core/json/tree-string-extractor.service';
 import { createNarrowViewportSignal } from '../../core/layout/narrow-viewport';
@@ -502,6 +506,13 @@ export class HomeComponent implements OnInit, OnDestroy {
    */
   private lastHydratedInputId: string | null = null;
   private signInRestoreAttempted = false;
+  /**
+   * Tracks the last `editorTabSize` observed by the issue #253 effect so
+   * the first synchronous read during construction is treated as the
+   * baseline rather than a change. Subsequent flips re-format the
+   * extract banner preview in place.
+   */
+  private lastObservedExtractorTabSize: IndentSize | null = null;
 
   readonly parseResult = computed<JsonParseResult>(() => this.parser.parse(this.content()));
 
@@ -890,6 +901,37 @@ export class HomeComponent implements OnInit, OnDestroy {
           this.seo.setNoindex(true);
         }
       }
+    });
+
+    // Issue #253: when `editorTabSize` changes, re-run extraction over
+    // the current content so the extract banner preview reformats with
+    // the new indent. This is intentionally lightweight: it does NOT
+    // emit `home.extract.banner.shown` again (the banner is already
+    // shown, only its rendered text is changing) -- it patches the
+    // candidate's `data` in place.
+    effect(() => {
+      const tabSize = this.prefs.prefs().editorTabSize;
+      if (this.lastObservedExtractorTabSize === null) {
+        this.lastObservedExtractorTabSize = tabSize;
+        return;
+      }
+      if (this.lastObservedExtractorTabSize === tabSize) {
+        return;
+      }
+      this.lastObservedExtractorTabSize = tabSize;
+      const candidate = this.extractedCandidate();
+      if (candidate === null || candidate.sourceVersion !== this.contentVersion()) {
+        return;
+      }
+      const reformatted = this.extractor.extractFromMixedText(this.content(), tabSize);
+      if (reformatted === null) {
+        return;
+      }
+      this.extractedCandidate.set({
+        data: reformatted,
+        sourceVersion: candidate.sourceVersion,
+        source: candidate.source,
+      });
     });
 
     effect(() => {
@@ -1981,7 +2023,10 @@ export class HomeComponent implements OnInit, OnDestroy {
       this.replaceExtractedCandidate(null, null);
       return;
     }
-    const extracted = this.extractor.extractFromMixedText(this.content());
+    const extracted = this.extractor.extractFromMixedText(
+      this.content(),
+      this.prefs.prefs().editorTabSize,
+    );
     if (extracted) {
       this.replaceExtractedCandidate(extracted, source);
     } else {
@@ -2008,7 +2053,10 @@ export class HomeComponent implements OnInit, OnDestroy {
       this.replaceExtractedCandidate(null, null);
     } else {
       const parseStartedAt = performance.now();
-      const extracted = this.extractor.extractFromMixedText(event.pastedText);
+      const extracted = this.extractor.extractFromMixedText(
+        event.pastedText,
+        this.prefs.prefs().editorTabSize,
+      );
       parseMs = this.durationSince(parseStartedAt);
       if (extracted) {
         this.replaceExtractedCandidate(extracted, 'editor.paste');

--- a/src/testing/fixtures.spec.ts
+++ b/src/testing/fixtures.spec.ts
@@ -161,7 +161,7 @@ describe('extractor on mixed-text fixtures', () => {
 
   it('extractFromMixedText finds the two HTTP bodies and wraps them with their surrounding prose', () => {
     const extractor = TestBed.inject(JsonExtractorService);
-    const extracted = extractor.extractFromMixedText(mixedText);
+    const extracted = extractor.extractFromMixedText(mixedText, 2);
 
     expect(extracted).withContext('extractor must return non-null on this fixture').not.toBeNull();
     expect(extracted!.blockCount).withContext('two HTTP bodies in this capture').toBe(2);


### PR DESCRIPTION
Fixes #253.

## Summary

The JSON extractor was hardcoding 2-space indents in four code paths,
ignoring the user's `editorTabSize: 2 | 4` preference. Pasting mixed
text into the editor with `editorTabSize=4` produced 2-space-indented
output, mismatching the rest of the editor.

This PR threads `tabSize` through the full extractor pipeline (core ->
service -> worker -> tree-string-extractor cache) so output indent
honors the preference at all times.

## Changes

**Core / service / worker**

- New `IndentSize = 2 | 4` type exported from `json-extractor.core.ts`
- `extractFromMixedText` and 5 internal builders take `tabSize: IndentSize`
- `JsonExtractorService.extractFromMixedText(input, tabSize)` ΓÇö the
  caller passes `tabSize`; the service does **not** inject
  `PreferencesService` (avoids a DI cascade through ~30 service tests)
- Worker `ScanRequest.tabSize` is required; throws on invalid
  (caught by existing try/catch -> `null` result)

**TreeStringExtractorService (TOCTOU-safe)**

- LRU cache keyed `${tabSize}:${rawString}` so 2- and 4-space results
  coexist under different keys
- `PendingChunk` captures `tabSize` at chunk-dispatch time, not at
  response time ΓÇö a mid-flight prefs flip cannot poison the cache
  under the wrong key
- Separate `definitelyNullStrings: Set<string>` for pre-screen
  failures (`shouldScan` rejections): those results are
  tabSize-independent and would otherwise need duplicate cache entries
- Constructor `effect()` watches `editorTabSize`; on change, re-scans
  the current generation under the new tabSize (cache hits served
  immediately; misses re-post to the worker)

**home.component.ts**

- Two extractor call sites pass `prefs.editorTabSize`
- New effect re-formats the existing banner preview in place when the
  pref flips, **without** re-emitting `home.extract.banner.shown`
  (would double-count)

**package.json**: 0.27.1 -> 0.27.2 (patch ΓÇö user-visible bug fix)

## Out of scope (explicit)

`json-tree.component.ts:4267`'s "Copy value" path has its own
hardcoded `JSON.stringify(value, null, 2)`. Issue #253 is scoped to
the extractor; that path is a separate surface and a separate
decision. Documented in the plan so future #253-duplicate filings
can be redirected.

## Tests

- `json-extractor.core.spec.ts`: 5 tabSize tests covering all 4 output
  shapes at `tabSize=4` + default-2 regression check
- `json-extractor.service.spec.ts`: 30 existing call sites updated;
  2 new plumbing tests (tabSize=2 and tabSize=4)
- `tree-string-extractor.service.spec.ts`: `PreferencesService` stub,
  `ScanRequest` interface + validator updated, 5 new tests:
  - TOCTOU regression (dispatch-time tabSize capture)
  - dispatch tabSize plumbing
  - invalidation + re-scan on tabSize flip
  - cache hit on re-flip back to prior tabSize
  - `definitelyNull` tabSize-independence
- `home.component.spec.ts`: 2 spy assertions + 1 fixture core call
  updated; new `editorTabSize=4` end-to-end test
- `src/testing/fixtures.spec.ts`: one call updated

## Verification

- `npm run lint:all` clean (tsc app + spec, ASCII, spec/prod patterns,
  CSP, SWA, lockfile, prettier, reduced-motion, api)
- `npx ng test` ΓÇö 2814 tests pass (1 skipped)
- `npm run build` ΓÇö production bundle generated cleanly

## Notes for reviewers

- Plan was rubber-ducked via `deep-review:skeptic`; 9 findings raised,
  7 adopted (including the TOCTOU fix above), 1 set aside, 1
  out-of-scope (the `json-tree` "Copy value" path).
- No new framework / language / cloud service dependencies.
- SemVer: patch (0.27.1 -> 0.27.2) per DESIGN_SPEC.md ΓåÆ Versioning ΓåÆ
  user-visible bug fix rules.
- Telemetry: no new events. The new home effect explicitly avoids
  re-emitting `home.extract.banner.shown` on pref flip.

---
**Session**
- AI-Local: `3678ee1f-1ffb-451c-8ead-a6d854fd770c`
- AI-Cloud: `e335d5de-ce5d-41ab-b380-559dda94d7a4`