### PR TITLE
Fix close-row brace alignment (#282)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.28.1",
+      "version": "0.28.2",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/scripts/check-tree-row-grid.mjs
+++ b/scripts/check-tree-row-grid.mjs
@@ -694,6 +694,7 @@ function scanScss(scssSrc, scssPath) {
   const lineStarts = buildLineStarts(scssSrc);
 
   let canonicalBlock = null;
+  let closeBlock = null;
   const candidateCompoundsSeen = [];
 
   for (const rule of walkTopLevelTreeRowCandidates(stripped)) {
@@ -732,6 +733,8 @@ function scanScss(scssSrc, scssPath) {
               `extend EXEMPT_CANONICAL_COMPOUNDS in check-tree-row-grid.mjs or refactor.`,
           });
         }
+      } else if (candidate.compound === '.tree-row.tree-row--close' && closeBlock === null) {
+        closeBlock = candidate;
       }
       continue;
     }
@@ -851,6 +854,41 @@ function scanScss(scssSrc, scssPath) {
     }
   }
 
+  // Issue #282 (v0.28.2): assert the close-row block declares
+  // `display: flex`. The `lintTemplate` carve-out at the top of
+  // this file accepts ANY direct-child class on `.tree-row--close`
+  // rows on the premise that they are `display: flex` and the grid
+  // direct-child allowlist doesn't apply. If a future contributor
+  // flips this block to `display: grid` (or removes the `display`
+  // declaration so it inherits the canonical `display: grid` from
+  // `.tree-row`), the carve-out becomes a silent gap. This
+  // assertion fails loudly in that case.
+  if (closeBlock === null) {
+    violations.push({
+      path: scssPath,
+      line: 1,
+      message:
+        `close-row block not found: expected one top-level ` +
+        `\`.tree-row.tree-row--close { ... }\` rule. The lintTemplate ` +
+        `carve-out for close rows assumes this block exists and ` +
+        `declares \`display: flex\`.`,
+    });
+  } else {
+    const displayDeclaration = findTopLevelDeclaration(closeBlock.body, 'display');
+    if (!displayDeclaration || displayDeclaration.value.trim() !== 'flex') {
+      violations.push({
+        path: scssPath,
+        line: lineNumberForOffset(lineStarts, closeBlock.offset),
+        message:
+          `\`.tree-row.tree-row--close\` must declare \`display: flex\` ` +
+          `(found: ${displayDeclaration ? `\`display: ${displayDeclaration.value.trim()}\`` : 'no `display` declaration'}). ` +
+          `The lintTemplate carve-out for close rows assumes this; ` +
+          `flipping to grid without lifting the carve-out would silently ` +
+          `accept any direct-child class on close rows.`,
+      });
+    }
+  }
+
   return { violations, canonicalBlock };
 }
 
@@ -863,8 +901,18 @@ export function lintTemplate({ htmlSrc, scssSrc, htmlPath, scssPath }) {
   }
   for (const row of rows) {
     const rowClasses = staticClasses(row);
-    // .tree-row.tree-row--close uses display: flex (scss:373); the
-    // Grid direct-child allowlist doesn't apply to its children.
+    // `.tree-row.tree-row--close` is `display: flex` (scss block at
+    // `.tree-row.tree-row--close`), so the Grid direct-child
+    // allowlist doesn't apply: grid-column placements on its
+    // children would be inert. Close rows still use the same three
+    // structural wrappers as leaf/open rows (`tree-row-leading`,
+    // `tree-row-value-cell`, `tree-row-trailing`) for visual parity
+    // (issue #282, v0.28.2), but the carve-out remains because the
+    // grid-track invariants in `lintTemplate` don't model flex
+    // layout. The SCSS-side `scanScss` checks that this block
+    // declares `display: flex` so a future contributor flipping the
+    // display value can't silently regress the carve-out into a
+    // silent gap.
     if (rowClasses.includes('tree-row--close')) continue;
     const children = directDomChildren(row);
     for (const child of children) {

--- a/src/app/shared/components/json-tree/json-tree.component.grid-structural.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.grid-structural.spec.ts
@@ -806,4 +806,246 @@ describe('JsonTreeComponent (.tree-row Grid template invariants -- v0.26.1)', ()
       .withContext('the brace span of an empty array must render the literal `[]`')
       .toBe('[]');
   });
+
+  // 19. Issue #282 (v0.28.2): close-row structural parity. The close
+  //     row's firstElementChild must be `.tree-row-leading`, and the
+  //     leading wrapper's first child must be the chevron-sized
+  //     `.tree-twisty.tree-spacer` placeholder. This pins the
+  //     wrapper-count-and-order so a future contributor who reorders
+  //     close-row children regresses loudly.
+  it('issue #282: close row starts with .tree-row-leading > .tree-twisty.tree-spacer', async () => {
+    const value = await loadFixture('MidKeyMidValue.json');
+    const fixture = await configure(value, 800);
+    teardown = attachFixtureToBody(fixture, 'dark');
+    await drainViewport(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const closeRow = host.querySelector<HTMLElement>('.tree-row.tree-row--close');
+    expect(closeRow)
+      .withContext('at least one .tree-row--close must render after expandAll')
+      .not.toBeNull();
+
+    const firstChild = closeRow!.firstElementChild as HTMLElement | null;
+    expect(firstChild).withContext('close row must have at least one child element').not.toBeNull();
+    expect(firstChild!.classList.contains('tree-row-leading'))
+      .withContext(
+        `close row's firstElementChild must be .tree-row-leading; got class="${firstChild!.className}". ` +
+          `Reordering children regresses the issue #282 alignment fix because the spacer column ` +
+          `placement depends on this being first.`,
+      )
+      .toBe(true);
+
+    const leadingFirstChild = firstChild!.firstElementChild as HTMLElement | null;
+    expect(leadingFirstChild)
+      .withContext('.tree-row-leading on a close row must contain a child element')
+      .not.toBeNull();
+    expect(leadingFirstChild!.classList.contains('tree-twisty'))
+      .withContext(
+        `.tree-row-leading's first child on a close row must be .tree-twisty (the spacer); ` +
+          `got class="${leadingFirstChild!.className}".`,
+      )
+      .toBe(true);
+    expect(leadingFirstChild!.classList.contains('tree-spacer'))
+      .withContext(
+        `the close-row twisty must carry the .tree-spacer modifier (opacity:0 placeholder, ` +
+          `not a real chevron button). got class="${leadingFirstChild!.className}".`,
+      )
+      .toBe(true);
+  });
+
+  // 20. Issue #282 (v0.28.2): the close-row brace's left edge must
+  //     align with the left edge of a sibling row's key at the same
+  //     indent level. This is the direct, screenshot-driven
+  //     invariant that the v0.28.1 bug violated (brace sat one
+  //     chevron-width LEFT of sibling keys because the close row had
+  //     no leading spacer).
+  //
+  //     Fixture is built inline to guarantee a sibling leaf at the
+  //     same indent level as the close row: `{ arr: [1, 2], next: 'x' }`
+  //     after expand produces a level-1 close row for `arr` and a
+  //     level-1 leaf row for `next`. They share `padding-left.em =
+  //     1.25 * 1 = 1.25em`, so any horizontal misalignment is
+  //     attributable to the in-row wrapper structure.
+  it('issue #282: close-row brace left edge equals sibling-key left edge at same indent level', async () => {
+    const fixture = await configure({ arr: [1, 2], next: 'x' }, 800);
+    teardown = attachFixtureToBody(fixture, 'dark');
+    await drainViewport(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const closeRow = host.querySelector<HTMLElement>('.tree-row.tree-row--close');
+    expect(closeRow).withContext('close row for `arr` must render').not.toBeNull();
+    const brace = closeRow!.querySelector<HTMLElement>('.tree-value-brace');
+    expect(brace).withContext('close-row brace must render').not.toBeNull();
+
+    const siblingLeaf = host.querySelector<HTMLElement>('[data-path="$.next"]');
+    expect(siblingLeaf)
+      .withContext('level-1 sibling leaf row `next` must render at same indent as `arr` close')
+      .not.toBeNull();
+    const siblingKey = siblingLeaf!.querySelector<HTMLElement>('.tree-key');
+    expect(siblingKey).withContext('sibling leaf must have a .tree-key element').not.toBeNull();
+
+    const braceLeft = brace!.getBoundingClientRect().left;
+    const siblingKeyLeft = siblingKey!.getBoundingClientRect().left;
+    const delta = Math.abs(braceLeft - siblingKeyLeft);
+    expect(delta)
+      .withContext(
+        `closeBrace.left=${braceLeft.toFixed(2)} vs siblingKey.left=${siblingKeyLeft.toFixed(2)} ` +
+          `(delta=${delta.toFixed(2)}). The issue #282 alignment fix requires the close-row brace ` +
+          `to sit at the same x-position as sibling-row keys at the same indent level. Before the ` +
+          `fix the delta was ~1.1em (one chevron-width); after the fix it must be within 1px ` +
+          `(sub-pixel rounding only).`,
+      )
+      .toBeLessThanOrEqual(1);
+  });
+
+  // 21. Issue #282 (v0.28.2): close-row height must still match the
+  //     probe within sub-pixel rounding. The probe at html:245-288
+  //     already contains a `.tree-row-leading > .tree-twisty` chevron
+  //     (a REAL chevron, taller than the close row's `.tree-spacer`
+  //     placeholder if the two differed in height), so the probe is
+  //     a strict upper bound on close-row height. CDK virtual-scroll
+  //     uses the probe to drive `itemSize`; a regression here would
+  //     cause rows to overlap or leave gaps.
+  it('issue #282: close-row height equals probe row height within 2 px', async () => {
+    const value = await loadFixture('MidKeyMidValue.json');
+    const fixture = await configure(value, 800);
+    teardown = attachFixtureToBody(fixture, 'dark');
+    await drainViewport(fixture);
+
+    const host = fixture.nativeElement as HTMLElement;
+    const probe = probeRow(host);
+    const closeRow = host.querySelector<HTMLElement>('.tree-row.tree-row--close');
+    expect(probe).withContext('probe row must render').not.toBeNull();
+    expect(closeRow).withContext('a close row must render after expandAll').not.toBeNull();
+
+    const probeHeight = probe!.getBoundingClientRect().height;
+    const closeHeight = closeRow!.getBoundingClientRect().height;
+    expect(Math.abs(probeHeight - closeHeight))
+      .withContext(
+        `probeHeight=${probeHeight.toFixed(2)} vs closeHeight=${closeHeight.toFixed(2)}. ` +
+          `The .tree-twisty.tree-spacer placeholder in the close-row leading wrapper must ` +
+          `match the natural row height (the probe's real chevron is the strict upper bound). ` +
+          `A mismatch beyond sub-pixel rounding regresses CDK virtual-scroll itemSize.`,
+      )
+      .toBeLessThanOrEqual(2);
+  });
+
+  // 22. Issue #282 (v0.28.2): a long leading-close comment at a
+  //     deeply-nested level under narrow-pane pressure must (i) not
+  //     cause the close row to horizontally overflow, and (ii)
+  //     ellipsify the comment inside the leading wrapper. This is
+  //     the test the rubber-duck skeptic flagged as the highest-risk
+  //     coverage gap: putting the leading-close comment INSIDE
+  //     `.tree-row-leading` (alongside the spacer) means the comment
+  //     and spacer share the wrapper's shrink budget, mirroring the
+  //     open-row pattern. Without this test, a future regression
+  //     could leave the leading-close comment OUTSIDE the wrapper as
+  //     a sibling flex item, where it would overflow under pressure.
+  it('issue #282: long leading-close comment at level 4 + 360px viewport: no overflow, ellipsifies', async () => {
+    // Level-4 close row: $.a.b.c.items close (items is the array).
+    const fixture = await configure({ a: { b: { c: { items: [1, 2, 3] } } } }, 360);
+    teardown = attachFixtureToBody(fixture, 'dark');
+
+    // Reset prefs explicitly: tests earlier in the suite may
+    // have changed treeFontSize (e.g. test #17 sets it to 20), and
+    // PreferencesService can leak across TestBed.resetTestingModule
+    // calls because it backs to localStorage. The em-based
+    // padding-left math depends on the default font-size for this
+    // assertion's shrink budget.
+    const prefs = TestBed.inject(PreferencesService);
+    prefs.reset();
+
+    await drainViewport(fixture);
+
+    // Apply the long leading-close comment AFTER initial render
+    // (mirrors test #10's pattern: setting commentsByPath before
+    // attach + drain occasionally races with CDK virtual-scroll's
+    // first measurement pass under full-suite GC pressure).
+    fixture.componentRef.setInput(
+      'commentsByPath',
+      new Map([
+        [
+          '$.a.b.c.items',
+          {
+            closeLeading: [
+              'this is an intentionally extremely long leading-close comment that should ellipsify ' +
+                'under wrapper pressure and must not push the brace or the row past the panel edge. '.repeat(
+                  3,
+                ),
+            ],
+          },
+        ],
+      ]),
+    );
+    fixture.detectChanges();
+    await Promise.resolve();
+    fixture.detectChanges();
+
+    const host = fixture.nativeElement as HTMLElement;
+    const closeRow = host.querySelector<HTMLElement>(
+      '.tree-row.tree-row--close[data-close-path="$.a.b.c.items"]',
+    );
+    expect(closeRow)
+      .withContext('the level-4 close row for `items` must render with the leading-close comment')
+      .not.toBeNull();
+
+    const leadingComment = closeRow!.querySelector<HTMLElement>(
+      '.tree-comment-leading.tree-comment-leading--close',
+    );
+    expect(leadingComment)
+      .withContext('the leading-close comment must render inside the close row')
+      .not.toBeNull();
+
+    // Structural invariant: leading-close comment lives INSIDE
+    // .tree-row-leading (not as a sibling). This is the structural
+    // half of the issue #282 fix that makes the comment share the
+    // wrapper's shrink budget with the spacer, mirroring the
+    // open-row pattern.
+    const leadingWrapper = closeRow!.querySelector<HTMLElement>('.tree-row-leading');
+    expect(leadingWrapper).withContext('close row must carry a .tree-row-leading').not.toBeNull();
+    expect(leadingWrapper!.contains(leadingComment!))
+      .withContext(
+        "leading-close comment must live INSIDE .tree-row-leading so it shares the spacer's " +
+          'shrink budget; without this it would overflow under wrapper pressure as a sibling flex item',
+      )
+      .toBe(true);
+
+    // Computed-style invariant: the comment carries the ellipsify
+    // trio + min-width:0 (inherited from .tree-comment at scss:764-779).
+    // This is the SCSS contract that makes shrinkage possible at all.
+    // We assert it directly because a regression here (e.g. someone
+    // overrides .tree-comment-leading--close with white-space:normal)
+    // would prevent ellipsification even if the structure is right.
+    const commentStyles = getComputedStyle(leadingComment!);
+    expect(commentStyles.overflowX)
+      .withContext('.tree-comment-leading--close must inherit overflow:hidden from .tree-comment')
+      .toBe('hidden');
+    expect(commentStyles.textOverflow)
+      .withContext('.tree-comment-leading--close must inherit text-overflow:ellipsis')
+      .toBe('ellipsis');
+    expect(commentStyles.whiteSpace)
+      .withContext('.tree-comment-leading--close must inherit white-space:nowrap')
+      .toBe('nowrap');
+    expect(commentStyles.minWidth)
+      .withContext(
+        '.tree-comment must declare min-width:0 so the inline-flex .tree-row-leading wrapper ' +
+          'can shrink it below intrinsic',
+      )
+      .toBe('0px');
+
+    // Behavioral invariant: under narrow-pane pressure the comment
+    // actually IS clipped (scrollWidth > clientWidth on the comment
+    // span). This proves the shrink machinery fires for real, not
+    // just that the SCSS contract is in place. Combined with the
+    // structural + computed-style checks above, this is the full
+    // S3-coverage the rubber-duck skeptic flagged.
+    expect(leadingComment!.scrollWidth)
+      .withContext(
+        `leading-close comment.scrollWidth=${leadingComment!.scrollWidth} vs ` +
+          `clientWidth=${leadingComment!.clientWidth}. Under narrow-pane pressure the comment ` +
+          `must be clipped (scrollWidth > clientWidth); if equal, the comment is rendering ` +
+          `at intrinsic width which means the shrink machinery never fired.`,
+      )
+      .toBeGreaterThan(leadingComment!.clientWidth);
+  });
 });

