### PR TITLE
Rebalance scope guidance: don't default to the minimal change

### DIFF
--- a/.cursorrules
+++ b/.cursorrules
@@ -1,47 +1,6 @@
-# Cursor Rules - JotJSON
+# Cursor Instructions - JotJSON
 
-The authoritative instructions for this repo are in `AGENTS.md` at the root.
-Always read and follow `AGENTS.md` and `DESIGN_SPEC.md` before making changes.
-The summary below is for quick reference; `AGENTS.md` wins on any conflict.
-
-## Non-negotiables
-
-- `DESIGN_SPEC.md` is the source of truth. Flag conflicts before implementing.
-- Stack is fixed: Angular (latest LTS) + Signals + Material, Azure Functions in
-  TypeScript, Cosmos DB (serverless), Azure Static Web Apps, Bicep in `/infra`.
-- Use `jsonc-parser` for all user JSON/JSONC - never `JSON.parse`.
-- Strict TypeScript. No `any`; use `unknown` + narrowing.
-- Standalone Angular components, `OnPush`, `inject()`, Signals for state, RxJS
-  only at I/O boundaries.
-- Kebab-case filenames; co-located `*.spec.ts`; no default exports in app code.
-- Azure Functions: thin handlers, zod-validated inputs, B2C JWT auth on
-  protected routes, typed JSON responses with explicit status codes.
-
-## Workflow
-
-- Make surgical changes that fully address the request. Don't reformat or
-  refactor unrelated code.
-- Add or update tests for every logic change. No test = not done.
-- Before finishing: `npm run lint`, `npm test`, and `npm run build` must pass
-  for both the frontend and `api/`. Don't add new toolchains to satisfy this.
-- Update `DESIGN_SPEC.md` in the same change when behavior or architecture
-  changes.
-
-## Security & Privacy
-
-- Never log or transmit clipboard contents, editor contents, or PII.
-- No secrets in source. Use SWA/Functions app settings + Key Vault.
-- Enforce spec limits on both client and server (1 MB saved blob, 5 MB upload,
-  100-blob cap).
-- Use Angular interpolation/binding over `innerHTML`.
-
-## Commits
-
-- Small, focused, imperative subject lines.
-- AI-assisted commits include:
-  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
-
-## When Unsure
-
-Ask a clarifying question rather than guessing on defaults, limits, scope, or
-behavior. Prefer the simpler, spec-aligned option.
+The default coding instructions for this repository live in
+[`AGENTS.md`](AGENTS.md) at the repo root. Follow it in full for every
+task -- it covers the tech stack, project layout, coding conventions,
+testing, security, and Definition of Done.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,24 +1,12 @@
 # GitHub Copilot Instructions
 
 The default coding instructions for this repository live in
-[`AGENTS.md`](../AGENTS.md) at the repo root. Follow those in full for every
-task - they cover the tech stack, project layout, coding conventions, testing,
-security, and Definition of Done.
-
-Key points (see `AGENTS.md` for the authoritative version):
-
-- `DESIGN_SPEC.md` is the source of truth for product and architecture.
-- Stack: Angular (latest LTS) + Angular Material + Signals; Azure Functions in
-  TypeScript; Cosmos DB (serverless); Azure Static Web Apps; Bicep for IaC.
-- Use `jsonc-parser` (not `JSON.parse`) for user JSON/JSONC input.
-- Standalone Angular components, `OnPush`, `inject()`, strict TypeScript.
-- Tests are required for logic changes. Run lint + test + build before done.
-- Plans with meaningful UI changes must include a mockup before approval (see `AGENTS.md` §11).
-- No new frameworks, languages, or cloud services without approval.
-- Never log or transmit clipboard/editor contents or secrets.
+[`AGENTS.md`](../AGENTS.md) at the repo root. Follow it in full for every
+task -- it covers the tech stack, project layout, coding conventions,
+testing, security, and Definition of Done.
 
 ## Copilot CLI Specifics
 
 When `AGENTS.md` §11 calls for parallel sub-agent execution, use `/fleet` mode
