### PR TITLE
Fix #365: preserve __proto__ keys via null-prototype parsed objects

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "dependencies": {
         "@angular/animations": "^21.2.14",
         "@angular/cdk": "^21.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/src/app/core/json/parse.spec.ts
+++ b/src/app/core/json/parse.spec.ts
@@ -51,6 +51,68 @@ describe('parse (pure)', () => {
     });
   });
 
+  describe('issue #365: __proto__ preservation', () => {
+    it('retains __proto__ as an own enumerable key', () => {
+      const result = parse('{"__proto__":1,"a":2}');
+      expect(result.errors).toEqual([]);
+      const value = result.value as Record<string, unknown>;
+      expect(Object.keys(value)).toEqual(['__proto__', 'a']);
+      expect(Object.prototype.hasOwnProperty.call(value, '__proto__')).toBe(true);
+      expect(value['__proto__']).toBe(1);
+      expect(value['a']).toBe(2);
+    });
+
+    it('retains __proto__ in nested objects', () => {
+      const result = parse('{"outer":{"__proto__":1}}');
+      const outer = (result.value as { outer: Record<string, unknown> }).outer;
+      expect(Object.keys(outer)).toEqual(['__proto__']);
+      expect(outer['__proto__']).toBe(1);
+    });
+
+    it('retains __proto__ in nested array elements', () => {
+      const result = parse('{"a":[{"__proto__":1}]}');
+      const inner = (result.value as { a: Record<string, unknown>[] }).a[0];
+      expect(Object.keys(inner)).toEqual(['__proto__']);
+      expect(inner['__proto__']).toBe(1);
+
+      const arrayRoot = parse('[{"__proto__":1}]').value as Record<string, unknown>[];
+      expect(Object.keys(arrayRoot[0])).toEqual(['__proto__']);
+      expect(arrayRoot[0]['__proto__']).toBe(1);
+    });
+
+    it('retains __proto__: null as a data property without setting the prototype', () => {
+      const result = parse('{"__proto__":null}');
+      const value = result.value as Record<string, unknown>;
+      expect(value['__proto__']).toBeNull();
+      // The recipient uses `Object.create(null)`, so the prototype is
+      // already null; the JSON value `null` lands as an own data
+      // property and does not "re-set" any prototype chain.
+      expect(Object.getPrototypeOf(value)).toBeNull();
+    });
+
+    it('round-trips __proto__ through JSON.stringify', () => {
+      const result = parse('{"__proto__":1,"a":2}');
+      expect(JSON.stringify(result.value)).toBe('{"__proto__":1,"a":2}');
+    });
+
+    it('pins Jasmine deep-equality across plain vs null prototype', () => {
+      // Regression guard for skeptic finding H1 (issue #365 plan).
+      // `parseResult().value` returns null-prototype objects after
+      // the #365 fix; existing specs at home.component.spec.ts:1020
+      // and :1147 use `expect(...).toEqual({ ... })` with plain-object
+      // literal expectations. Jasmine 6.2's `eq_` short-circuits the
+      // constructor-mismatch gate when either constructor is
+      // `undefined` (which is the case for null-prototype objects).
+      // Mirror that exact pattern -- a null-prototype LHS deep-equal
+      // to a plain object literal RHS -- so a future Jasmine upgrade
+      // that tightens the gate fails this spec first instead of
+      // breaking the broader suite silently.
+      const result = parse('{"seed":2}');
+      expect(Object.getPrototypeOf(result.value)).toBeNull();
+      expect(result.value).toEqual({ seed: 2 });
+    });
+  });
+
   describe('JSONC extensions', () => {
     it('accepts // and /* */ comments and surfaces commentCount', () => {
       const result = parse(`{

--- a/src/app/core/json/parse.spec.ts
+++ b/src/app/core/json/parse.spec.ts
@@ -98,15 +98,20 @@ describe('parse (pure)', () => {
     it('pins Jasmine deep-equality across plain vs null prototype', () => {
       // Regression guard for skeptic finding H1 (issue #365 plan).
       // `parseResult().value` returns null-prototype objects after
-      // the #365 fix; existing specs at home.component.spec.ts:1020
-      // and :1147 use `expect(...).toEqual({ ... })` with plain-object
-      // literal expectations. Jasmine 6.2's `eq_` short-circuits the
-      // constructor-mismatch gate when either constructor is
-      // `undefined` (which is the case for null-prototype objects).
-      // Mirror that exact pattern -- a null-prototype LHS deep-equal
-      // to a plain object literal RHS -- so a future Jasmine upgrade
-      // that tightens the gate fails this spec first instead of
-      // breaking the broader suite silently.
+      // the #365 fix; existing specs in home.component.spec.ts --
+      // notably "onValueChange does not update treePaneInputs
+      // synchronously when editor is non-empty" and "onFormat
+      // preserves the existing parseResult shape so tree selection
+      // can survive", plus any other spec that uses
+      // `expect(...parseResult().value).toEqual({ ... })` with a
+      // plain-object literal -- depend on this equivalence.
+      // Jasmine 6.2's `eq_` short-circuits the constructor-mismatch
+      // gate when either constructor is `undefined` (which is the
+      // case for null-prototype objects). Mirror that exact pattern
+      // here -- a null-prototype LHS deep-equal to a plain object
+      // literal RHS -- so a future Jasmine upgrade that tightens
+      // the gate fails this spec first instead of breaking the
+      // broader suite silently.
       const result = parse('{"seed":2}');
       expect(Object.getPrototypeOf(result.value)).toBeNull();
       expect(result.value).toEqual({ seed: 2 });

--- a/src/app/core/json/parse.ts
+++ b/src/app/core/json/parse.ts
@@ -161,6 +161,27 @@ function toError(parseError: ParseError, originalText: string, bomShift: number)
   };
 }
 
+/**
+ * Returns a freshly-allocated object for use as a parsed-JSON object
+ * recipient.
+ *
+ * Uses `Object.create(null)` (no prototype) so that assignments to
+ * any key whose name collides with an inherited `Object.prototype`
+ * setter create an own enumerable data property rather than
+ * invoking the setter. The motivating key is `__proto__`: with a
+ * plain `{}` recipient, `obj['__proto__'] = value` invokes
+ * `Object.prototype.__proto__`'s setter and the key vanishes from
+ * the returned object, silently dropping user data (see issue #365).
+ *
+ * **Invariant**: all future code that reconstructs a parsed-JSON-
+ * shaped object (e.g. a key-sort pass on `parseResult().value`)
+ * MUST use this helper to preserve the round-trip. Allocating a
+ * plain `{}` and copying keys re-introduces the bug.
+ */
+export function createJsonObject(): Record<string, unknown> {
+  return Object.create(null);
+}
+
 function nodeToValue(node: JsoncNode): unknown {
   switch (node.type) {
     case 'null':
@@ -172,7 +193,7 @@ function nodeToValue(node: JsoncNode): unknown {
     case 'array':
       return (node.children ?? []).map((c) => nodeToValue(c));
     case 'object': {
-      const obj: Record<string, unknown> = {};
+      const obj = createJsonObject();
       for (const prop of node.children ?? []) {
         const [keyNode, valueNode] = prop.children ?? [];
         if (keyNode && valueNode) {

--- a/src/app/core/title-suggester/title-suggester.service.spec.ts
+++ b/src/app/core/title-suggester/title-suggester.service.spec.ts
@@ -166,6 +166,30 @@ describe('TitleSuggesterService', () => {
       const result = service.suggest(inputFor('{"name":"foo","version":"1.0"}', 'random.json'));
       expect(result.find((c) => c.source === 'packageJson')).toBeUndefined();
     });
+
+    it('handles null-prototype parsed inputs (#365 regression guard)', () => {
+      // Production parser (`JsonParserService.parse`) returns
+      // null-prototype objects after the #365 fix. `JSON.parse`
+      // (used by `inputFor` above) returns plain-prototype
+      // objects, so the existing tests do not exercise the
+      // null-prototype path. Construct one directly and verify
+      // the strategies (isPlainObject + Object.prototype.
+      // hasOwnProperty.call) still work end-to-end.
+      const parsed: Record<string, unknown> = Object.create(null);
+      parsed['name'] = 'jotjson';
+      parsed['version'] = '0.5.0';
+      const scripts: Record<string, unknown> = Object.create(null);
+      scripts['build'] = '';
+      parsed['scripts'] = scripts;
+      const result = service.suggest({
+        jsonText: JSON.stringify(parsed),
+        parsed,
+        hasParseErrors: false,
+        filename: null,
+      });
+      const entry = result.find((c) => c.source === 'packageJson');
+      expect(entry?.value).toBe('jotjson@0.5.0');
+    });
   });
 
   describe('kubernetes strategy', () => {

--- a/src/app/features/home/home.component.spec.ts
+++ b/src/app/features/home/home.component.spec.ts
@@ -533,6 +533,26 @@ describe('HomeComponent (unit-level)', () => {
     expect(fixture.componentInstance.content()).toBe(broken);
   });
 
+  it('onMinify preserves __proto__ keys (#365)', () => {
+    const fixture = TestBed.createComponent(HomeComponent);
+    fixture.componentInstance.content.set('{\n  "__proto__": 1,\n  "a": 2\n}');
+    fixture.componentInstance.onMinify();
+    expect(fixture.componentInstance.content()).toBe('{"__proto__":1,"a":2}');
+  });
+
+  it('onFormat preserves __proto__ keys (#365 regression guard)', () => {
+    // Format is text-based via jsoncFormat + applyEdits, not via
+    // `parseResult().value`, so it never went through the
+    // null-prototype recipient bug. This spec locks that behavior
+    // in so a future Format refactor through the parsed value
+    // does not silently re-introduce the bug.
+    const fixture = TestBed.createComponent(HomeComponent);
+    fixture.componentInstance.content.set('{"__proto__":1,"a":2}');
+    fixture.componentInstance.onFormat();
+    expect(fixture.componentInstance.content()).toContain('"__proto__"');
+    expect(fixture.componentInstance.content()).toContain('"a"');
+  });
+
   it('onCopy writes the editor text to the clipboard', async () => {
     const fixture = TestBed.createComponent(HomeComponent);
     fixture.componentInstance.content.set('{"a":1}');

--- a/src/app/shared/components/json-tree/build-tree.spec.ts
+++ b/src/app/shared/components/json-tree/build-tree.spec.ts
@@ -72,6 +72,25 @@ describe('buildTree (pure)', () => {
     expect(buildTree({}).nodeCount).toBe(1);
     expect(buildTree([]).nodeCount).toBe(1);
   });
+
+  it('includes __proto__ as a child node when present in the parsed value (#365)', () => {
+    // Regression guard for issue #365: `nodeToValue` uses
+    // `Object.create(null)` so `__proto__` is an own enumerable
+    // key on the parsed value. `buildChildren` must surface it
+    // as a normal tree row. Constructed directly with
+    // `Object.create(null)` + bracket assignment to mirror what
+    // `parse('{"__proto__":1,"a":2}').value` returns without
+    // taking a cross-module dependency here.
+    const parsed: Record<string, unknown> = Object.create(null);
+    parsed['__proto__'] = 1;
+    parsed['a'] = 2;
+    const result = buildTree(parsed);
+    expect(result.root.children?.map((c) => c.segment)).toEqual(['__proto__', 'a']);
+    const protoNode = result.root.children?.[0] as TreeNode;
+    expect(protoNode.value).toBe(1);
+    expect(protoNode.type).toBe('number');
+    expect(protoNode.pathString).toBe('$.__proto__');
+  });
 });
 
 describe('buildChildren / buildNode', () => {


### PR DESCRIPTION
## Summary

Fixes #365. `nodeToValue` allocated a plain `{}` recipient, so an `obj['__proto__']` assignment invoked `Object.prototype`'s `__proto__` setter rather than creating an own property. The key was silently dropped from `parseResult().value`, which made:

- **Minify** drop the key from its `JSON.stringify` output, and
- the **JsonTree** miss the row entirely (`Object.keys` returned nothing).

`Format` was never affected (text-based via `jsoncFormat` + `applyEdits`); the new spec is a regression guard.

## Fix

Introduce an exported `createJsonObject()` helper in `parse.ts` returning `Object.create(null)`, and use it as the `nodeToValue` recipient. The helper's JSDoc documents the invariant for any future code that reconstructs parsed-JSON-shaped objects (e.g. #361's eventual sort path), so the bug cannot silently re-appear at the next call site.

## Tests

10 new specs across 4 files:

- `parse.spec.ts` (6 tests): own-key retention, nested-object, nested-array-element, `__proto__: null` edge case, `JSON.stringify` round-trip, **Jasmine deep-equality pin** (regression guard against future Jasmine versions tightening the constructor-mismatch gate -- the H1 finding from the rubber-duck review).
- `build-tree.spec.ts` (1 test): tree renders the `__proto__` child row.
- `home.component.spec.ts` (2 tests): `onMinify` preserves the key; `onFormat` regression guard.
- `title-suggester.service.spec.ts` (1 test): strategies handle null-prototype parsed inputs end-to-end (the existing `inputFor` uses `JSON.parse`, which returns plain objects, so the existing coverage didn't exercise the production path after the fix).

## Verification (Definition of Done)

- `npm run lint:all`: PASS (lockfile drift caught and synced on first run).
- `npm test`: **2981 / 2982 SUCCESS** (1 pre-existing skip; H1 Jasmine-equality concern empirically refuted -- every existing `toEqual(parseResult().value)` keeps passing).
- `npm --prefix api test`: **465 / 465 SUCCESS**.
- `npm run build`: PASS (1.01 MB initial bundle).
- **Perf gate** (`perf:l1` before/after on the same machine): **zero regressions exceeding 5%**. `parse.deep25.10k` -46.0% and `parse.mixed-d10.380k` -25.3% (faster, likely V8 dictionary-mode allocation tradeoff or first-run noise). All build-tree deltas within +/-5%. No fallback to Option B needed.

## SemVer

Patch bump `1.0.0` -> `1.0.1`. Bug fix restoring intended behavior on an edge-case input; no API or stored-shape change.

## Alternatives considered

- **Option B**: `Object.defineProperty` for `__proto__` only -- conditionally rejected. Kept as the fallback if perf measurement showed regression; perf cleared, so unused.
- **Option C**: filter `__proto__` keys at parse time -- rejected. That IS the current broken behavior.

## Closes

Closes #365.

---
**Session**
- AI-Local: `ecea1723-9daa-4144-9ffa-6ed6445df083`
- AI-Cloud: `24f96145-9ead-44d9-9a60-b051a50d79f9`