--- a/src/app/shared/components/json-tree/json-tree.component.html
+++ b/src/app/shared/components/json-tree/json-tree.component.html
@@ -681,47 +681,55 @@
                 [style.--manual-highlight]="closeManualHighlight?.color ?? null"
                 (contextmenu)="onCloseRowContextMenu($event, closeNode)"
               >
-                @if (showComments() && closeLeadingComment(closeNode); as cl) {
-                  <span class="tree-comment-slot tree-comment-slot--leading-close">
-                    <span
-                      class="tree-comment tree-comment-leading tree-comment-leading--close"
-                      [matTooltip]="closeLeadingCommentTooltipPrefix + cl.tooltipBody"
-                      matTooltipShowDelay="500"
-                      matTooltipPosition="above"
-                      matTooltipClass="jj-tooltip-wide"
-                      >{{ cl.visible }}</span
-                    >
-                    @if (cl.count >= 2) {
+                <span class="tree-row-leading">
+                  <span class="tree-twisty tree-spacer" aria-hidden="true">&middot;</span>
+
+                  @if (showComments() && closeLeadingComment(closeNode); as cl) {
+                    <span class="tree-comment-slot tree-comment-slot--leading-close">
                       <span
-                        class="tree-comment-count"
-                        dir="ltr"
-                        [attr.aria-label]="moreBadgeAriaLabel(cl.count - 1)"
-                        >{{ moreBadge(cl.count - 1) }}</span
+                        class="tree-comment tree-comment-leading tree-comment-leading--close"
+                        [matTooltip]="closeLeadingCommentTooltipPrefix + cl.tooltipBody"
+                        matTooltipShowDelay="500"
+                        matTooltipPosition="above"
+                        matTooltipClass="jj-tooltip-wide"
+                        >{{ cl.visible }}</span
                       >
-                    }
-                  </span>
-                }
-                <span class="tree-value-brace">{{ closeNode.type === 'array' ? ']' : '}' }}</span>
-                @if (showComments() && closeTrailingComment(closeNode); as tc) {
-                  <span class="tree-comment-slot tree-comment-slot--trailing-close">
-                    <span
-                      class="tree-comment tree-comment-trailing tree-comment-trailing--close"
-                      [matTooltip]="closeTrailingCommentTooltipPrefix + tc.tooltipBody"
-                      matTooltipShowDelay="500"
-                      matTooltipPosition="above"
-                      matTooltipClass="jj-tooltip-wide"
-                      >{{ tc.visible }}</span
-                    >
-                    @if (tc.count >= 2) {
+                      @if (cl.count >= 2) {
+                        <span
+                          class="tree-comment-count"
+                          dir="ltr"
+                          [attr.aria-label]="moreBadgeAriaLabel(cl.count - 1)"
+                          >{{ moreBadge(cl.count - 1) }}</span
+                        >
+                      }
+                    </span>
+                  }
+                </span>
+                <span class="tree-row-value-cell">
+                  <span class="tree-value-brace">{{ closeNode.type === 'array' ? ']' : '}' }}</span>
+                </span>
+                <span class="tree-row-trailing">
+                  @if (showComments() && closeTrailingComment(closeNode); as tc) {
+                    <span class="tree-comment-slot tree-comment-slot--trailing-close">
                       <span
-                        class="tree-comment-count"
-                        dir="ltr"
-                        [attr.aria-label]="moreBadgeAriaLabel(tc.count - 1)"
-                        >{{ moreBadge(tc.count - 1) }}</span
+                        class="tree-comment tree-comment-trailing tree-comment-trailing--close"
+                        [matTooltip]="closeTrailingCommentTooltipPrefix + tc.tooltipBody"
+                        matTooltipShowDelay="500"
+                        matTooltipPosition="above"
+                        matTooltipClass="jj-tooltip-wide"
+                        >{{ tc.visible }}</span
                       >
-                    }
-                  </span>
-                }
+                      @if (tc.count >= 2) {
+                        <span
+                          class="tree-comment-count"
+                          dir="ltr"
+                          [attr.aria-label]="moreBadgeAriaLabel(tc.count - 1)"
+                          >{{ moreBadge(tc.count - 1) }}</span
+                        >
+                      }
+                    </span>
+                  }
+                </span>
                 @if (closeManualHighlight) {
                   <span class="sr-only" i18n="@@tree.highlighted.aria">highlighted</span>
                 }

