### PR TITLE
Consolidate four append*(path, body) parser helpers and pending-queue drain sites

### DIFF
--- a/src/app/core/json/parse.spec.ts
+++ b/src/app/core/json/parse.spec.ts
@@ -175,7 +175,7 @@ describe('parse (pure)', () => {
 
     it('pushes onto an existing slot rather than replacing it (case 3)', () => {
       // Stacked leading comments exercise the "path exists, slot exists,
-      // push" branch. The `flushPendingAsLeading` drain calls `appendBody`
+      // push" branch. The `flushPending` drain calls `appendBody`
       // twice for the same path+slot; the second call must push to the
       // existing array, not overwrite it.
       const result = parse('{\n  // first\n  // second\n  "x": 1\n}');

--- a/src/app/core/json/parse.spec.ts
+++ b/src/app/core/json/parse.spec.ts
@@ -144,4 +144,44 @@ describe('parse (pure)', () => {
       expect(locationAt(text, offsetOnValue)).toEqual(['a']);
     });
   });
+
+  describe('comment bundles (appendBody)', () => {
+    it('creates a fresh bundle when no bundle exists for the path (case 1)', () => {
+      // Single leading comment exercises the new-bundle branch of
+      // `appendBody`: `map.get(path)` is undefined, so a fresh
+      // `MutableCommentBundle` is constructed with only the leading slot.
+      const result = parse('{\n  // hello\n  "x": 1\n}');
+      expect(result.errors).toEqual([]);
+      const bundle = result.commentsByPath.get('$.x');
+      expect(bundle).toBeDefined();
+      expect(bundle?.leading).toEqual(['hello']);
+      expect(bundle?.trailing).toBeUndefined();
+      expect(bundle?.closeLeading).toBeUndefined();
+      expect(bundle?.closeTrailing).toBeUndefined();
+    });
+
+    it('preserves an existing slot when adding a different slot (case 2)', () => {
+      // A leading + trailing pair on the same value exercises the
+      // "path exists, second slot is undefined" branch of `appendBody`.
+      // A regression that replaced `existing[slot] = [body]` with a
+      // computed-property-name literal (`map.set(path, { [slot]: [body] })`)
+      // would clobber the leading slot; this asserts both coexist.
+      const result = parse('{\n  // L\n  "x": 1 // T\n}');
+      expect(result.errors).toEqual([]);
+      const bundle = result.commentsByPath.get('$.x');
+      expect(bundle?.leading).toEqual(['L']);
+      expect(bundle?.trailing).toEqual(['T']);
+    });
+
+    it('pushes onto an existing slot rather than replacing it (case 3)', () => {
+      // Stacked leading comments exercise the "path exists, slot exists,
+      // push" branch. The `flushPendingAsLeading` drain calls `appendBody`
+      // twice for the same path+slot; the second call must push to the
+      // existing array, not overwrite it.
+      const result = parse('{\n  // first\n  // second\n  "x": 1\n}');
+      expect(result.errors).toEqual([]);
+      const bundle = result.commentsByPath.get('$.x');
+      expect(bundle?.leading).toEqual(['first', 'second']);
+    });
+  });
 });

--- a/src/app/core/json/parse.ts
+++ b/src/app/core/json/parse.ts
@@ -56,6 +56,8 @@ type MutableCommentBundle = {
   -readonly [K in keyof CommentBundle]: string[];
 };
 
