### PR TITLE
Surface failing tests on CI run page

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -391,6 +391,13 @@ jobs:
           path: api/test-results/api/junit.xml
           reporter: java-junit
           fail-on-error: false
+          # Override dorny defaults (list-suites: all, list-tests: all)
+          # so the Step Summary on the run page shows only failing
+          # suites + tests instead of a wall of every passing test. A
+          # 1-in-N failure was invisibly buried in ~3300 lines of green
+          # check marks before this override (see run 26011840111).
+          list-suites: failed
+          list-tests: failed
       # ------------------------------------------------------------------
       # Build the API and upload it as the api-dist artifact for cd.yml's
       # workflow_run path. With cd.yml passing skip_api_build: true to the
@@ -528,6 +535,9 @@ jobs:
           path: api/test-results/api-integration/junit.xml
           reporter: java-junit
           fail-on-error: false
+          # See rationale on the api test-results step above.
+          list-suites: failed
+          list-tests: failed
 
   workflows-lint:
     name: Workflows lint (actionlint)
@@ -627,6 +637,9 @@ jobs:
           path: test-results/web/junit.xml
           reporter: java-junit
           fail-on-error: false
+          # See rationale on the api test-results step above.
+          list-suites: failed
+          list-tests: failed
 
   e2e:
     name: Smoke e2e (anonymous, Chromium)
@@ -713,4 +726,7 @@ jobs:
           path: test-results/e2e/junit.xml
           reporter: java-junit
           fail-on-error: false
+          # See rationale on the api test-results step above.
+          list-suites: failed
+          list-tests: failed
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -93,7 +93,12 @@ module.exports = function (config) {
     specReporter: {
       suppressErrorSummary: false,
       suppressFailed: false,
-      suppressPassed: false,
+      // Suppress per-spec PASS lines in CI so a single failure isn't
+      // buried in thousands of green-check lines in the runner's
+      // "Run tests" step log (see run 26011840111: ~5000 lines of
+      // passes hiding 1 failure). Kept on locally so the inner loop
+      // still shows live progress as specs run.
+      suppressPassed: isCI,
       suppressSkipped: true,
       showSpecTiming: false,
       failFast: false,


### PR DESCRIPTION
## Summary

Make the GitHub Actions `Summary` page useful when a CI run has a tiny number of failures in a huge suite.

Concrete trigger: [run 26011840111](https://github.com/geevensingh/jotjson/actions/runs/26011840111) had **1 failing test out of 2805** web specs, but the only signal on the run page was `Process completed with exit code 1` and a Step Summary that listed every passing suite + test (~3300 lines), burying the failure.

## What changes

**`.github/workflows/ci.yml`** -- on all four `dorny/test-reporter@v3` invocations (api, api-integration, web, e2e), set:

```yaml
list-suites: failed
list-tests: failed
```

dorny's defaults are `list-suites: all` and `list-tests: all`, which is what was producing the wall of green check marks. With `failed` on both, the Step Summary on the run page shows only the suites/tests that failed. The header pass/fail counts and badge are unchanged, so all-green runs still confirm "N passed, 0 failed."

**`karma.conf.js`** -- gate `suppressPassed` on `isCI`:

```diff
- suppressPassed: false,
+ suppressPassed: isCI,
```

The per-job `Run tests` step log was equally noisy (one PASS line per spec = ~5000 lines on a green web run, also burying any failure). Suppressing PASS lines in CI keeps the runner log focused on what failed, while local `ng test --watch` keeps live progress as specs run.

## Validation

- `npm run lint:all` -- pass (root + api workspaces)
- `npm test` -- 2817 passed / 3 skipped / 0 failed
- `npm --prefix api test` -- 465 passed
- `npm run build` -- clean (only pre-existing json-tree SCSS budget warning)
- Verified `isCI` gating by evaluating `karma.conf.js` with and without `CI=true`: `suppressPassed` is `true` under CI and `false` locally.
- Workflow YAML changes will be validated by the `workflows-lint` (actionlint) job on this PR.

## What this PR does NOT change

- **Inline PR annotations** on the Files Changed view. dorny uses `use-actions-summary: true` (the v3 default), which routes details to the Step Summary and skips check-run / inline-annotation creation. Adding inline annotations is a separate (larger) change.
- **Mergify CI Insights uploads.** Those continue unchanged and remain the cross-PR view for flake/duration trends.
- **dorny's pass/fail summary header.** Green runs still show the same `N passed, 0 failed` pill -- we only suppress the per-test detail rows when they're passes.
- **karma-spec-reporter local behavior.** `isCI` is false on dev boxes, so `ng test --watch` is identical to today.

## SemVer

No bump -- CI tooling only, no user-visible behavior change (per `AGENTS.md` s7 #11).

---
**Session**
- AI-Local: `bd77fd3b-cc86-4ce1-ab13-67ab06b11ee3`
- AI-Cloud: `154546fc-b96a-498c-9116-a20ab129617f`