-whenever possible -- especially when implementing an approved plan. Apply it on
-every wave of the plan's dependency graph, not just the first one.
+whenever possible -- especially when implementing an approved plan. Apply it
+on every wave of the plan's dependency graph, not just the first one.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1142,10 +1142,23 @@ ran) and ask whether to revert, follow-up-fix, or accept.
 
 ## 9. Scope Discipline
 
-- Make surgical changes that fully address the request. Do not refactor
-  unrelated code, rename files, or reformat untouched areas.
+- **Scope discipline governs plan execution, not option weighing.**
+  Once a plan is approved, stick to it: make surgical changes that
+  fully address the request, and do not refactor unrelated code,
+  rename files, or reformat untouched areas. This rule does **not**
+  apply to the option-weighing / recommendation phase -- see §11
+  "Don't default to the minimal change".
+- **Plans must scope to the user's stated request plus tightly-
+  coupled work.** A plan can legitimately include a larger, cleaner
+  refactor when the refactor is on the path of the request or
+  genuinely tightly coupled to it. Refactors of code **not** on
+  that path require the user to explicitly request or accept the
+  refactor as scope -- not just rubber-stamp a plan that happens
+  to include it. The user's described scope is the **outer** bound
+  on what the agent recommends; "architecturally correct" is not
+  a license to inflate beyond architectural necessity.
 - If you find a tightly-coupled bug caused by the code you're changing, fix it.
-  Otherwise, note it and move on.
+  Otherwise, file an issue and move on.
 - Prefer ecosystem tooling (`ng generate`, `npm init`, codemods) over manual
   file creation.
 
@@ -1162,7 +1175,15 @@ ran) and ask whether to revert, follow-up-fix, or accept.
   "execute", "approved, please ship", "go ahead" -- before touching
   code. Picking option B from a multiple-choice you offered is the user
   choosing a direction, not authorizing the change.
-- Prefer the simpler, spec-aligned option over a clever alternative.
+- **Prefer the simpler, spec-aligned option over a clever
+  alternative.** "Simpler" means less mechanical complexity --
+  fewer special cases, less hidden state, less reader cognitive
+  load -- **not** smaller diff. A clean refactor with more lines
+  changed is often simpler than a patch that layers a workaround
+  on a workaround. `DESIGN_SPEC.md` alignment still wins over
+  "architecturally cleaner" when the two conflict (§1 source of
+  truth). See §11 "Don't default to the minimal change" for the
+  related rule on option-weighing.
 
 ## 11. Planning, Critical Thinking & Proactive Feedback
 
