### PR TITLE
Fix CD freshness check: remove orphaned --expected-sha flag

### DIFF
--- a/.github/workflows/cd-nonprod.yml
+++ b/.github/workflows/cd-nonprod.yml
@@ -239,7 +239,7 @@ jobs:
       - name: Check deploy freshness
         if: ${{ success() && steps.deploy_swa.outcome == 'success' }}
         timeout-minutes: 10
-        run: npm run check:deploy-freshness -- --expected-sha=${{ github.sha }} --origin=${{ vars.NONPROD_DEPLOY_REDIRECT_URI }}
+        run: npm run check:deploy-freshness -- --origin=${{ vars.NONPROD_DEPLOY_REDIRECT_URI }}
 
       - name: Summary
         if: ${{ always() && !cancelled() }}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -393,5 +393,17 @@ jobs:
       - name: Check deploy freshness
         if: ${{ success() && steps.deploy_swa.outcome == 'success' }}
         timeout-minutes: 10
-        run: npm run check:deploy-freshness -- --expected-sha=${{ github.sha }} --origin=https://jotjson.com
+        # NOTE: Do not re-add --expected-sha=${{ github.sha }} -- in
+        # workflow_run context `github.sha` resolves to the
+        # default-branch HEAD at trigger time, NOT the built SHA
+        # (which is `workflow_run.head_sha`, used at line 105 above).
+        # The current freshness check verifies edge propagation via
+        # byte-match against the locally-built `dist/jotjson/browser/sw.js`.
+        # That match is structural, not SHA-tied: `src/sw.worker.ts`
+        # has no per-commit values, so the SW bytes are deterministic
+        # across commits that don't touch SW source. Restoring true
+        # SHA-tied verification needs a build-time SHA marker that the
+        # script can probe (e.g., a generated `/build-info.json`).
+        # Tracked as a follow-up issue (see PR description).
+        run: npm run check:deploy-freshness -- --origin=https://jotjson.com
 

--- a/scripts/check-deploy-freshness.test.mjs
+++ b/scripts/check-deploy-freshness.test.mjs
@@ -78,6 +78,19 @@ test('parseCliOptions rejects non-https origins', () => {
   );
 });
 
+test('parseCliOptions rejects unknown arguments', () => {
+  // Regression test for the post-PR-#330 CI break: the workflow
+  // callsites were passing `--expected-sha=<sha>`, but the script's
+  // strict `requireNoUnknownArgs` rejects anything outside `--origin`
+  // / `--local-sw`. Asserting the rejection prevents a future
+  // re-introduction of unknown flags from going unnoticed at PR-review
+  // time. See `.github/workflows/cd.yml` -- "Check deploy freshness".
+  assert.throws(
+    () => parseCliOptions(['--expected-sha=abc123', '--origin=https://example.com'], {}),
+    /Unknown argument '--expected-sha=abc123'/,
+  );
+});
+
 test('waitForPropagation retries until the SW body byte-matches', async () => {
   const fetchUrls = [];
   const delays = [];


### PR DESCRIPTION
## Summary

Fixes `Check deploy freshness` step failing on every Deploy (SWA) run on `main` after PR #330 merged. The Azure SWA upload itself succeeded (production has the new SW; verified via `https://jotjson.com/sw.js` `Last-Modified: Tue, 19 May 2026 22:03:55 GMT`), but the post-deploy verification step errors out with:

```
check-deploy-freshness: Unknown argument '--expected-sha=2b1704cb...'. Valid options: --origin, --local-sw.
```

Root cause: PR #330 rewrote `scripts/check-deploy-freshness.mjs` to verify SW propagation via byte-match against the locally-built `dist/jotjson/browser/sw.js`, replacing the prior `appData.buildSha === expectedSha` manifest probe. Both workflow callsites (`cd.yml:396`, `cd-nonprod.yml:242`) were not updated to match, leaving `--expected-sha=${{ github.sha }}` in the invocation. The script's strict `requireNoUnknownArgs` rejects unknown flags.

## What this PR does (stop-the-bleed)

- **`.github/workflows/cd.yml:396`**: drop `--expected-sha=...`.
  Add inline comment warning future contributors that `github.sha`
  in `workflow_run` context resolves to the default-branch HEAD at
  trigger time (not the built SHA, which is `workflow_run.head_sha`,
  used at `cd.yml:105`). Comment also documents the structural-only
  nature of the current byte-match (see "Verification gap accepted"
  below) and cross-links the follow-up issue.
- **`.github/workflows/cd-nonprod.yml:242`**: drop `--expected-sha=...`.
  No comment needed -- this workflow is `workflow_dispatch` only,
  so the `workflow_run`/`github.sha` race doesn't apply.
- **`scripts/check-deploy-freshness.test.mjs`**: add regression
  test asserting `parseCliOptions` rejects an unknown
  `--expected-sha` argument. Prevents this exact regression from
  going unnoticed at PR-review time.

## What this PR does NOT do

Per AGENTS.md §9 (Scope Discipline) and §11 (anti-creep), this PR deliberately does not:

- Add `--expected-sha` parsing back to the script.
- Add a generated `/build-info.json` route for SHA verification.
- Add bundle-parsing of `main-*.js` to extract embedded SHA.
- Reformat the freshness script or its tests.

All of these are tracked in the follow-up issue below.

## Verification gap accepted

The skeptic panel (`deep-review:skeptic`) flagged a real flaw the advocate + architect both missed: **the byte-match propagation check is NOT SHA-tied**. `src/sw.worker.ts` has zero per-commit interpolation (verified: no `sha`, `buildNumber`, `commit`, `version`, `BUILD_INFO`, or `process.env` reference). `build-sw.mjs` emits a deterministic transpile. `check-sw-shape.mjs` locks the source bytes to `EXPECTED_SW_SOURCE_SHA256`. Therefore `dist/jotjson/browser/sw.js` is byte-identical across every commit that does not touch the SW source.

For non-SW-touching deploys, the freshness probe matches whatever bytes are already at the edge -- even if SWA's upload silently no-op'd or rolled back. The gate no longer catches the failure mode PR #226 originally designed it for.

This PR **explicitly accepts that gap** to un-red CI. Restoring true SHA-tied verification (via a generated, HTTP-fetchable `/build-info.json`) is tracked as #336.

## Definition of Done

- [x] `npm run test:scripts` passes (307 tests, +1 regression).
- [x] `npm run lint:all` passes (root + api workspace).
- [ ] CI green on this PR.
- [ ] After merge: next push-to-main triggers Deploy (SWA);
      `Check deploy freshness` step shows green.
- [ ] Manual `workflow_dispatch` on `cd-nonprod.yml` (low risk,
      nonprod) shows green `Check deploy freshness`.

## SemVer bump

**None.** Workflow + test-only changes; no user-facing change, no API change.

## Follow-up issue

#336 -- restore SHA-tied post-deploy verification via a generated `/build-info.json` probe. P1, tech-debt, ci.

---
**Session**
- AI-Local: `25b50f60-d9d0-4d79-a76c-2fadb6198c6d`
- AI-Cloud: `978814d5-4b96-4f59-92e4-064dc846b71b`
