### PR TITLE
Release v1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "0.30.0",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "0.30.0",
+      "version": "1.0.0",
       "dependencies": {
         "@angular/animations": "^21.2.14",
         "@angular/cdk": "^21.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "0.30.0",
+  "version": "1.0.0",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {


### PR DESCRIPTION
# Release v1.0.0

The v1.0.0 cutover. Per [`DESIGN_SPEC.md` Versioning line 2031](https://github.com/geevensingh/jotjson/blob/main/DESIGN_SPEC.md#versioning), v1.0.0 is explicitly a major bump and a user call. The pre-1.0 carve-out (lines 2034-2039) ends with this PR -- going forward, breaking changes to **share-link URL formats** or **stored data shapes** bump major. Everything else (internal HTTP API, telemetry shape, headers, route paths) continues to ship freely.

## v1 readiness checklist

- [x] Zero open `priority:high` issues.
- [x] Zero open `priority:medium` v1-shipped-feature bugs.
- [x] All M1-M8 milestones complete except M7o (BYO Functions; explicitly deferred post-v1).
- [x] Pre-v1 readiness review: every item strikethrough.
- [x] CD pipeline freshness-gated (#349) and pin-aware nonprod auto-deploy (#342) live and soaked through recent Angular + material group bumps.
- [x] Service-worker cohort drain in flight (#330 + #339 backfill).
- [x] DoD locally green: `lint:all` pass, api 465/465 Jest pass, web 2971/2971 Jasmine pass, production `build` pass.

## Scope

- One root `package.json` version flip: `0.30.0` -> `1.0.0`.
- Mirrored lockfile refresh (4-line diff: root `version` + `packages.""` mirror, no transitive upgrades).

## Out of scope (deliberate)

- `api/package.json` (independent versioning; stays at 0.1.1).
- `DESIGN_SPEC.md` / `why-jotjson.md` / `CHANGELOG.md` text changes.
- Dependabot follow-ons -- none currently open.

## Post-merge follow-ups (separate work)

- Tag `v1.0.0` on the merge commit; backfill annotated tags for `v0.17.0` through `v0.30.0`.
- Cut a GitHub Release for v1.0.0 with a minimal SemVer-policy intro that links to [`why-jotjson.md`](https://github.com/geevensingh/jotjson/blob/main/why-jotjson.md) for the product pitch.
- Watch the freshness gate on deploy.

---
**Session**
- AI-Local: `8acd3d28-b72c-4a69-b413-a2825488489b`
- AI-Cloud: `022d9dab-b951-4550-b1cd-d02a257eebeb`