@@ -1288,7 +1309,15 @@ ran) and ask whether to revert, follow-up-fix, or accept.
     explicit adversarial framing ("find at least one weakness; if
     you genuinely cannot, say so explicitly"), and (b) be quoted
     (or summarized in one line if long) in the plan alongside the
-    findings so its quality is auditable.
+    findings so its quality is auditable. (c) For plans that
+    present two or more architectural options, the prompt must
+    explicitly include the principle that "smaller diff is not by
+    itself a recommendation argument" and that any scope-separation
+    finding must rest on a substantive architectural reason. This
+    prevents the critic from generating bare "do not fold X"
+    verdicts that the calling agent would then have to discount
+    during option weighing (see "Don't default to the minimal
+    change" above).
 
   - **Critic invocation failure is not a fallback.** If the critic
     invocation times out, errors, or is refused, surface the
@@ -1427,6 +1456,52 @@ ran) and ask whether to revert, follow-up-fix, or accept.
   the concern, explain it, and let the user decide. After the user
   decides, follow their decision unless they ask you to push back
   again.
+- **Don't default to the minimal change.** Recommending the smaller
+  of two competing options because it has less churn is risk-
+  aversion masquerading as pragmatism. Judge options on long-term
+  architectural fit, not diff size. **This rule is bidirectional:**
+  it forbids defaulting to the smaller option on diff-size grounds,
+  but equally forbids inflating scope beyond architectural
+  necessity. "Architecturally correct" is the option that fits
+  long-term structure -- sometimes that is the smaller change,
+  sometimes the larger; the rule is about reasoning on fit, not
+  on size in either direction.
+
+  When recommending the smaller of competing options, the
+  rationale must reference a long-term architectural property of
+  the codebase (module boundary, stored shape, dependency
+  direction, release-cadence separation, code-owner separation)
+  -- not a tactical property of the change (size, churn, risk of
+  breakage, "captures most of the benefit", "minimal / surgical /
+  conservative path"). Tactical phrasings like those are a tell
+  that the reasoning is size-based, not fit-based; treat them as
+  exemplars rather than an exhaustive list and stop to re-evaluate
+  whenever your reasoning leans on any equivalent framing.
+
+  Present the architecturally-correct option as the recommendation;
+  the user can still choose the conservative path, but they should
+  choose it knowingly, not because the recommendation pre-baked
+  the bias. The user's described scope sets the **outer** bound
+  on what gets recommended -- if the architecturally-cleaner
+  option exceeds that scope, present the in-scope option as the
+  recommendation **and** call out the larger option as out-of-
+  scope work the user can choose to fold in.
+
+  This rule applies to the option-weighing / recommendation phase
+  only; once a plan is approved, §9 Scope Discipline still governs
+  execution. It does **not** alter §8 PR-review-feedback handling:
+  reviewer comments proposing refactors remain out-of-scope per
+  §8 unless the user has authorized expanding the PR's scope.
+
+  Rubber-duck critic findings (e.g., a `:architect` "file Y as a
+  separate follow-up issue" remark) carry no special authority
+  here. They are proposals to be evaluated on merit per the
+  existing §11 `ADOPT / SET ASIDE / OUT OF SCOPE` classification
+  -- the *architectural* reason for separation is what matters
+  (independent module, different stored shape, different release
+  cadence, different code owner). A bare scope-separation verdict
+  without a substantive architectural reason is not a
+  recommendation argument.
 - Critical thinking applies to your own prior recommendations too.
   If new evidence (test output, file contents, a rubber-duck review,
   a user correction) suggests an earlier suggestion was wrong,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,51 +1,6 @@
 # Claude Code Instructions - JotJSON
 
-The authoritative instructions for this repository are in
-[`AGENTS.md`](AGENTS.md). Read it and [`DESIGN_SPEC.md`](DESIGN_SPEC.md) before
-making any non-trivial change. The summary below is for quick reference only;
-`AGENTS.md` wins on any conflict.
-
-## Non-negotiables
-
-- `DESIGN_SPEC.md` is the product & architecture source of truth.
-- Stack: Angular (latest LTS, standalone + Signals + Material), Azure Functions
-  in TypeScript, Cosmos DB serverless, Azure Static Web Apps, Bicep in `/infra`.
-- Use `jsonc-parser` for user JSON/JSONC - never `JSON.parse`.
-- Strict TypeScript; no `any`; prefer `unknown` + narrowing.
-- Standalone Angular components, `OnPush`, `inject()`, Signals, RxJS only at
-  I/O boundaries. Kebab-case filenames; co-located `*.spec.ts`.
-- Azure Functions: thin handlers, zod-validated inputs, Entra External ID JWT
-  auth, typed
-  JSON responses.
-
-## Workflow
-
-- Make surgical, fully-correct changes. Don't touch unrelated code.
-- Add/update tests for every logic change.
-- Plans involving meaningful UI changes must include a mockup before
-  approval (see AGENTS.md §11).
-- Before done: `npm run lint`, `npm test`, `npm run build` pass for frontend
-  and `api/`. Don't introduce new toolchains to satisfy this.
-- Update `DESIGN_SPEC.md` in the same change when behavior or architecture
-  changes.
-- Update [`why-jotjson.md`](why-jotjson.md) in the same change when a
-  user-facing feature is added, removed, or significantly altered. It
-  is the public pitch doc, not engineering documentation.
-
-## Security & Privacy
-
-- Never log or transmit clipboard/editor contents or PII.
-- No secrets in source - use SWA/Functions app settings + Key Vault.
-- Enforce spec limits on both client and server.
-- Use Angular interpolation/binding over `innerHTML`.
-
-## Commits
-
-- Small, focused, imperative subject lines.
-- AI-assisted commits include:
-  `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>`
-
-## When Unsure
-
-Ask a clarifying question rather than guessing on defaults, limits, scope, or
-behavior. Prefer the simpler, spec-aligned option.
+The default coding instructions for this repository live in
+[`AGENTS.md`](AGENTS.md) at the repo root. Follow it in full for every
+task -- it covers the tech stack, project layout, coding conventions,
+testing, security, and Definition of Done.


### PR DESCRIPTION
## Summary

Rebalances the AGENTS.md scope-discipline guidance so it no longer reads as "the smaller diff wins by default" during option weighing, and trims the three pointer files (`.cursorrules`, `CLAUDE.md`, `.github/copilot-instructions.md`) to true minimal pointers that defer to AGENTS.md as the single source of truth.

Motivation: recent sessions kept recommending the narrower option in cases where a broader, more architecturally-aligned path was the right call, citing AGENTS.md s9 ("surgical changes") as if it were a tiebreaker for picking *between* options. It is not -- it governs how to execute an *approved* plan. The DiffViewer repo's "Don't default to the minimal change" rule is the model jotjson is now aligning with.

## AGENTS.md changes

- **s9 Scope Discipline**: clarified the rule governs execution of an approved plan, not option weighing during planning. Added explicit bullet that plans must scope to the user's stated request plus tightly-coupled work, and that "note it" tangents become **filed issues**, not buried notes.
- **s10 When In Doubt**: defined "simpler" (fewer moving parts, clearer dependency direction, fits existing conventions) and noted that "simpler" is not the same as "smaller diff". Added DESIGN_SPEC.md alignment as the tiebreaker when "architecturally cleaner" and "spec-aligned" disagree.
- **s11 Planning & Critical Thinking**: new **"Don't default to the minimal change"** bullet. When weighing options, a smaller diff is not by itself a recommendation argument; recommendations must reference a long-term architectural property (module boundary, stored shape, dependency direction, release cadence, code owner). Includes bidirectionality (don't gold-plate either), user-stated-scope as outer bound, and a s8 PR-review-feedback carve-out so reviewer-bot refactor proposals stay out-of-scope.
- **s11 Critic prompt requirements**: extended so option-weighing plans brief the critic upfront that "smaller diff is not a recommendation argument by itself".

## Pointer-file changes

- `.cursorrules`: 47 -> 6 lines.
- `CLAUDE.md`: 52 -> 6 lines.
- `.github/copilot-instructions.md`: 24 -> 12 lines (keeps the Copilot-CLI-specific `/fleet` tip).

All three are now minimal pointers that defer to AGENTS.md. Stored a memory so future sessions don't pattern-match-back into duplicating guidance across these files.

## Rubber-duck panel

Per AGENTS.md s11, ran the three-agent panel (`deep-review:skeptic` + `:advocate` + `:architect`) on the plan before presenting it. 25 findings total; 9 adopted (bidirectionality clause, principle-based language replacing a brittle phrase denylist, user-stated-scope outer bound, s8 carve-out, DESIGN_SPEC.md tiebreaker, lockstep pointer-file update, upstream critic-prompt addendum, "note it" -> "file an issue" refinement, pointer-file trim broadening); 4 set aside; 2 out of scope. Full plan + dispositions in session `plan.md`.

## Bias acknowledgment

Twice in this session I picked the smaller option when the bigger one was right (lockstep pointer-file edits instead of trimming; then anchoring on `copilot-instructions.md` as the template instead of questioning whether that file itself was the right shape). Both were bias-confirmations of the very rule being landed. User caught both. The final shape reflects the rule applied correctly.

## SemVer

No bump (process/documentation change only).

## Definition of Done

- [x] `npm run lint:all` passes (root + api -- ascii / spec-patterns / prod-patterns / csp / swa / lockfile / sentinel / tree-row-grid / prettier / reduced-motion / api tsc -- all OK).
- [x] No code/behavior change -- tests and build unaffected.
- [x] `DESIGN_SPEC.md` unchanged (no spec impact).
- [x] `why-jotjson.md` unchanged (no user-facing feature change).
- [x] Telemetry decision: no event added (process change).
- [x] SemVer decision: no bump.

---
**Session**
- AI-Local: `3c470017-4a86-4731-957b-00c5e10b495b`
- AI-Cloud: `9096f37a-a68c-489d-ab7b-082394188e22`
