### PR TITLE
Fix banner-extract undo (M7v spec violation)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.28.0",
+      "version": "0.28.1",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.28.0",
+  "version": "0.28.1",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -1247,6 +1247,45 @@ export const TELEMETRY_MESSAGE_IDS = [
 
   /**
    * Kind: event
+   * Fired by: `HomeComponent` (`features/home/home.component.ts`) on
+   *           snackbar Undo click or when Ctrl+Z (or any other content
+   *           reset that restores the pre-extract text without bumping
+   *           `viewResetToken`) brings the editor back to the
+   *           pre-extract text within ~30s of a successful banner-accept
+   *           extract.
+   * Volume control: bounded-frequency. At most one undo per
+   *   banner-accept extract; capped at 30s by `pendingExtractUndo`.
+   * Props: { source: 'snackbar' | 'ctrlZ';
+   *          pasteSource: 'paste' | 'editor.paste' | 'upload.pick' | 'upload.drag';
+   *          undoLatencyMsBucket: '<1s' | '1-5s' | '5s+' }.
+   *          `source` distinguishes the undo entry path; `pasteSource`
+   *          mirrors `home.extract.banner.{shown,accept}` so an
+   *          accept-rate vs undo-rate-by-origin KQL is a clean join.
+   *          `undoLatencyMsBucket` mirrors `tree.extract.undo` so a
+   *          misclick-rate query works the same way across both
+   *          extract surfaces.
+   * Privacy: no string contents or paths.
+   */
+  'home.extract.banner.undo',
+
+  /**
+   * Severity: warn
+   * Fired by: `HomeComponent.onExtractAccept`
+   *           (`features/home/home.component.ts`) when the editor's
+   *           `applyEdit` primitive cannot splice the extracted document
+   *           in place; the component falls back to a full setValue
+   *           replacement via `replaceDocument` so the user still gets
+   *           the extract result, and the snackbar is still opened so
+   *           snackbar-Undo (which goes through `replaceDocument`)
+   *           remains available even though Monaco-native Ctrl+Z is
+   *           lost on this branch.
+   * Props: { reason: 'editorUnavailable' | 'applyEditFailed' }. Mirrors
+   *   `tree.extract.applyFailed`.
+   */
+  'home.extract.banner.applyFailed',
+
+  /**
+   * Kind: event
    * Fired by: `JsonTreeComponent.onDecodedButtonClick` /
    *           `JsonTreeComponent.onDecodedMenuClick`
    *           (`shared/components/json-tree/json-tree.component.ts`)
@@ -1268,9 +1307,22 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           (`features/home/home.component.ts`) when a second extract
    *           opens while the prior snackbar ref is still live; the
    *           prior snackbar is dismissed before the new one opens.
+   *           Fires for ALL cross-extract snackbar replacements - i.e.
+   *           tree->tree, tree->banner, banner->tree, banner->banner.
+   *           The legacy event name retains the `tree.` prefix from
+   *           M7v even though banner-extract also triggers it; renaming
+   *           would break dashboards keyed off the existing namespace
+   *           per AGENTS.md s4 ("Pick the right sink up front -
+   *           migrating later breaks history"). `from`/`to` props
+   *           disambiguate the surfaces.
    * Volume control: bounded-frequency. Bounded by double-extract
    * frequency while the prior snackbar is still active (rare).
-   * Props: none.
+   * Props: { from: 'tree' | 'banner'; to: 'tree' | 'banner' }. The
+   *   surface of the snackbar being dismissed (`from`) and the
+   *   surface of the snackbar being opened (`to`). Cross-combos are
+   *   the motivating signal: e.g., banner->tree means the user
+   *   accepted the banner, then promptly extracted a tree row before
+   *   the banner snackbar timed out.
    * Privacy: no content.
    */
   'tree.extract.snackbarReplaced',

--- a/src/app/features/home/home.component.spec.ts
+++ b/src/app/features/home/home.component.spec.ts
@@ -6137,7 +6137,10 @@ describe('HomeComponent tree extract wiring (M7s)', () => {
     );
 
     expect(firstSnackRefHarness.dismissSpy).toHaveBeenCalledTimes(1);
-    expect(eventSpy).toHaveBeenCalledWith('tree.extract.snackbarReplaced');
+    expect(eventSpy).toHaveBeenCalledWith('tree.extract.snackbarReplaced', {
+      from: 'tree',
+      to: 'tree',
+    });
   });
 
   it('logs ctrlZ undo telemetry when the document returns to the pre-extract text', () => {
@@ -6362,6 +6365,308 @@ describe('HomeComponent tree extract wiring (M7s)', () => {
       candidateNodes: 2,
     });
   }));
