### PR TITLE
Size Inspect-string-value dialog to content with 90vw cap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.28.3",
+      "version": "0.28.4",
       "dependencies": {
         "@angular/animations": "^21.2.12",
         "@angular/cdk": "^21.2.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.28.3",
+  "version": "0.28.4",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/shared/components/json-tree/decoded-value-dialog/decoded-value-dialog.component.scss
+++ b/src/app/shared/components/json-tree/decoded-value-dialog/decoded-value-dialog.component.scss
@@ -26,9 +26,18 @@
 .decoded-title__path {
   flex: 1 1 auto;
   min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  // The dialog auto-sizes to content (see the dialog.open() comment in
+  // json-tree.component.ts -> openDecodedDialog). A `white-space:
+  // nowrap` path with `min-width: 0` only shrinks when the parent
+  // imposes a width constraint -- which the auto-sized dialog does
+  // not -- so a long path would otherwise become the dialog's
+  // width-driver and produce the exact "wide dialog with narrow body"
+  // we are trying to eliminate. Wrap the path instead so the body
+  // (or actions row) drives width. `break-all` handles paths without
+  // natural break points (UUIDs, long array indices). The full path
+  // remains available verbatim via the `matTooltip` on the span.
+  white-space: normal;
+  word-break: break-all;
   font-family: var(--font-mono, ui-monospace, SFMono-Regular, Menlo, Consolas, monospace);
   font-size: 13px;
   color: var(--mat-sys-on-surface-variant, #aeb6c2);

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -6055,7 +6055,7 @@ describe('JsonTreeComponent', () => {
     });
 
     describe('opening the dialog', () => {
-      it('pill click opens with viewport-relative width matching the v0.23.1 tooltip principle', async () => {
+      it('pill click opens with content-sized width capped at 90vw, mirroring the height behavior', async () => {
         await createWith({ note: 'first\nsecond' });
         cmp.expandAll();
         fixture.detectChanges();
@@ -6063,16 +6063,21 @@ describe('JsonTreeComponent', () => {
         decodedButtonFor('$.note')!.click();
         fixture.detectChanges();
         expect(open).toHaveBeenCalledTimes(1);
-        // jasmine.objectContaining guards intent without freezing the
-        // shape of the config object: future PRs may add panelClass /
-        // restoreFocus / other MatDialogConfig keys, and this
-        // assertion should keep firing on the dimensions only. The
-        // sibling `jj-tooltip-wide` rule in `src/styles/_material.scss`
-        // uses `max-width: 90vw` for the same reasoning.
-        expect(open).toHaveBeenCalledWith(
-          DecodedValueDialogComponent,
-          jasmine.objectContaining({ width: '90vw', maxWidth: '95vw' }),
-        );
+        // Two explicit assertions instead of `jasmine.objectContaining`:
+        // the latter only checks listed keys and does NOT assert
+        // absence, so a future PR re-introducing `width: '90vw'`
+        // would silently satisfy `objectContaining({ maxWidth: '90vw' })`
+        // and re-introduce the "narrow content, wide dialog" bug.
+        // Pinning `config.width` to `undefined` plus `config.maxWidth`
+        // to `'90vw'` matches the intent: content-sized, capped at
+        // 90vw (the same model the `.jj-tooltip-wide` rule in
+        // `src/styles/_material.scss` uses).
+        const config = open.calls.mostRecent().args[1] as {
+          width?: string;
+          maxWidth?: string;
+        };
+        expect(config.width).toBeUndefined();
+        expect(config.maxWidth).toBe('90vw');
       });
 
       it('pill click opens without extractCandidate when the row is not extractable', async () => {

--- a/src/app/shared/components/json-tree/json-tree.component.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.ts
@@ -3410,19 +3410,30 @@ export class JsonTreeComponent {
       DecodedValueDialogResult
     >(DecodedValueDialogComponent, {
       data,
-      // Viewport-relative width follows the v0.23.1 tree-value tooltip
-      // approach in `src/styles/_material.scss` (the `.jj-tooltip-wide`
-      // surface uses `max-width: 90vw` and rejects fixed pixel caps).
-      // Tooltips and this dialog are two tiers of viewer for the same
-      // content kind (long monospace strings); the dialog is the
-      // committed-inspection mode, so the same percentage-only rule
-      // applies here. Other MatDialog callers in this app (history,
-      // blobs, formatting-rules, etc.) keep their fixed `420px` form
-      // dialogs; this pattern is specific to dialogs rendering
-      // pre-wrap monospace user content where horizontal real estate
-      // matters.
-      width: '90vw',
-      maxWidth: '95vw',
+      // Width sizes to content with `max-width: 90vw` as the cap,
+      // mirroring the height model (`max-height: 70vh; overflow: auto`
+      // on `.decoded-content`). This aligns the dialog with the
+      // `.jj-tooltip-wide` rule in `src/styles/_material.scss` (which
+      // also uses `max-width: 90vw` and no fixed `width`); tooltips
+      // and this dialog are two tiers of viewer for the same content
+      // kind (long monospace strings), so they share the cap-only
+      // sizing model. Prior versions (<= v0.23.x) pinned `width:
+      // '90vw'`, which made narrow escaped strings render in a very
+      // wide dialog.
+      //
+      // Floor note: Material 21's M3 dialog tokens still impose
+      // `min-width: 280px` on `.cdk-overlay-pane.mat-mdc-dialog-panel`
+      // via `--mat-dialog-container-min-width` (see
+      // `node_modules/@angular/material/dialog/_m3-dialog.scss:21`).
+      // We do not override that token here because the action row's
+      // intrinsic width (Copy + Close ~= 330px; Extract + Copy +
+      // Close ~= 450px) is always wider than 280px, so the M3 floor
+      // never effectively bites for this dialog. Other MatDialog
+      // callers (history, blobs, formatting-rules, etc.) keep their
+      // fixed `420px` form-dialog widths; this content-sized pattern
+      // is specific to viewers rendering pre-wrap monospace user
+      // content where horizontal real estate matters.
+      maxWidth: '90vw',
       autoFocus: 'dialog',
     });
     dialogRef


### PR DESCRIPTION
The Inspect string value dialog (`DecodedValueDialogComponent`) was opened with a fixed `width: '90vw'`, so even narrow escaped strings rendered in a very wide dialog. The height already auto-sizes (capped at `max-height: 70vh` via `.decoded-content`); make the width follow the same pattern.

## Repro

Open a row with a short escaped value (e.g., a single-line POST header string ~70 chars). Before this change the dialog renders at ~90vw regardless of content. After: the dialog sizes to the natural width of the content, capped at 90vw.

## Changes

- **`json-tree.component.ts` (`openDecodedDialog`)** — drop `width: '90vw'`; tighten `maxWidth: '95vw'` -> `maxWidth: '90vw'`. Rewrite the surrounding comment to document the cap-only sizing model (now aligned with the `.jj-tooltip-wide` rule in `_material.scss`) and the Material 21 M3 dialog `min-width: 280px` floor (from `_m3-dialog.scss:21`), which doesn't effectively bite because the action row's intrinsic width is always wider.
- **`decoded-value-dialog.component.scss`** — `.decoded-title__path` drops `nowrap` + `ellipsis` and wraps via `white-space: normal; word-break: break-all`. With the dialog auto-sizing, a `nowrap` path with `min-width: 0` has no parent constraint to shrink against and would otherwise re-create the wide-dialog-narrow-body bug for long paths. The full path is still surfaced verbatim via the existing `matTooltip` on the span.
- **`json-tree.component.spec.ts`** — rename the dialog-open test to `'pill click opens with content-sized width capped at 90vw, mirroring the height behavior'`. Replace `jasmine.objectContaining({ width: '90vw', maxWidth: '95vw' })` with two explicit checks: `expect(config.width).toBeUndefined()` and `expect(config.maxWidth).toBe('90vw')`. `objectContaining` only asserts listed keys (not absence), so a future PR re-introducing a fixed `width` would silently still satisfy the old form; the new form fails fast.
- **`package.json` / `package-lock.json`** — bump `0.28.3` -> `0.28.4` (patch; UX polish, no API/schema/stored-shape change).

## Behavior after

- Short content + short path -> dialog auto-sizes narrow.
- Long content (single very long unbroken token) -> hits 90vw cap, body wraps via existing `pre-wrap; word-break: break-word`.
- Long path + short body -> path wraps to multiple lines within the title; body+actions drive width.

## DoD

- `npm run verify:fast`: pass (2916 tests passed, 3 skipped).
- `npm run lint` (incl. lockfile + ASCII + prod/spec pattern gates + prettier): pass.

## Rubber-duck

Plan was rubber-ducked with `deep-review:skeptic` before implementation. Critic raised 4 issues + 3 edge cases + 2 suspicious patterns:

- **Adopted (6/6 material findings):** Material 21 M3 `min-width: 280px` floor (documented in code comment); long-path forces width when `nowrap` (fixed via SCSS); `jasmine.objectContaining` doesn't pin absence (replaced with explicit assertions); stale test name (renamed); tooltip-principle realignment framing (folded into comment rewrite); plan's elision of M3 token system (addressed via floor doc).
- **Set aside (3):** Extract-button width delta (acceptable UX variance), scrollbar-gutter at the wrap threshold (same condition exists for height today without complaints), tall-narrow viewport paint sequence (no regression vs. current).
- **Out of scope:** overriding the M3 `--mat-dialog-container-min-width` token (cross-dialog blast radius; the 280px floor doesn't bite here).

---
**Session**
- AI-Local: `8fa9e10f-b265-471a-a925-bc3742333774`
- AI-Cloud: `ae31aefa-0970-48f4-b1fd-8bd7dc44e064`