+type CommentSlot = keyof CommentBundle;
+
 export interface JsonParseResult {
   value: unknown;
   ast: JsoncNode | undefined;
@@ -215,62 +217,26 @@ function harvestComments(text: string): {
   let lastContainerOpenEndOffset = -1;
   let lastContainerOpenLine = -1;
 
-  const appendLeading = (path: string, body: string): void => {
+  const appendBody = (path: string, slot: CommentSlot, body: string): void => {
     const existing = map.get(path);
     if (existing) {
-      if (existing.leading) {
-        existing.leading.push(body);
+      const arr = existing[slot];
+      if (arr) {
+        arr.push(body);
       } else {
-        existing.leading = [body];
+        existing[slot] = [body];
       }
     } else {
-      map.set(path, { leading: [body] });
+      const newBundle: MutableCommentBundle = {};
+      newBundle[slot] = [body];
+      map.set(path, newBundle);
     }
   };
 
   const flushPendingAsLeading = (path: string): void => {
     if (pendingLeading.length === 0) return;
-    for (const body of pendingLeading) appendLeading(path, body);
+    for (const body of pendingLeading) appendBody(path, 'leading', body);
     pendingLeading.length = 0;
-  };
-
-  const appendTrailing = (path: string, body: string): void => {
-    const existing = map.get(path);
-    if (existing) {
-      if (existing.trailing) {
-        existing.trailing.push(body);
-      } else {
-        existing.trailing = [body];
-      }
-    } else {
-      map.set(path, { trailing: [body] });
-    }
-  };
-
-  const appendCloseLeading = (path: string, body: string): void => {
-    const existing = map.get(path);
-    if (existing) {
-      if (existing.closeLeading) {
-        existing.closeLeading.push(body);
-      } else {
-        existing.closeLeading = [body];
-      }
-    } else {
-      map.set(path, { closeLeading: [body] });
-    }
-  };
-
-  const appendCloseTrailing = (path: string, body: string): void => {
-    const existing = map.get(path);
-    if (existing) {
-      if (existing.closeTrailing) {
-        existing.closeTrailing.push(body);
-      } else {
-        existing.closeTrailing = [body];
-      }
-    } else {
-      map.set(path, { closeTrailing: [body] });
-    }
   };
 
   const onValueStart = (path: string): void => {
@@ -288,7 +254,7 @@ function harvestComments(text: string): {
     const path = containerPathStack.pop();
     if (path === undefined) return;
     if (pendingLeading.length > 0) {
-      for (const body of pendingLeading) appendCloseLeading(path, body);
+      for (const body of pendingLeading) appendBody(path, 'closeLeading', body);
       pendingLeading.length = 0;
     }
     const endOffset = offset + length;
@@ -352,7 +318,7 @@ function harvestComments(text: string): {
           startLine === closeJustSeenLine &&
           offset >= closeJustSeenOffset
         ) {
-          appendCloseTrailing(closeJustSeenPath, body);
+          appendBody(closeJustSeenPath, 'closeTrailing', body);
           return;
         }
 
@@ -361,12 +327,12 @@ function harvestComments(text: string): {
           startLine === lastValueEndLine &&
           offset >= lastValueEndOffset
         ) {
-          appendTrailing(lastValuePath, body);
+          appendBody(lastValuePath, 'trailing', body);
           return;
         }
 
         if (isOpenRowTrailing(offset, length, startLine)) {
-          appendTrailing(lastContainerOpenPath as string, body);
+          appendBody(lastContainerOpenPath as string, 'trailing', body);
           return;
         }
 

--- a/src/app/core/json/parse.ts
+++ b/src/app/core/json/parse.ts
@@ -233,14 +233,14 @@ function harvestComments(text: string): {
     }
   };
 
-  const flushPendingAsLeading = (path: string): void => {
+  const flushPending = (path: string, slot: 'leading' | 'closeLeading'): void => {
     if (pendingLeading.length === 0) return;
-    for (const body of pendingLeading) appendBody(path, 'leading', body);
+    for (const body of pendingLeading) appendBody(path, slot, body);
     pendingLeading.length = 0;
   };
 
   const onValueStart = (path: string): void => {
-    flushPendingAsLeading(path);
+    flushPending(path, 'leading');
     closeJustSeenPath = null;
   };
 
@@ -253,10 +253,7 @@ function harvestComments(text: string): {
   const onContainerEnd = (offset: number, length: number, startLine: number): void => {
     const path = containerPathStack.pop();
     if (path === undefined) return;
-    if (pendingLeading.length > 0) {
-      for (const body of pendingLeading) appendBody(path, 'closeLeading', body);
-      pendingLeading.length = 0;
-    }
+    flushPending(path, 'closeLeading');
     const endOffset = offset + length;
     closeJustSeenPath = path;
     closeJustSeenOffset = endOffset;


### PR DESCRIPTION
## Summary

Consolidates the four parallel `append*(path, body)` parser helpers and the two parallel pending-queue drain sites in `harvestComments` (`src/app/core/json/parse.ts`) into two slot-parameterized helpers (`appendBody` + `flushPending`). Both consolidations are diff-by-one-identifier collapses that became structurally identical after PR #295 reshaped `CommentBundle` slots to `readonly string[]`.

Two named commits for review-time clarity (forfeit under squash-merge, accepted tradeoff).

Closes #298.

## Commits

1. **`f7e3d07` Consolidate four `append*(path, body)` parser helpers into `appendBody`** -- adds module-local `type CommentSlot = keyof CommentBundle` and replaces the four 12-line helpers with one parameterized helper. Updates 5 call sites. Adds ~40-line spec in `parse.spec.ts` covering all three observable branches.

2. **`5598977` Consolidate `flushPendingAsLeading` and `onContainerEnd` drain into `flushPending`** -- adds `flushPending(path, slot)` with a narrowed inline-union slot type (`'leading' | 'closeLeading'` only - the two positions `pendingLeading` ever drains to). Deletes `flushPendingAsLeading`; collapses the inline drain block in `onContainerEnd` to one call.

## Type-safety review checklist

- [x] **Single-structural-cast invariant preserved.** The harvest function continues to hold a `Map<string, MutableCommentBundle>` and casts once at the export-boundary return statement to `ReadonlyMap<string, CommentBundle>`. No new casts. **Watch-out for future tidy-up**: the new-bundle branch builds `MutableCommentBundle` stepwise (`const newBundle: MutableCommentBundle = {}; newBundle[slot] = [body];`) rather than as a computed-property-name literal (`{ [slot]: [body] }`). The literal form would widen to `{ [x: string]: string[] }` index signature and break the single-cast invariant -- a future "simplification" to `map.set(path, { [slot]: [body] } as MutableCommentBundle)` would silently re-introduce a second cast. Stepwise construction is load-bearing, not stylistic.
- [x] **`CommentSlot` is module-local (no `export`).** The parser's public API surface (`CommentBundle`, `JsonParseResult`, `parse`, `harvestComments`'s indirect surface through `JsonParserService`) is unchanged. **No SemVer bump.**
- [x] **`flushPending` slot type is the narrowed inline union, not `CommentSlot`.** `pendingLeading` only ever drains in leading or closeLeading position; allowing `'trailing'` / `'closeTrailing'` would be a latent footgun with no current call site. The inline union avoids minting a second named alias for a two-value domain.
- [x] **No `as`-casts added.** The preexisting `lastContainerOpenPath as string` at the open-row-trailing branch is unchanged (orthogonal cleanup per AGENTS.md SS9).

## Test strategy

The new spec block in `parse.spec.ts` exercises `appendBody`'s three observable branches through the public `parse()` surface:

1. **Case 1 - new bundle**: single leading comment, `map.get(path)` is undefined, fresh `MutableCommentBundle` created with only the leading slot.
2. **Case 2 - existing bundle, second slot undefined**: leading + trailing on the same path. **Asserts both slots coexist** -- a regression that replaced `existing[slot] = [body]` with `map.set(path, { [slot]: [body] })` would clobber the leading slot silently. This is the most fragile branch.
3. **Case 3 - existing bundle, slot non-empty, push**: stacked leading comments. The `flushPending` drain calls `appendBody` twice for the same path+slot; the second call must push, not overwrite.

**Negative-slot tests intentionally not added.** A test like "appendBody with slot='nonexistent'" can't compile -- `slot: CommentSlot` is a closed enum (`keyof CommentBundle`). TypeScript already enforces the invariant.

**No perf assertion.** The consolidation reshuffles closures (one new dispatcher with a `slot` parameter and one extra indirection per call vs the prior named-helper inlining); microbenchmark deltas are noise-floor and not worth tracking. Existing layer-1 parse baselines remain valid; nothing in this PR claims to move them.

## Fold rationale (commit 2)

Plan v3 originally deferred `flushPending` to a separate issue per architect rubber-duck pass-5. User authorized folding it in because:

- Both drain sites live in the same closure, same file, same scope as `appendBody`.
- The drain shape is **mechanically derivable** from the appendBody collapse (loop over `pendingLeading` -> call `appendBody(path, <slot>, body)` -> truncate).
- The drain duplication is **only visible because of the parent cleanup** -- prior to the appendBody consolidation, the two drain sites called *different* named helpers and looked unrelated.

This admission criterion ("mechanically derivable AND only visible because of parent cleanup") explicitly excludes the other architect-flagged adjacent candidates, which are tracked separately:

- #314 `onObjectBegin` / `onArrayBegin` -> shared `onContainerBegin` (always visible, independent of this PR).
- #315 state-triplet bundling (`lastValue*`, `closeJustSeen*`, `lastContainerOpen*`) (independent refactor with allocation-perf design questions).

## DoD

- [x] `npm run lint:all` passes.
- [x] `npm --prefix api test` passes (15 suites, 465 tests).
- [x] `npm test` passes (Karma: 2868 passed, 3 skipped baseline).
- [x] `npm run build` passes.
- [x] No new user-facing strings; `extract-i18n` not needed.
- [x] No SemVer bump (module-local helpers + module-local `CommentSlot` alias; zero exported-symbol changes).
- [x] Spec updated (`parse.spec.ts` +40 lines).
- [x] `DESIGN_SPEC.md` unchanged (no behavior, architecture, or schema change).
- [x] Two named commits document the consolidation order for review; squash-merge collapses them but the per-commit log remains in the PR history if anyone needs to bisect mentally.

---
**Session**
- AI-Local: `a8b469ab-c2be-4f2a-8fc0-c250c18f74ef`
- AI-Cloud: `2b6fd0cd-d28d-42e7-ba3b-2b7bd7059d36`