+});
+
+describe('HomeComponent banner-extract undo (M7v)', () => {
+  setupMinimalMonacoStub();
+
+  interface ExtractSnackBarStub {
+    open: jasmine.Spy<
+      (message: string, action?: string, config?: unknown) => MatSnackBarRef<TextOnlySnackBar>
+    >;
+  }
+
+  interface ExtractSnackBarRefHarness {
+    action: Subject<void>;
+    dismissSpy: jasmine.Spy;
+    ref: MatSnackBarRef<TextOnlySnackBar>;
+  }
+
+  function createSnackHarness(): ExtractSnackBarRefHarness {
+    const action = new Subject<void>();
+    const dismissed = new Subject<unknown>();
+    const dismissSpy = jasmine.createSpy('dismiss');
+    const snackRef: Partial<MatSnackBarRef<TextOnlySnackBar>> = {
+      onAction: () => action.asObservable(),
+      afterDismissed: () =>
+        dismissed.asObservable() as unknown as ReturnType<
+          MatSnackBarRef<TextOnlySnackBar>['afterDismissed']
+        >,
+      dismiss: dismissSpy,
+    };
+    return {
+      action,
+      dismissSpy,
+      ref: snackRef as unknown as MatSnackBarRef<TextOnlySnackBar>,
+    };
+  }
+
+  interface EditorStub {
+    applyEdit: jasmine.Spy<
+      (startOffset: number, endOffset: number, text: string, source: string) => boolean
+    >;
+  }
+
+  function setup(options: { editor: 'real' | 'failing' | 'absent' } = { editor: 'real' }): {
+    fixture: ComponentFixture<HomeComponent>;
+    component: HomeComponent;
+    snack: ExtractSnackBarStub;
+    snackHarness: ExtractSnackBarRefHarness;
+    editorStub: EditorStub | null;
+    eventSpy: jasmine.Spy;
+    warnSpy: jasmine.Spy;
+  } {
+    localStorage.removeItem(PREFS_KEY);
+    localStorage.removeItem(DRAFT_KEY);
+    localStorage.removeItem(SPLIT_KEY);
+    localStorage.removeItem(PANE_VIS_KEY);
+    TestBed.resetTestingModule();
+    const snackHarness = createSnackHarness();
+    const snack: ExtractSnackBarStub = {
+      open: jasmine.createSpy('open').and.returnValue(snackHarness.ref),
+    };
+    TestBed.configureTestingModule({
+      imports: [HomeComponent],
+      providers: [
+        ...provideFakeAuth(),
+        provideRouter([]),
+        { provide: MatSnackBar, useValue: snack },
+      ],
+    });
+    const logger = TestBed.inject(LoggerService);
+    const eventSpy = spyOn(logger, 'event');
+    const warnSpy = spyOn(logger, 'warn');
+    const fixture = TestBed.createComponent(HomeComponent);
+    fixture.detectChanges();
+    const component = fixture.componentInstance;
+
+    let editorStub: EditorStub | null = null;
+    if (options.editor === 'absent') {
+      (component as unknown as { editor: () => undefined }).editor = () => undefined;
+    } else if (options.editor === 'failing') {
+      editorStub = {
+        applyEdit: jasmine.createSpy('applyEdit').and.returnValue(false),
+      };
+      (component as unknown as { editor: () => EditorStub }).editor = () => editorStub!;
+    } else {
+      editorStub = {
+        applyEdit: jasmine
+          .createSpy('applyEdit')
+          .and.callFake(
+            (startOffset: number, endOffset: number, text: string, _source: string): boolean => {
+              const currentContent = component.content();
+              if (endOffset - startOffset !== currentContent.length) {
+                return false;
+              }
+              const next =
+                currentContent.substring(0, startOffset) +
+                text +
+                currentContent.substring(endOffset);
+              component.onValueChange(next);
+              return true;
+            },
+          ),
+      };
+      (component as unknown as { editor: () => EditorStub }).editor = () => editorStub!;
+    }
+
+    return { fixture, component, snack, snackHarness, editorStub, eventSpy, warnSpy };
+  }
+
+  afterEach(() => {
+    localStorage.removeItem(PREFS_KEY);
+    localStorage.removeItem(DRAFT_KEY);
+    localStorage.removeItem(SPLIT_KEY);
+    localStorage.removeItem(PANE_VIS_KEY);
+  });
+
+  function seedMixedContent(component: HomeComponent, mixedText: string, candidateText: string) {
+    component.onValueChange(mixedText);
+    component.extractedCandidate.set({
+      data: {
+        text: candidateText,
+        blockCount: 1,
+        preservesComments: true,
+        hasComments: false,
+      },
+      sourceVersion: 0,
+      source: 'paste',
+    });
+  }
+
+  it('onExtractAccept goes through editor.applyEdit on the happy path and opens a snackbar', () => {
+    const { component, snack, editorStub } = setup();
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    seedMixedContent(component, priorText, candidateText);
+
+    component.onExtractAccept();
+
+    expect(editorStub!.applyEdit).toHaveBeenCalledTimes(1);
+    expect(editorStub!.applyEdit).toHaveBeenCalledWith(
+      0,
+      priorText.length,
+      candidateText,
+      'jotjson-extract-banner',
+    );
+    expect(component.content()).toBe(candidateText);
+    expect(component.extractedCandidate()).toBeNull();
+    expect(snack.open).toHaveBeenCalledTimes(1);
+  });
+
+  it('snackbar Undo restores priorText, restores highlights, re-arms the banner, and emits home.extract.banner.undo with source=snackbar', () => {
+    const { component, snackHarness, eventSpy } = setup();
+    let nowMs = 1000;
+    spyOn(performance, 'now').and.callFake(() => nowMs);
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    seedMixedContent(component, priorText, candidateText);
+
+    const highlightsBefore: readonly BlobHighlight[] = [
+      { path: 'a', color: '#ff0000', cascade: false },
+    ];
+    component.highlights.set(highlightsBefore);
+
+    nowMs = 1200;
+    component.onExtractAccept();
+    expect(component.content()).toBe(candidateText);
+    // resetHighlightsForDocumentReplacement moves highlights into mutatedPaths.
+    expect(component.highlights().length).toBe(0);
+
+    eventSpy.calls.reset();
+    nowMs = 2500;
+    snackHarness.action.next();
+
+    expect(component.content()).toBe(priorText);
+    expect(component.highlights()).toEqual(highlightsBefore);
+    expect(component.extractBannerVisible()).toBe(true);
+    expect(component.extractedCandidate()?.source).toBe('paste');
+    expect(eventSpy).toHaveBeenCalledWith('home.extract.banner.undo', {
+      source: 'snackbar',
+      pasteSource: 'paste',
+      undoLatencyMsBucket: '1-5s',
+    });
+  });
+
+  it('content reverting to priorText (Ctrl+Z) emits home.extract.banner.undo with source=ctrlZ and re-arms the banner', () => {
+    const { fixture, component, snackHarness, eventSpy } = setup();
+    let nowMs = 1000;
+    spyOn(performance, 'now').and.callFake(() => nowMs);
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    seedMixedContent(component, priorText, candidateText);
+
+    const highlightsBefore: readonly BlobHighlight[] = [
+      { path: 'a', color: '#00ff00', cascade: false },
+    ];
+    component.highlights.set(highlightsBefore);
+
+    nowMs = 1500;
+    component.onExtractAccept();
+    eventSpy.calls.reset();
+
+    // Simulate Monaco Ctrl+Z: content reverts WITHOUT bumping
+    // viewResetToken (Ctrl+Z goes through editor.valueChange ->
+    // setContent, not replaceDocument).
+    nowMs = 2000;
+    component.onValueChange(priorText);
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(eventSpy).toHaveBeenCalledWith('home.extract.banner.undo', {
+      source: 'ctrlZ',
+      pasteSource: 'paste',
+      undoLatencyMsBucket: '<1s',
+    });
+    expect(component.highlights()).toEqual(highlightsBefore);
+    expect(component.extractBannerVisible()).toBe(true);
+    expect(snackHarness.dismissSpy).toHaveBeenCalled();
+  });
+
+  it('phantom-undo gate: a re-paste of priorText (replaceDocument path that bumps viewResetToken) does NOT emit home.extract.banner.undo', () => {
+    const { fixture, component, eventSpy } = setup();
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    seedMixedContent(component, priorText, candidateText);
+
+    component.onExtractAccept();
+    eventSpy.calls.reset();
+
+    // Simulate a user pasting the same priorText back via the toolbar
+    // paste path -- which routes through replaceDocument and bumps
+    // viewResetToken. The phantom-undo gate must distinguish this
+    // from a Monaco Ctrl+Z (which leaves the token alone).
+    (component as unknown as { replaceDocument: (text: string) => void }).replaceDocument(
+      priorText,
+    );
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(eventSpy).not.toHaveBeenCalledWith(
+      'home.extract.banner.undo',
+      jasmine.anything() as unknown as never,
+    );
+  });
+
+  it('falls back to replaceDocument when editor() is undefined, still opens the snackbar, and emits home.extract.banner.applyFailed', () => {
+    const { component, snack, warnSpy } = setup({ editor: 'absent' });
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    seedMixedContent(component, priorText, candidateText);
+
+    component.onExtractAccept();
+
+    expect(component.content()).toBe(candidateText);
+    expect(component.extractedCandidate()).toBeNull();
+    expect(snack.open).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith('home.extract.banner.applyFailed', {
+      reason: 'editorUnavailable',
+    });
+  });
+
+  it('falls back to replaceDocument when editor.applyEdit returns false, still opens the snackbar, and emits home.extract.banner.applyFailed with reason=applyEditFailed', () => {
+    const { component, snack, warnSpy } = setup({ editor: 'failing' });
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    seedMixedContent(component, priorText, candidateText);
+
+    component.onExtractAccept();
+
+    expect(component.content()).toBe(candidateText);
+    expect(snack.open).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith('home.extract.banner.applyFailed', {
+      reason: 'applyEditFailed',
+    });
+  });
+
+  it('fallback-path snackbar Undo still restores priorText, highlights, and re-arms the banner', () => {
+    const { component, snackHarness, eventSpy } = setup({ editor: 'absent' });
+    let nowMs = 1000;
+    spyOn(performance, 'now').and.callFake(() => nowMs);
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    seedMixedContent(component, priorText, candidateText);
+    const highlightsBefore: readonly BlobHighlight[] = [
+      { path: 'a', color: '#0000ff', cascade: false },
+    ];
+    component.highlights.set(highlightsBefore);
+
+    nowMs = 1100;
+    component.onExtractAccept();
+    eventSpy.calls.reset();
+
+    nowMs = 1500;
+    snackHarness.action.next();
+
+    expect(component.content()).toBe(priorText);
+    expect(component.highlights()).toEqual(highlightsBefore);
+    expect(component.extractBannerVisible()).toBe(true);
+    expect(eventSpy).toHaveBeenCalledWith('home.extract.banner.undo', {
+      source: 'snackbar',
+      pasteSource: 'paste',
+      undoLatencyMsBucket: '<1s',
+    });
+  });
 });
 
 describe('HomeComponent splash render-complete hook (Phase C)', () => {

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -271,10 +271,49 @@ export class HomeComponent implements OnInit, OnDestroy {
    */
   private coldBootClipboardSnackRef: MatSnackBarRef<TextOnlySnackBar> | null = null;
   private extractUndoSnackRef: MatSnackBarRef<TextOnlySnackBar> | null = null;
+  /**
+   * Kind tag for the currently-visible extract Undo snackbar. Set
+   * atomically with `extractUndoSnackRef` and cleared on dismiss.
+   * Used to populate `from` / `to` on `tree.extract.snackbarReplaced`
+   * when a new extract supersedes a still-visible snackbar.
+   */
+  private extractUndoSnackKind: 'tree' | 'banner' | null = null;
   private pendingExtractUndo: {
     priorText: string;
     startMs: number;
     undoneViaSnackbar: boolean;
+    /**
+     * Discriminates the entry surface so the constructor effect and
+     * `openExtractUndoSnack`'s `onAction` route to the right
+     * telemetry messageId and decide whether to restore highlights
+     * and re-arm the banner on undo.
+     */
+    kind: 'tree' | 'banner';
+    /**
+     * Banner-only: the paste-origin enum captured at accept time.
+     * Used to re-arm the banner with the same source after undo and
+     * to populate `pasteSource` on `home.extract.banner.undo`. Null
+     * for `kind: 'tree'`.
+     */
+    pasteSource: ExtractSource | null;
+    /**
+     * Banner-only snapshots: `resetHighlightsForDocumentReplacement`
+     * moves highlights into `mutatedPaths` on accept, so the user
+     * would lose their highlights permanently after undo. Capture
+     * both pre-accept signals so undo can restore them. Empty for
+     * `kind: 'tree'` (which doesn't reset highlights).
+     */
+    highlightsSnapshot: readonly BlobHighlight[];
+    mutatedPathsAtAccept: ReadonlySet<string>;
+    /**
+     * Phantom-undo gate (banner only). `replaceDocument` /
+     * banner-accept bump `viewResetToken`; capture the post-bump
+     * value so the constructor effect can distinguish a Monaco
+     * Ctrl+Z (token unchanged) from a user re-pasting the same
+     * `priorText` (token bumped again). Tree-extract doesn't bump
+     * the token, so the field is informational for `kind: 'tree'`.
+     */
+    viewResetTokenAtAccept: number;
   } | null = null;
   // Single owner of the 30s `pendingExtractUndo` cap. Cleared atomically
   // with `pendingExtractUndo` via `clearPendingExtractUndo()`; never null
@@ -949,6 +988,21 @@ export class HomeComponent implements OnInit, OnDestroy {
         this.clearPendingExtractUndo();
         return;
       }
+      // Phantom-undo gate (banner kind only). The banner-accept path
+      // bumps `viewResetToken` to force a tree-pane re-fit; a Monaco
+      // Ctrl+Z leaves the token unchanged because it goes through
+      // `applyEdit` -> `valueChange` -> `setContent` (no bump). A user
+      // re-pasting the same `priorText` from the clipboard goes
+      // through `replaceDocument` which DOES bump the token again, so
+      // the captured `viewResetTokenAtAccept` no longer matches. Tree-
+      // extract doesn't bump the token at accept, so it doesn't need
+      // this gate.
+      if (
+        pendingExtractUndo.kind === 'banner' &&
+        this.viewResetToken() !== pendingExtractUndo.viewResetTokenAtAccept
+      ) {
+        return;
+      }
       // Case 2: content reverted to priorText via some non-snackbar
       // path (Ctrl+Z is the dominant case). Fire ctrlZ telemetry,
       // clear pending state, and dismiss any still-visible snackbar
@@ -960,6 +1014,28 @@ export class HomeComponent implements OnInit, OnDestroy {
         !pendingExtractUndo.undoneViaSnackbar &&
         currentContent === pendingExtractUndo.priorText
       ) {
+        if (pendingExtractUndo.kind === 'banner') {
+          this.logger.event('home.extract.banner.undo', {
+            source: 'ctrlZ',
+            pasteSource: pendingExtractUndo.pasteSource ?? 'paste',
+            undoLatencyMsBucket: bucketUndoLatency(undoLatencyMs),
+          });
+          // Restore the pre-accept highlights and `mutatedPaths` (the
+          // accept path called `resetHighlightsForDocumentReplacement`,
+          // which moved highlights into `mutatedPaths`). Re-arm the
+          // banner per spec policy "snackbar plus Ctrl+Z are the
+          // recovery affordances" (DESIGN_SPEC.md M7v) - the user is
+          // back at the mixed text, so the banner should re-offer.
+          this.highlights.set([...pendingExtractUndo.highlightsSnapshot]);
+          this.mutatedPaths.set(new Set(pendingExtractUndo.mutatedPathsAtAccept));
+          const pasteSource = pendingExtractUndo.pasteSource;
+          this.clearPendingExtractUndo();
+          this.extractUndoSnackRef?.dismiss();
+          if (pasteSource !== null) {
+            this.runExtractorOnCurrentContent(pasteSource);
+          }
+          return;
+        }
         this.logger.event('tree.extract.undo', {
           source: 'ctrlZ',
           undoLatencyMsBucket: bucketUndoLatency(undoLatencyMs),
@@ -1280,9 +1356,15 @@ export class HomeComponent implements OnInit, OnDestroy {
 
   private openExtractUndoSnack(priorText: string): void {
     if (this.extractUndoSnackRef) {
+      const fromKind = this.extractUndoSnackKind ?? 'tree';
+      const toKind = this.pendingExtractUndo?.kind ?? 'tree';
       this.extractUndoSnackRef.dismiss();
-      this.logger.event('tree.extract.snackbarReplaced');
+      this.logger.event('tree.extract.snackbarReplaced', {
+        from: fromKind,
+        to: toKind,
+      });
       this.extractUndoSnackRef = null;
+      this.extractUndoSnackKind = null;
     }
     const pendingExtractUndo = this.pendingExtractUndo;
     if (!pendingExtractUndo) {
@@ -1294,6 +1376,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       { duration: 8000, politeness: 'assertive' },
     );
     this.extractUndoSnackRef = snackRef;
+    this.extractUndoSnackKind = pendingExtractUndo.kind;
     snackRef
       .onAction()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -1318,10 +1401,26 @@ export class HomeComponent implements OnInit, OnDestroy {
         // any post-extract typing - same observable outcome with more
         // code.
         this.replaceDocument(priorText);
-        this.logger.event('tree.extract.undo', {
-          source: 'snackbar',
-          undoLatencyMsBucket: bucketUndoLatency(performance.now() - pendingExtractUndo.startMs),
-        });
+        if (pendingExtractUndo.kind === 'banner') {
+          this.logger.event('home.extract.banner.undo', {
+            source: 'snackbar',
+            pasteSource: pendingExtractUndo.pasteSource ?? 'paste',
+            undoLatencyMsBucket: bucketUndoLatency(performance.now() - pendingExtractUndo.startMs),
+          });
+          // Restore pre-accept highlights / mutated paths and re-arm
+          // the extract banner so the user lands at the mixed text
+          // with the same offer they had before clicking Extract.
+          this.highlights.set([...pendingExtractUndo.highlightsSnapshot]);
+          this.mutatedPaths.set(new Set(pendingExtractUndo.mutatedPathsAtAccept));
+          if (pendingExtractUndo.pasteSource !== null) {
+            this.runExtractorOnCurrentContent(pendingExtractUndo.pasteSource);
+          }
+        } else {
+          this.logger.event('tree.extract.undo', {
+            source: 'snackbar',
+            undoLatencyMsBucket: bucketUndoLatency(performance.now() - pendingExtractUndo.startMs),
+          });
+        }
       });
     snackRef
       .afterDismissed()
@@ -1329,6 +1428,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       .subscribe(() => {
         if (this.extractUndoSnackRef === snackRef) {
           this.extractUndoSnackRef = null;
+          this.extractUndoSnackKind = null;
         }
       });
   }
@@ -1875,6 +1975,14 @@ export class HomeComponent implements OnInit, OnDestroy {
       priorText,
       startMs: performance.now(),
       undoneViaSnackbar: false,
+      kind: 'tree',
+      pasteSource: null,
+      highlightsSnapshot: [],
+      mutatedPathsAtAccept: new Set(),
+      // Tree-extract doesn't bump `viewResetToken`; record the
+      // current value so the phantom-undo gate in the effect is a
+      // no-op for `kind: 'tree'`.
+      viewResetTokenAtAccept: this.viewResetToken(),
     };
     this.pendingExtractUndoTimer = setTimeout(
       () => this.clearPendingExtractUndo(),
@@ -2083,9 +2191,18 @@ export class HomeComponent implements OnInit, OnDestroy {
   onExtractAccept(): void {
     const candidate = this.extractedCandidate();
     if (!candidate) return;
+    // Capture everything into locals BEFORE mutating signals so the
+    // fallback branch (and the snackbar's captured closure) never
+    // depends on the signal-backed state being non-null.
+    const priorText = this.content();
+    const candidateText = candidate.data.text;
+    const pasteSource = candidate.source;
+    const highlightsSnapshot = this.highlights();
+    const mutatedPathsAtAccept = new Set(this.mutatedPaths());
+
     this.logger.event(
       'home.extract.banner.accept',
-      { source: candidate.source },
+      { source: pasteSource },
       {
         blockCount: candidate.data.blockCount,
         preservesComments: candidate.data.preservesComments ? 1 : 0,
@@ -2097,8 +2214,59 @@ export class HomeComponent implements OnInit, OnDestroy {
     // does not additionally fire `home.extract.banner.dismiss` with
     // `reason='content.changed'` for the same candidate.
     this.extractedCandidate.set(null);
-    this.replaceDocument(candidate.data.text);
-    this.resetHighlightsForDocumentReplacement();
+
+    // Install pending state BEFORE `applyEdit` so any synchronously-
+    // flushed effect that reaches the constructor's content-watch
+    // effect sees the snapshot rather than a null pending field.
+    this.clearPendingExtractUndo();
+    this.pendingExtractUndo = {
+      priorText,
+      startMs: performance.now(),
+      undoneViaSnackbar: false,
+      kind: 'banner',
+      pasteSource,
+      highlightsSnapshot,
+      mutatedPathsAtAccept,
+      // Both the happy and fallback paths bump `viewResetToken` by
+      // exactly 1 below; record the post-bump value so the
+      // phantom-undo gate in the constructor effect can distinguish
+      // a Monaco Ctrl+Z (token unchanged) from a user re-pasting the
+      // same `priorText` (token bumped again).
+      viewResetTokenAtAccept: this.viewResetToken() + 1,
+    };
+    this.pendingExtractUndoTimer = setTimeout(
+      () => this.clearPendingExtractUndo(),
+      EXTRACT_UNDO_CAP_MS,
+    );
+
+    const editor = this.editor();
+    const applied =
+      editor?.applyEdit(0, priorText.length, candidateText, 'jotjson-extract-banner') ?? false;
+
+    if (applied) {
+      // `applyEdit` only mutates the Monaco model; mirror the three
+      // side-effects `replaceDocument` performs on top of `setContent`
+      // so the rest of the app (tree pane, view-reset listeners,
+      // highlight reset) sees the same state it would have after a
+      // full document swap.
+      this.treeFlush$.next();
+      this.viewResetToken.update((token) => token + 1);
+      this.resetHighlightsForDocumentReplacement();
+    } else {
+      this.logger.warn('home.extract.banner.applyFailed', {
+        reason: editor ? 'applyEditFailed' : 'editorUnavailable',
+      });
+      // Snapshot-based snackbar Undo still works on this branch
+      // (`replaceDocument(priorText)` doesn't depend on Monaco's
+      // undo stack), so the snackbar is still opened below to
+      // preserve at least one undo affordance even when Monaco-
+      // native Ctrl+Z is lost. Precedent: cold-boot clipboard's
+      // snackbar-only Undo at home.component.ts cold-boot section.
+      this.replaceDocument(candidateText);
+      this.resetHighlightsForDocumentReplacement();
+    }
+
+    this.openExtractUndoSnack(priorText);
   }
 
   onExtractDismiss(): void {

--- a/src/app/shared/components/json-editor/json-editor.component.ts
+++ b/src/app/shared/components/json-editor/json-editor.component.ts
@@ -283,6 +283,12 @@ export class JsonEditorComponent implements AfterViewInit, OnDestroy {
    * input + the existing setValue effect for whole-document replacement (paste,
    * load, clear) - the 17 existing setContent callers in HomeComponent are not
    * migrating in this PR.
+   *
+   * Whole-document edits (range `[0, model length]`) are also supported when
+   * undo preservation is the goal; `executeEdits` with a single operation
+   * lands as one undo entry on Monaco's stack regardless of range size. The
+   * banner-extract accept path uses this property to make Ctrl+Z reverse a
+   * full-document swap from mixed text to extracted JSON.
    */
   applyEdit(startOffset: number, endOffset: number, text: string, source: string): boolean {
     const editor = this.editor;


### PR DESCRIPTION
## Summary

Banner-accept extract (paste mixed content, click "Extract embedded JSON" in the banner) went through `replaceDocument` -> `setContent` -> editor effect's `setValue`, which clears Monaco's undo stack -- and no snackbar opened either. So the user had **no** undo affordance, even though the tree-row Extract path provides both Ctrl+Z and an 8-second snackbar.

This is a spec deviation. `DESIGN_SPEC.md` -> M7v (lines 2588-2599) explicitly mandates "every successful extract preserves Monaco-native Ctrl+Z and opens an 8-second Undo snackbar." This PR closes that gap.

## Approach

1. **Use `editor.applyEdit` on the happy path.** Bring `onExtractAccept` onto the same primitive the tree-row Extract path already uses: `editor.applyEdit(0, priorText.length, candidateText, 'jotjson-extract-banner')`. One `executeEdits` call = one Monaco undo entry, so Ctrl+Z reverts to the pre-extract mixed text.
2. **Fallback that still preserves snackbar Undo.** If `applyEdit` fails (no editor or the length-safety check rejects), fall back to `replaceDocument(candidateText)`. The snackbar opens on both branches, and snackbar Undo uses `replaceDocument(priorText)` -- which doesn't depend on Monaco's undo stack -- so at least one undo affordance is always present (precedent: cold-boot-clipboard's snackbar-only Undo).
3. **Mirror `replaceDocument`'s side-effects on happy path.** `applyEdit` only mutates the Monaco model, so emit `treeFlush$`, bump `viewResetToken`, and call `resetHighlightsForDocumentReplacement` to keep the tree pane / view-reset listeners / highlight reset in sync.
4. **Extend `pendingExtractUndo`** with `kind: 'tree' | 'banner'`, `pasteSource`, pre-accept `highlightsSnapshot`, `mutatedPathsAtAccept`, and `viewResetTokenAtAccept`. The last field is a phantom-undo gate: a real Monaco Ctrl+Z lands via `valueChange` -> `setContent` and leaves the token alone, while a user re-pasting the same `priorText` goes through `replaceDocument` and bumps the token -- so we can distinguish them and only fire `home.extract.banner.undo` on the real undo.
5. **Restore + re-arm on banner undo.** When undo (snackbar or detected Ctrl+Z) lands the user back on the pre-extract mixed text, restore the captured highlights / `mutatedPaths` and re-arm the extract banner via `runExtractorOnCurrentContent(pasteSource)`. Per the M7v policy, "snackbar plus Ctrl+Z are the recovery affordances" -- after recovery the banner should re-offer.

## Telemetry

- **New**: `home.extract.banner.undo` (mirrors `tree.extract.undo` shape; adds `pasteSource` so accept-rate-by-origin vs undo-rate-by-origin is a clean KQL join).
- **New**: `home.extract.banner.applyFailed` (mirrors `tree.extract.applyFailed`; reason: `'editorUnavailable' | 'applyEditFailed'`).
- **Expanded**: `tree.extract.snackbarReplaced` now carries `{ from: 'tree' | 'banner', to: 'tree' | 'banner' }` so cross-surface replacements (tree -> banner, banner -> tree) are observable. Existing event name kept per AGENTS.md s4 ("migrating later breaks history").

## Out of scope

Adjacent same-root-cause Ctrl+Z losses identified during review (each gets its own bug post-merge):

- **Upload Ctrl+Z loss** -- explicit `DESIGN_SPEC.md:453` violation. File-upload pick / drag goes through `replaceDocument`.
- **Format / minify Ctrl+Z loss** -- `onFormat` / `onMinify` at `home.component.ts:2460/2467` also clobber Monaco's undo stack.

## Validation

- `npm run lint:all` -- OK (root + api/)
- `npm test` -- 2865 / 2865 SUCCESS (Karma)
- `npm --prefix api test` -- 465 / 465 SUCCESS (Jest)
- `npm run build` -- OK (prerender + postbuild OK)

## Tests

7 new specs in `HomeComponent banner-extract undo (M7v)` describe block:

1. Happy path: `editor.applyEdit` called with `(0, priorText.length, candidateText)`, content replaced, snackbar opens.
2. Snackbar Undo: restores priorText, restores highlights, re-arms the banner, emits `home.extract.banner.undo` with `source: 'snackbar'` and `pasteSource: 'paste'`.
3. Ctrl+Z (simulated via `onValueChange(priorText)`): emits `home.extract.banner.undo` with `source: 'ctrlZ'`, restores highlights, re-arms the banner, dismisses the snackbar.
4. Phantom-undo gate: a user re-pasting `priorText` via `replaceDocument` (token bumps) does NOT emit `home.extract.banner.undo`.
5. `editorUnavailable` fallback: still opens snackbar, emits `home.extract.banner.applyFailed`.
6. `applyEditFailed` fallback (mocked editor returns false): same as above, with `reason: 'applyEditFailed'`.
7. Fallback-path snackbar Undo: still restores priorText / highlights / banner.

One existing assertion updated: `tree.extract.snackbarReplaced` now expected with `{ from: 'tree', to: 'tree' }` props.

## SemVer

0.28.0 -> 0.28.1 (patch; user-visible bug fix; no API, schema, or stored-shape changes).

---
**Session**
- AI-Local: `53c804db-798d-4aec-841b-b308f00e529a`
- AI-Cloud: `ae5a24a6-a8c6-40ac-bc3d-ca6097b5242b`
