### PR TITLE
Fix flaky grid-structural tests: replace px-floor with structural CSS (#287)

### DIFF
--- a/src/app/shared/components/json-tree/json-tree.component.grid-structural.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.grid-structural.spec.ts
@@ -247,17 +247,37 @@ describe('JsonTreeComponent (.tree-row Grid template invariants -- v0.26.1)', ()
     const key = longLongRow!.querySelector<HTMLElement>('.tree-key')!;
     const valueEl = longLongRow!.querySelector<HTMLElement>('.tree-value-string')!;
 
-    // Both renderable (nonzero clientWidth). A regression to flex
-    // shrink-to-0 would trip this without invoking any flaky px
-    // floor.
-    expect(key.clientWidth)
-      .withContext(`key.clientWidth=${key.clientWidth} -- key must render with nonzero width`)
-      .toBeGreaterThan(0);
-    expect(valueEl.clientWidth)
+    // Both present in the render tree and not visibility:hidden. A
+    // regression to `display: none` on the element OR any ancestor
+    // (e.g. `.tree-row { display: none }`) trips `getClientRects()`.
+    // We do NOT assert `clientWidth > 0` here: `.tree-key` has
+    // `min-width: 0` and the `[key]` Grid track is `minmax(0,
+    // max-content)`, so under unbreakable-content competition the
+    // track CAN legitimately resolve to 0px without it being a
+    // regression (see issue #287; the author's note at the `long
+    // leading comment + long key` test below documents the 2-50+ px
+    // cross-platform variance). This assertion is strictly narrower
+    // than the old `clientWidth > 0` -- "key is wide enough to be
+    // readable" is intentionally NOT enforced (and was not reliably
+    // enforced before either, since 0px is a legitimate layout
+    // outcome). The row-overflow assertion below guards the
+    // user-visible "row fits the panel" contract.
+    expect(key.getClientRects().length)
       .withContext(
-        `value.clientWidth=${valueEl.clientWidth} -- value must render with nonzero width`,
+        'key must be in the render tree (display:none on element or any ancestor would fail this)',
       )
       .toBeGreaterThan(0);
+    expect(getComputedStyle(key).visibility)
+      .withContext('key must not be visibility:hidden (inherited from ancestor or set directly)')
+      .not.toBe('hidden');
+    expect(valueEl.getClientRects().length)
+      .withContext(
+        'value must be in the render tree (display:none on element or any ancestor would fail this)',
+      )
+      .toBeGreaterThan(0);
+    expect(getComputedStyle(valueEl).visibility)
+      .withContext('value must not be visibility:hidden')
+      .not.toBe('hidden');
 
     // Row no horizontal overflow. This is the user-visible
     // contract: the Grid template MUST shrink long-long content
@@ -353,8 +373,20 @@ describe('JsonTreeComponent (.tree-row Grid template invariants -- v0.26.1)', ()
       .toBeLessThanOrEqual(2);
   });
 
-  // 9. Long-trailing-comment fixture at 400px: key + value both >= 1px.
-  it('LongUnbreakableValue Parameters[0].Value at 400px: key clientWidth >= 1 and value clientWidth >= 1', async () => {
+  // 9. Long-trailing-comment fixture at 400px: key + value present in
+  //    the render tree (structural CSS). The previous assertions used
+  //    `key.clientWidth >= 1` / `value.clientWidth >= 1` (px floor on
+  //    Grid track widths), which is fragile -- both elements have
+  //    `min-width: 0` and the `[key]` / `[value]` tracks are
+  //    `minmax(0, max-content)`, so under unbreakable-content
+  //    competition the track can legitimately resolve to 0px without
+  //    it being a regression (see issue #287 + the cross-platform
+  //    variance note at test 10). We now assert render-tree presence
+  //    (catches `display: none` on element or any ancestor) and
+  //    non-hidden visibility (catches `visibility: hidden`). Row-no-
+  //    overflow under this fixture is already covered by test 11
+  //    (every row at 300px) so we do not duplicate it here.
+  it('LongUnbreakableValue Parameters[0].Value at 400px: key + value present in render tree (structural CSS)', async () => {
     const value = await loadFixture('LongUnbreakableValue.json');
     const fixture = await configure(value, 400);
     teardown = attachFixtureToBody(fixture, 'dark');
@@ -369,14 +401,22 @@ describe('JsonTreeComponent (.tree-row Grid template invariants -- v0.26.1)', ()
     expect(key).not.toBeNull();
     expect(valueEl).not.toBeNull();
 
-    expect(key!.clientWidth)
+    expect(key!.getClientRects().length)
       .withContext(
-        `key.clientWidth=${key!.clientWidth} must be >= 1 even under extreme value pressure`,
+        'key must be in the render tree (display:none on element or any ancestor would fail this)',
       )
-      .toBeGreaterThanOrEqual(1);
-    expect(valueEl!.clientWidth)
-      .withContext(`value.clientWidth=${valueEl!.clientWidth} must be >= 1`)
-      .toBeGreaterThanOrEqual(1);
+      .toBeGreaterThan(0);
+    expect(getComputedStyle(key!).visibility)
+      .withContext('key must not be visibility:hidden')
+      .not.toBe('hidden');
+    expect(valueEl!.getClientRects().length)
+      .withContext(
+        'value must be in the render tree (display:none on element or any ancestor would fail this)',
+      )
+      .toBeGreaterThan(0);
+    expect(getComputedStyle(valueEl!).visibility)
+      .withContext('value must not be visibility:hidden')
+      .not.toBe('hidden');
   });
 
   // 10. Long-leading-comment + long-key fixture at 400px:
@@ -385,17 +425,24 @@ describe('JsonTreeComponent (.tree-row Grid template invariants -- v0.26.1)', ()
   //         so it CAN truncate rather than push the row;
   //     (b) the leading-wrapper has `min-width: 0` so Grid is
   //         allowed to size its track below intrinsic;
-  //     (c) the key has nonzero clientWidth (renders);
+  //     (c) the key is in the render tree (i.e. not `display: none`
+  //         on the element or any ancestor, and not
+  //         `visibility: hidden`);
   //     (d) the row has no horizontal overflow.
   //
-  //     The fragile `key.clientWidth >= N` assertion that earlier
-  //     drafts used is intentionally NOT re-asserted: Grid track
-  //     sharing under unbreakable-content competition tie-breaks
-  //     on font metrics + layout timing and is not stable across
-  //     local Chrome on Windows vs. Chrome headless on CI Linux
-  //     (observed: 2-50+ px variance for the same SCSS + fixture).
-  //     The structural assertions below are the actual contract;
-  //     row-level no-overflow guards the user-visible outcome.
+  //     We do NOT assert `key.clientWidth > 0` here: `.tree-key`
+  //     has `min-width: 0` and the `[key]` Grid track is `minmax(0,
+  //     max-content)`, so under unbreakable-content competition
+  //     the track CAN legitimately resolve to 0px without it being
+  //     a regression (see issue #287). Grid track sharing under
+  //     unbreakable-content competition tie-breaks on font metrics
+  //     + layout timing and is not stable across local Chrome on
+  //     Windows vs. Chrome headless on CI Linux (observed: 2-50+ px
+  //     variance for the same SCSS + fixture). The structural
+  //     assertions below are the actual contract; row-level no-
+  //     overflow guards the user-visible outcome. "Key is wide
+  //     enough to be readable" is intentionally NOT enforced here
+  //     -- it would need a separate test with retry + tolerance.
   it('long leading comment + long key at 400px: comment ellipsify contract holds + row no overflow', async () => {
     const value = await loadFixture('LongUnbreakableKey.json');
     const fixture = await configure(value, 400);
@@ -477,12 +524,25 @@ describe('JsonTreeComponent (.tree-row Grid template invariants -- v0.26.1)', ()
       )
       .toBe('0px');
 
-    // (c) Key has nonzero clientWidth (i.e. actually renders -- a
-    //     `display: none` or fully-collapsed-to-0 regression would
-    //     trip this without invoking any flaky px floor).
-    expect(key!.clientWidth)
-      .withContext(`key.clientWidth=${key!.clientWidth} -- key must render with nonzero width`)
+    // (c) Key is in the render tree and not visibility:hidden. A
+    //     `display: none` regression on the element or any ancestor
+    //     (e.g. `.tree-row { display: none }`) would produce an
+    //     empty `getClientRects()` list. Replaces the earlier
+    //     `clientWidth > 0` runtime layout check, which flaked on
+    //     Linux CI because `.tree-key { min-width: 0 }` plus the
+    //     `[key]` track's `minmax(0, max-content)` legitimately
+    //     allows 0px under unbreakable-content competition (issue
+    //     #287). `getClientRects()` is not subject to Grid track
+    //     sizing -- a 0px-wide rendered element still produces one
+    //     `DOMRect` with `length === 1`.
+    expect(key!.getClientRects().length)
+      .withContext(
+        'key must be in the render tree (display:none on element or any ancestor would fail this)',
+      )
       .toBeGreaterThan(0);
+    expect(getComputedStyle(key!).visibility)
+      .withContext('key must not be visibility:hidden (inherited from ancestor or set directly)')
+      .not.toBe('hidden');
 
     // (d) Row no horizontal overflow.
     expect(longKeyRow!.scrollWidth)


### PR DESCRIPTION
Closes #287.

## What

Three tests in `json-tree.component.grid-structural.spec.ts` asserted `expect(key.clientWidth).toBeGreaterThan(0)` (or `>= 1`) on `.tree-key` / `.tree-value-string` widths. The CSS legitimately permits 0px (`.tree-key { min-width: 0 }` and `[key]` Grid track sized `minmax(0, max-content)`). Under unbreakable-content competition on Linux CI Chrome, the tracks can deterministically resolve to 0px without it being a regression. PR #285 saw 3 consecutive failures at line 483 (attempt 4 passed, same SHA).

Replace the px-floor assertions in tests 5, 9, and 10 with structural guards that catch the author's stated regression class without depending on Grid track sizing:

`ts
expect(key.getClientRects().length).toBeGreaterThan(0);
expect(getComputedStyle(key).visibility).not.toBe('hidden');
`

## Why `getClientRects().length`, not `getComputedStyle().display !== 'none'`

`display` is **not inherited**. A regression that sets `display: none` on an ancestor (e.g. `.tree-row`) leaves `getComputedStyle(key).display === 'block'`. `getClientRects()` returns an empty list iff the element is `display: none` OR any ancestor is, and is NOT affected by Grid track width. The new check is strictly broader for the regression class the author named (`display: none`) while remaining robust to the CI flake.

## Honest scope statement

The new assertion does NOT enforce "key is wide enough to be readable" - and neither did the old `clientWidth > 0` reliably, since 0px is a legitimate layout outcome. That contract would need a separate test with retry + tolerance and is out of scope here.

## What's hardened

| Test | Line | Change |
| --- | --- | --- |
| #5 `LongUnbreakableKey longKeyLongValue at 400px` | 250-260 | Replace `clientWidth > 0` x 2 with structural guards |
| #9 `LongUnbreakableValue Parameters[0].Value at 400px` | 357-380 | Replace `>= 1` x 2 with structural guards. **Renamed** -- previous name (`key clientWidth >= 1 and value clientWidth >= 1`) would lie after the fix |
| #10 `long leading comment + long key at 400px` | 480-485 | Replace `clientWidth > 0` with structural guards (this is the one that flaked) |

Only test 10 has been observed to flake; tests 5 and 9 are hardened preventively because they use the same fragile assertion shape under similar Grid track sharing pressure.

## What's out of scope (deliberate)

- **Test 13's `twistyWidth >= 13`** at `grid-structural.spec.ts:569-574` and the duplicate at `overflow.spec.ts:211-216`. Similar px-floor pattern but twisty has `flex-shrink: 0` and is NOT in Grid track competition. The 13 floor has held across CI history.
- **Pinning Jasmine `random: false`** in `karma.conf.js` -- hides fragility class instead of fixing it.
- **Echoing the Jasmine random seed to CI logs** (a free reproducibility win flagged by the rubber-duck pass). Worth doing as a follow-up; not folded in because `karma.conf.js` is repo-wide infrastructure. **Will file as follow-up issue.**
- **`fixtureCache` mutation safety** at `grid-structural.spec.ts:32`. Speculative concern; no actual mutation observed. **Will file as follow-up issue.**
- Broader px-floor audit across the repo.

## Verification

- `npm run lint:all` -- green
- Full test suite: 2804/2805 SUCCESS (1 always-skipped)
- `ng test --include='**/json-tree.component.grid-structural.spec.ts'` -- 18/18 pass
- After CI green, would suggest re-running 3-4 times to confirm determinism (re-running GREEN CI for post-fix verification is legitimate per AGENTS.md §11)

## SemVer

No bump. Test-only change.

---
**Session**
- AI-Local: `cf9b4e50-a30a-4a9b-98bd-2735e9c92be2`
- AI-Cloud: `bc6787c5-b0af-410a-8f22-c3afec8cd661`