### PR TITLE
Echo Jasmine random seed to CI stdout (#291)

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -49,6 +49,22 @@ module.exports = function (config) {
   const jasmineConfig = { random: true };
   if (trimmedSeed) {
     jasmineConfig.seed = trimmedSeed;
+    // Early-startup echo (fires at karma config load, before the browser
+    // launches) so the user gets sub-second confirmation that the env
+    // var was honored, rather than waiting ~30s for the end-of-run
+    // SeedReporter line. Helps catch copy-paste typos quickly.
+    console.log(
+      `[karma.conf] JASMINE_SEED applied: ${trimmedSeed} (replay key, not a unique run id).`,
+    );
+  } else if (typeof rawSeed === 'string') {
+    // JASMINE_SEED was set but resolved to empty after trim (e.g. "   ",
+    // ""). Without this warning the seed is silently dropped and the
+    // user believes replay is in effect, only to discover at end-of-run
+    // that a fresh random seed was used. Warn loudly so the discrepancy
+    // is visible immediately.
+    console.warn(
+      `[karma.conf] JASMINE_SEED was set but resolved to empty after trim; using random seed.`,
+    );
   }
 
   config.set({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,10 +1,56 @@
 // Karma configuration for JotJSON.
 // Adds a ChromeHeadlessCI launcher (with --no-sandbox) suitable for GitHub
 // Actions runners. Angular's default config otherwise applies.
+
+// Inline Karma reporter that echoes Jasmine's random spec-ordering seed so a
+// CI flake can be reproduced locally. The seed is delivered as the SECOND arg
+// of `onBrowserComplete(browser, result)` -- not on `browser.lastResult` (the
+// karma BrowserResult class has no `order` field) and not on `onRunComplete`
+// (which receives an aggregate without order). See issue #291.
+function SeedReporter(logger) {
+  const log = logger.create('reporter.seed');
+  this.onBrowserComplete = function (browser, result) {
+    // Guard: `result` is undefined on browser disconnect / no-activity
+    // timeout (karma/lib/browser.js emits browser_complete with no second
+    // arg in those paths). Without this guard we would TypeError exactly
+    // when the reporter is most needed.
+    const order = result && result.order;
+    if (!order || !order.random || order.seed == null) return;
+    const seed = String(order.seed);
+    log.info(
+      `Jasmine ${browser.name}: random order, seed=${seed} ` +
+        `(replay key, not a unique run id).\n` +
+        `  Replay locally:\n` +
+        `    bash/zsh:    JASMINE_SEED=${seed} npm test\n` +
+        `    PowerShell:  $env:JASMINE_SEED='${seed}'; npm test`,
+    );
+    // GitHub Actions workflow command: surfaces the seed in the run summary
+    // and as a ::notice:: annotation, durable beyond stdout scroll.
+    if (process.env.GITHUB_ACTIONS === 'true') {
+      console.log(`::notice title=Jasmine seed::seed=${seed} (browser ${browser.name})`);
+    }
+  };
+}
+SeedReporter.$inject = ['logger'];
+
 module.exports = function (config) {
   const isCI = !!process.env.CI;
-  const reporters = ['spec', 'kjhtml'];
+  const reporters = ['spec', 'kjhtml', 'seed'];
   if (isCI) reporters.push('junit');
+
+  // Optional JASMINE_SEED env-var passthrough for reproducing a specific
+  // random spec order locally. Trim+revalidate so JASMINE_SEED="   " is
+  // treated as "no seed" rather than handed to Jasmine. Note: today's
+  // config is single-browser; multi-browser would need namespacing
+  // (e.g., JASMINE_SEED_CHROMEHEADLESS=...) since one env var can't
+  // simultaneously reproduce two browsers' independent seeds.
+  const rawSeed = process.env.JASMINE_SEED;
+  const trimmedSeed = typeof rawSeed === 'string' ? rawSeed.trim() : '';
+  const jasmineConfig = { random: true };
+  if (trimmedSeed) {
+    jasmineConfig.seed = trimmedSeed;
+  }
+
   config.set({
     basePath: '',
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
@@ -16,9 +62,10 @@ module.exports = function (config) {
       require('karma-junit-reporter'),
       require('karma-coverage'),
       require('@angular-devkit/build-angular/plugins/karma'),
+      { 'reporter:seed': ['type', SeedReporter] },
     ],
     client: {
-      jasmine: {},
+      jasmine: jasmineConfig,
       clearContext: false,
     },
     jasmineHtmlReporter: { suppressAll: true },


### PR DESCRIPTION
Closes #291.

## What

Adds an inline Karma reporter (`SeedReporter` in `karma.conf.js`) that
echoes Jasmine's random spec-ordering seed to stdout at the end of each
run, plus replay instructions for both bash/zsh and PowerShell. Under
GitHub Actions, also emits a `::notice::` workflow annotation so the
seed surfaces in the run summary and survives beyond stdout scroll /
log rotation.

Also makes `random: true` explicit in the Jasmine client config and adds
optional `JASMINE_SEED` env-var passthrough (trim+revalidate) so a
specific seed from a CI log can be replayed locally.

## Why

Issue #287 (fixed in PR #290) was a Linux-CI-only px-floor flake
exposed by a perturbation in Jasmine's random spec order. No seed was
captured in CI logs, so the flake couldn't be replayed locally and
diagnosis took several attempts. With this change in place, the next
order-sensitive flake produces a one-line repro command.

Sample output (local run, single browser):

```
INFO [reporter.seed]: Jasmine Chrome Headless 148.0.0.0 (Windows 10): random order, seed=18803 (replay key, not a unique run id).
  Replay locally:
    bash/zsh:    JASMINE_SEED=18803 npm test
    PowerShell:  $env:JASMINE_SEED='18803'; npm test
```

Under GitHub Actions, an additional line emits:

```
::notice title=Jasmine seed::seed=18803 (browser ChromeHeadless)
```

which the GitHub Actions UI surfaces both as an annotation badge on
the run page and in the workflow summary.

## How

The seed is delivered from `karma-jasmine` via
`tc.complete({ order: { random, seed }, ... })` and arrives as the
SECOND argument of Karma's `browser_complete` event. It is NOT carried
on `browser.lastResult` (the `BrowserResult` class has no `order` field)
and NOT on `onRunComplete` (which receives an aggregate without order).
The reporter hooks `onBrowserComplete(browser, result)` and reads
`result.order` directly.

The reporter guards against `result === undefined`, which happens on
browser disconnect / no-activity-timeout (`karma/lib/browser.js` emits
`browser_complete` with no second arg in those paths). Without that
guard the reporter would TypeError exactly when it's most needed.

## Verification

- `npm run lint:all` -- green (all gates: ascii, spec-patterns,
  prod-patterns, csp-hashes, swa-config, lockfile, prettier,
  reduced-motion, api tsc).
- `npm test` -- 2819 SUCCESS (skipped 1); seed line surfaces at the end.
- `$env:JASMINE_SEED='12345'; npm test` -- confirmed the env-var
  passthrough echoes back `seed=12345`.

CI run on this PR will confirm the `::notice::` annotation appears on
the linux runner.

## Risk

Very low. Purely additive test-infra change; no production code or
behavior diff. Single browser config today; if a multi-browser config
is ever added, `JASMINE_SEED` would need namespacing (noted in inline
comment).

## SemVer

No bump (test-infra-only).

---
**Session**
- AI-Local: `cf9b4e50-a30a-4a9b-98bd-2735e9c92be2`
- AI-Cloud: `bc6787c5-b0af-410a-8f22-c3afec8cd661`