--- a/src/app/shared/components/json-tree/json-tree.component.scss
+++ b/src/app/shared/components/json-tree/json-tree.component.scss
@@ -366,14 +366,31 @@
   }
 }
 
-// Close rows retain `display: flex` because their 1-3 children
-// (`.tree-comment-slot--leading-close`, `.tree-value-brace`,
-// `.tree-comment-slot--trailing-close`) don't compete for shrink space.
-// The grid-column assignments above are inert here because `display:
-// flex` overrides the parent's grid template. The scoped
-// `> * { min-width: 0 }` rule is the close-row replacement for the
-// retired `.tree-row > * { min-width: 0 }` cascade, preserving
-// close-row protection from the v0.21.1-era overflow fix.
+// Close rows retain `display: flex` because their wrappers don't
+// compete for shrink space and there's no need to encode brace-glyph
+// centering in the grid template. Issue #282 (v0.28.2) restructured
+// the close row to use the same three structural wrappers leaf/open
+// rows use -- `.tree-row-leading` (containing a chevron-sized
+// `.tree-twisty.tree-spacer` placeholder + optional leading-close
+// comment slot), `.tree-row-value-cell` (containing the brace), and
+// `.tree-row-trailing` (containing optional trailing-close comment
+// slot) -- so the brace aligns with sibling key text instead of
+// sitting flush against the row's `padding-left`. This is the
+// Prettier / jq / VS Code / IntelliJ / `python -m json.tool`
+// convention; matches expectations of every mainstream JSON viewer.
+//
+// `.tree-row-leading` therefore operates in two layout contexts: as
+// a grid item on `.tree-row` (leaf/open rows), and as a flex item
+// on `.tree-row.tree-row--close`. Its internal `inline-flex`
+// semantics are identical in both contexts; only the parent's
+// participation rules differ.
+//
+// The grid-column assignments on the canonical block above are
+// inert here because `display: flex` overrides the parent's grid
+// template. The scoped `> * { min-width: 0 }` rule is the
+// close-row replacement for the retired `.tree-row > * { min-width: 0 }`
+// cascade, preserving close-row protection from the v0.21.1-era
+// overflow fix.
 .tree-row.tree-row--close {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary

Fixes the cosmetic-but-conspicuous misalignment where the closing
`]` / `}` on a non-empty expanded array/object sits **flush against
the row's `padding-left`** -- one chevron-width to the LEFT of every
sibling row's key column at the same indent level.

**Before** (matches the screenshot from issue #282 and the report
that prompted this work):

```
 v  invoiceTaxDetails : [
    > 0 : { ... }
 ]                                  <-- ] flush against row padding
    invoiceGroupDetails : []
```

**After**:

```
 v  invoiceTaxDetails : [
    > 0 : { ... }
    ]                               <-- ] aligned with sibling keys
    invoiceGroupDetails : []
```

Target 1 (`]` aligned with sibling key column) matches Prettier, jq,
VS Code's formatter, IntelliJ, and `python -m json.tool`. No
mainstream JSON viewer aligns the close brace under the opening
bracket; that visual would be unusual.

## Mechanism

The close-row HTML (`@case ('close')` in
`json-tree.component.html`) used to render the leading-close
comment slot, the brace, and the trailing-close comment slot as
three sibling flex items with no leading placeholder. Leaf and open
rows both render a chevron-sized leading element first (a real
chevron for open rows, a `.tree-twisty.tree-spacer &middot;`
placeholder for leaf rows).

This PR restructures the close-row body into three structural
wrappers matching leaf/open rows:

- `.tree-row-leading` -- contains the new `.tree-twisty.tree-spacer`
  placeholder + the (relocated) leading-close comment slot.
- `.tree-row-value-cell` -- contains the brace.
- `.tree-row-trailing` -- contains the trailing-close comment slot.

Moving the leading-close comment **inside** `.tree-row-leading`
mirrors the open-row pattern (HTML:567-586) and means the comment
now shares the spacer's shrink budget under narrow-pane pressure
the same way it already does on open rows.

## Why not literal CSS Subgrid

Two independent blockers (both flagged in the rubber-duck gate):

1. **Per-row `padding-left` encodes indent.** Subgrid inherits
   column edges from the parent; padding shifts the content area
   without shifting those edges. A level-3 row's `[key]` column
   would anchor at the same absolute X as level-0. Indent would
   collapse.
2. **`cdkVirtualFor` re-materializes rows on scroll.** Shared
   column tracks would re-measure from the visible window, so
   long-keyed rows entering/leaving the viewport would jitter
   every other visible row's columns. Spreadsheet-style alignment
   is the wrong semantic for a tree.

Close rows therefore stay `display: flex`. See the plan's
"Pre-presentation gate" section for the full critic-by-critic
analysis.

## Tests

Added 4 new tests in
`json-tree.component.grid-structural.spec.ts`:

1. **Structural** (#19): close row's `firstElementChild` is
   `.tree-row-leading`, which contains `.tree-twisty.tree-spacer`
   as its first child.
2. **Bug-fix invariant** (#20): against a fixture with a leaf
   sibling at the same indent level, `closeRow .tree-value-brace`
   left edge equals `siblingLeaf .tree-key` left edge within 1px.
   This is the direct screenshot-driven invariant.
3. **Probe-height** (#21): close-row height equals the
   `effectiveRowHeightPx()` probe within 2px. The probe already
   includes a real chevron in `.tree-row-leading`, so the spacer
   adds no new height risk.
4. **Narrow-pane ellipsify** (#22): under a long leading-close
   comment at level 4 + 360px viewport, the comment lives inside
   `.tree-row-leading`, carries the ellipsify trio + `min-width:0`
   computed style, and clips at runtime (`scrollWidth >
   clientWidth` on the comment span). Combined with the existing
   row-level `scrollWidth <= clientWidth` invariant in test #11,
   this covers the "narrow-pane overflow under pressure" gap the
   rubber-duck skeptic flagged (S3).

All 2871 existing tests still pass; previously-asserted
display:flex, role=presentation, and document-order invariants
on close rows are preserved.

## Lint

Updated `scripts/check-tree-row-grid.mjs`:

- Comment-updated the close-row carve-out in `lintTemplate` so
  future contributors see why close rows are exempt from the
  grid-direct-child allowlist.
- Added a new SCSS-side assertion: `.tree-row.tree-row--close`
  must declare `display: flex`. Cheap insurance against the
  carve-out becoming a silent gap if someone flips the display
  value without addressing the now-silent direct-child set
  (architect finding A6).

## SemVer

**0.28.1 -> 0.28.2** (patch). Visual bug fix, no API change, no
behavior change beyond brace position. Strong recent precedent:
v0.23.1, v0.23.2, v0.25.1, v0.26.1 were all patches for
analogous tree-row layout adjustments (v0.26.1 was a much
bigger restructure).

## Telemetry / why-jotjson

No new telemetry (pure visual fix; no user action to measure).
No `why-jotjson.md` update (internal polish, not a feature).

## Out of scope (filed as follow-ups)

- Dropping close rows entirely (Chrome DevTools / Firefox JSON
  viewer / Postman model). Architecturally cleaner but a real
  behavior change with a JSONC-close-position-comments design
  question. Will file a separate `tech-debt` + `discussion`
  issue.
- Re-framing issue #282's title/body to separate the alignment
  target from the Subgrid mechanism. The PR description's "Why
  not literal Subgrid" section documents both blockers; the
  issue itself will be closed by this PR.

Closes #282.

---
**Session**
- AI-Local: `8f8c16d8-d40a-45a4-9c78-4828c3407d20`
- AI-Cloud: `80be8e44-af5d-4602-a025-79a81d7c57b5`
