### PR TITLE
Make three-agent panel the required rubber-duck configuration

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1297,18 +1297,27 @@ ran) and ask whether to revert, follow-up-fix, or accept.
     **three-agent panel**: `deep-review:skeptic` (attack mindset)
     + `deep-review:advocate` (defense mindset)
     + `deep-review:architect` (direction mindset), invoked in
-    parallel on every plan presented to the user. **There is no
-    non-panel mode.** Token and wall-clock cost are explicitly
-    accepted as the price of catching the failure modes a solo
-    critic misses (over-adoption of one perspective, missed
-    direction concerns, missed defense rebuttals). `general-purpose`
-    is permitted **only** to substitute for one missing
-    `deep-review:*` agent in a runtime that lacks it, and its prompt
-    must be explicitly adversarial and explicitly take the missing
-    role. **`explore` is not a critic** -- it is a research agent;
-    do not use it for rubber-duck. **`deep-review:advocate` remains
-    forbidden as a solo critic**: its role is to defend, so a
-    solo-advocate gate is not adversarial.
+    parallel on every plan presented to the user. **The default
+    is panel-only**; solo, paired, or otherwise reduced panels
+    are not permitted as a default. A reduced panel is allowed
+    only as the explicit failure-mode exception documented in
+    "Panelist failure is not a fallback" below, and that
+    exception requires user authorization in the same turn.
+    Token and wall-clock cost are explicitly accepted as the
+    price of catching the failure modes a solo critic misses
+    (over-adoption of one perspective, missed direction concerns,
+    missed defense rebuttals). `general-purpose` is permitted to
+    substitute for **at most one** missing `deep-review:*` agent
+    in a runtime that lacks it, and its prompt must be explicitly
+    adversarial and explicitly take the missing role. If two or
+    more `deep-review:*` agents are unavailable, do not present
+    the plan; surface the situation to the user and require
+    explicit authorization for the substitute configuration (the
+    same "reduced panel" exception above). **`explore` is not a
+    critic** -- it is a research agent; do not use it for
+    rubber-duck. **`deep-review:advocate` remains forbidden as a
+    solo critic**: its role is to defend, so a solo-advocate gate
+    is not adversarial.
 
   - **Critic prompt requirements.** The prompt must (a) include
     explicit adversarial framing ("find at least one weakness; if
@@ -1335,17 +1344,20 @@ ran) and ask whether to revert, follow-up-fix, or accept.
     generation, no matter how rigorous, does not satisfy this
     rule under any circumstance.
 
-  - **Quote findings in full.** Quote each panelist's findings
-    verbatim in the plan; do not paraphrase, do not elide, do not
-    truncate. If a panelist's output is unwieldy (over ~1500 chars),
-    save the full transcript as `plan.critic-<role>.md` (where
+  - **Quote findings.** Each panelist's **full transcript** must
+    be preserved verbatim in `plan.critic-<role>.md` (where
     `<role>` is `skeptic`, `advocate`, or `architect`) alongside
-    `plan.md` and link from the gate section, but still inline a
-    full verbatim copy of the findings list. **Single-listing rule**:
-    list each distinct finding once under the panelist who raised it
-    most directly; if another panelist raised the same concern, note
-    it in the cross-critic synthesis (Agreements) rather than
-    re-listing.
+    `plan.md`; this is the per-panelist record and must not be
+    paraphrased, elided, or truncated. In the inline
+    `Pre-presentation gate` section, each *distinct* finding is
+    listed once under the panelist who raised it most directly,
+    **verbatim from that panelist's output** (the selected quote
+    must not be paraphrased, elided, or truncated). If another
+    panelist raised the same concern, note it in the cross-critic
+    synthesis (Agreements) by panelist name rather than re-listing
+    the finding text. This preserves the full per-panelist record
+    in the transcript files without ballooning the inline gate
+    with duplicate text.
 
   - **Tag each finding's disposition**: `ADOPT` (link to the plan
     section that was changed), `SET ASIDE` (one-line reason), or
@@ -1432,22 +1444,28 @@ ran) and ask whether to revert, follow-up-fix, or accept.
   - **Prompt**: <one-line summary, or "see plan.critic-skeptic.md">
   - **Conclusion**: <one-line, e.g. "12 findings raised" or
     "no material weaknesses found">
-  - **Findings**: (verbatim, one per bullet)
-    - <finding> -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
+  - **Findings**: (one bullet per distinct finding; finding text
+    quoted verbatim from this panelist's output, followed by
+    disposition + one-line reason)
+    - "<verbatim finding text>" -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
 
   ### Advocate
   - **Invocation**: <one-line summary>
   - **Prompt**: <one-line summary, or "see plan.critic-advocate.md">
   - **Conclusion**: <one-line>
-  - **Findings**: (verbatim, one per bullet)
-    - <finding> -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
+  - **Findings**: (one bullet per distinct finding; finding text
+    quoted verbatim from this panelist's output, followed by
+    disposition + one-line reason)
+    - "<verbatim finding text>" -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
 
   ### Architect
   - **Invocation**: <one-line summary>
   - **Prompt**: <one-line summary, or "see plan.critic-architect.md">
   - **Conclusion**: <one-line>
-  - **Findings**: (verbatim, one per bullet)
-    - <finding> -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
+  - **Findings**: (one bullet per distinct finding; finding text
+    quoted verbatim from this panelist's output, followed by
+    disposition + one-line reason)
+    - "<verbatim finding text>" -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
 
   ### Cross-critic synthesis
   - **Agreements**: <findings raised by 2+ panelists, listed once

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1293,17 +1293,22 @@ ran) and ask whether to revert, follow-up-fix, or accept.
     invocation, stop and tell the user; do not present plans from
     that runtime.
 
-  - **Critic selection.** Default solo critic: `deep-review:skeptic`
-    (attack mindset). `deep-review:architect` (direction mindset)
-    is permitted for direction-heavy plans. **`deep-review:advocate`
-    is forbidden as a solo critic** -- its role is to defend, not
-    attack. For plans that touch `AGENTS.md`, `DESIGN_SPEC.md`,
-    `staticwebapp.config.json`, auth, security, schema evolution,
-    or migrations, use the **three-agent panel** (`:skeptic`
-    + `:advocate` + `:architect`). `general-purpose` is permitted
-    only when no `deep-review:*` agent is available, and the prompt
-    must be explicitly adversarial. **`explore` is not a critic**
-    -- it is a research agent; do not use it for rubber-duck.
+  - **Critic selection.** The required configuration is the
+    **three-agent panel**: `deep-review:skeptic` (attack mindset)
+    + `deep-review:advocate` (defense mindset)
+    + `deep-review:architect` (direction mindset), invoked in
+    parallel on every plan presented to the user. **There is no
+    non-panel mode.** Token and wall-clock cost are explicitly
+    accepted as the price of catching the failure modes a solo
+    critic misses (over-adoption of one perspective, missed
+    direction concerns, missed defense rebuttals). `general-purpose`
+    is permitted **only** to substitute for one missing
+    `deep-review:*` agent in a runtime that lacks it, and its prompt
+    must be explicitly adversarial and explicitly take the missing
+    role. **`explore` is not a critic** -- it is a research agent;
+    do not use it for rubber-duck. **`deep-review:advocate` remains
+    forbidden as a solo critic**: its role is to defend, so a
+    solo-advocate gate is not adversarial.
 
   - **Critic prompt requirements.** The prompt must (a) include
     explicit adversarial framing ("find at least one weakness; if
@@ -1319,24 +1324,41 @@ ran) and ask whether to revert, follow-up-fix, or accept.
     during option weighing (see "Don't default to the minimal
     change" above).
 
-  - **Critic invocation failure is not a fallback.** If the critic
-    invocation times out, errors, or is refused, surface the
-    failure to the user and do not present the plan. Retry with a
-    different critic only after telling the user the first attempt
-    failed. Self-critique inline with plan generation, no matter
-    how rigorous, does not satisfy this rule under any
-    circumstance.
+  - **Panelist failure is not a fallback.** If any panelist's
+    invocation times out, errors, or is refused, retry that
+    panelist **once** with a fresh invocation. If the retry also
+    fails, surface the failure to the user with the panelist
+    role, the failure mode, and what the other panelists found,
+    and **require explicit user authorization** to present the
+    plan with a reduced panel. Do not silently degrade to a
+    two-agent or solo gate. Self-critique inline with plan
+    generation, no matter how rigorous, does not satisfy this
+    rule under any circumstance.
 
-  - **Quote findings in full.** Quote the critic's findings
+  - **Quote findings in full.** Quote each panelist's findings
     verbatim in the plan; do not paraphrase, do not elide, do not
-    truncate. If the critic output is unwieldy (over ~1500 chars),
-    save the full transcript as `plan.critic-<N>.md` alongside
+    truncate. If a panelist's output is unwieldy (over ~1500 chars),
+    save the full transcript as `plan.critic-<role>.md` (where
+    `<role>` is `skeptic`, `advocate`, or `architect`) alongside
     `plan.md` and link from the gate section, but still inline a
-    full verbatim copy of the findings list.
+    full verbatim copy of the findings list. **Single-listing rule**:
+    list each distinct finding once under the panelist who raised it
+    most directly; if another panelist raised the same concern, note
+    it in the cross-critic synthesis (Agreements) rather than
+    re-listing.
 
   - **Tag each finding's disposition**: `ADOPT` (link to the plan
     section that was changed), `SET ASIDE` (one-line reason), or
-    `OUT OF SCOPE` (one-line reason).
+    `OUT OF SCOPE` (one-line reason). **For findings tagged
+    `SET ASIDE` or `OUT OF SCOPE` that propose scope separation**
+    (split into multiple PRs, defer to a follow-up issue, exclude
+    from the current change), the one-line reason must reference
+    a substantive architectural property (module boundary, stored
+    shape, dependency direction, release cadence, code-owner
+    separation), not a tactical property (diff size, churn,
+    "smaller PR is easier to review"). This mirrors the
+    "Don't default to the minimal change" rule applied to critic
+    findings.
 
   - **Critic-vs-user-preference conflict.** When a finding
     materially contradicts a user choice already made, do not
@@ -1362,6 +1384,16 @@ ran) and ask whether to revert, follow-up-fix, or accept.
     preserved. Typo / formatting edits to the plan itself are
     exempt.
 
+  - **Anti-bundling.** Do **not** bundle unrelated changes into a
+    single plan to amortize the cost of the rubber-duck gate. If
+    two changes do not share a causal coupling (one's
+    implementation choice constrains the other, or one is a
+    necessary precondition for the other), they are separate
+    plans with separate gates. Bundling unrelated changes hides
+    findings and dilutes panelist attention. Causally-coupled
+    changes can be planned together but should still ship as
+    separate PRs unless the same file is touched by both.
+
   - **Borderline direct-command requests.** If you find yourself
     classifying a borderline request as a direct command to skip
     the rubber-duck gate, default to plan-and-rubber-duck. The
@@ -1377,8 +1409,12 @@ ran) and ask whether to revert, follow-up-fix, or accept.
   - **Independence is mechanical, not epistemic.** A sub-agent is
     the same model with separate context; that is enough to catch
     "I missed this because I was attached to my own plan", which
-    is the failure this rule fixes. For high-stakes plans use the
-    three-agent panel to broaden epistemic coverage.
+    is the failure this rule fixes. The three-agent panel
+    broadens epistemic coverage further by having three distinct
+    role framings (attack / defend / direct) examine the plan in
+    parallel -- the asymmetry between the framings is what makes
+    the panel materially stronger than a solo critic, not the
+    raw count of sub-agents.
 
   This step applies to plans you author; it does **not** apply to
   direct-command echoes, which are not plans.
@@ -1391,25 +1427,45 @@ ran) and ask whether to revert, follow-up-fix, or accept.
   ```
   ## Pre-presentation gate
 
-  - **Critic agent**: <agent_type> -- <one-line invocation summary>
-  - **Critic prompt**: <one-line summary, or "see plan.critic-<N>.md">
-  - **Critic conclusion**: <one-line, e.g. "15 findings raised" or
+  ### Skeptic
+  - **Invocation**: <one-line summary>
+  - **Prompt**: <one-line summary, or "see plan.critic-skeptic.md">
+  - **Conclusion**: <one-line, e.g. "12 findings raised" or
     "no material weaknesses found">
-  - **Findings adopted**:
-    - <finding> (-> changed: <plan section>)
-  - **Findings set aside**:
-    - <finding> -- <one-line reason>
-  - **Findings out of scope**:
-    - <finding> -- <one-line reason>
+  - **Findings**: (verbatim, one per bullet)
+    - <finding> -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
+
+  ### Advocate
+  - **Invocation**: <one-line summary>
+  - **Prompt**: <one-line summary, or "see plan.critic-advocate.md">
+  - **Conclusion**: <one-line>
+  - **Findings**: (verbatim, one per bullet)
+    - <finding> -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
+
+  ### Architect
+  - **Invocation**: <one-line summary>
+  - **Prompt**: <one-line summary, or "see plan.critic-architect.md">
+  - **Conclusion**: <one-line>
+  - **Findings**: (verbatim, one per bullet)
+    - <finding> -- <ADOPT | SET ASIDE | OUT OF SCOPE> -- <one-line>
+
+  ### Cross-critic synthesis
+  - **Agreements**: <findings raised by 2+ panelists, listed once
+    here with references to which panelists raised each>
+  - **Tensions**: <findings where panelists disagreed, with how
+    the tension was resolved>
+  - **Total distinct findings**: <N adopted, M set aside, K out
+    of scope>
   ```
 
   For inline plans, render the gate as a fenced block at the end of
   the message. For `plan.md`, render it as the file's last section
   (or append a new gate on plan revision, preserving prior gates).
   For `exit_plan_mode` content, render it as a trailing section
-  before exiting. The `Critic conclusion` line is required even when
-  the critic raised no material findings -- it disambiguates
-  "critic was silent" from "critic spoke and I adopted".
+  before exiting. The `Conclusion` line is required for each
+  panelist even when that panelist raised no material findings --
+  it disambiguates "panelist was silent" from "panelist spoke and
+  I adopted everything".
 - **User unavailability is never authorization to proceed.** If the
   runtime reports the user as away, busy, or unresponsive, that does
   not let you act on a guess. Ask the question anyway and wait. Do


### PR DESCRIPTION
Replaces the "default solo critic" rule with a required three-agent panel (skeptic + advocate + architect, invoked in parallel) for every plan presented to the user. Token and wall-clock cost are explicitly accepted as the price of catching the failure modes a solo critic misses.

## Why

A recent rubber-duck on issue #350 used `:skeptic` alone. Over-adoption of one perspective produced a ~5-day-of-work plan for what should have been a ~7-hour problem; only after the user pushed back did the over-adoption become visible. A panel of three asymmetric framings (attack / defend / direct) makes one-perspective over-adoption visible **at synthesis time**, before the plan reaches the user.

Per user direction: cost is not a concern. Correctness of the recommendation is.

## What changes (`AGENTS.md` §11)

- **Critic selection**: "default solo critic" -> "required three-agent panel". Panel is the default; reduced panel is the documented failure-mode exception (requires user authorization). `general-purpose` is permitted to substitute for at most one missing `deep-review:*` agent; 2+ missing requires user authorization. `:advocate` remains forbidden as a solo critic.
- **Panelist failure**: retry once; if the retry also fails, surface to the user and require explicit authorization for a reduced panel. No silent degradation to solo.
- **Quote findings**: full per-panelist transcripts preserved verbatim in `plan.critic-<role>.md`; inline gate uses single-listing rule (list each distinct finding once under the panelist who raised it most directly, verbatim from that panelist's output; duplicates noted in the cross-critic synthesis Agreements section).
- **Disposition rule update**: `SET ASIDE` / `OUT OF SCOPE` findings that propose scope separation must cite a substantive architectural reason (module boundary, stored shape, dependency direction, release cadence, code-owner separation), not a tactical one (diff size, churn). Mirrors "Don't default to the minimal change".
- **New anti-bundling rule**: do not bundle unrelated changes into a single plan to amortize gate cost. Causally-coupled changes can be planned together but should still ship as separate PRs unless they touch the same file.
- **Independence is mechanical**: rewritten to clarify that the panel is materially stronger because of role-framing asymmetry, not raw sub-agent count.
- **Gate template**: one structured block per panelist (Skeptic / Advocate / Architect) + cross-critic synthesis (Agreements, Tensions, Total distinct findings). Each finding bullet is the verbatim quote from the panelist, followed by disposition + reason.

## PR review feedback addressed

Four wording-precision threads (all from `copilot-pull-request-reviewer[bot]`) addressed in commit 57af138:

1. "There is no non-panel mode" previously contradicted the reduced-panel exception. Now explicit: panel-only is the default, reduced panel is the documented exception.
2. `general-purpose` substitution didn't cover the 2+ missing case. Now spelled out (do not present; require user authorization).
3. "Quote findings verbatim" + "single-listing dedup" conflicted. Now two scopes: full transcripts always preserved per panelist; inline gate uses single-listing with verbatim canonical quote.
4. Gate template "(verbatim)" bullets had disposition + reason mixed in. Now: finding text quoted verbatim, disposition + reason labeled as editorial.

## DoD

- [x] `npm run lint:ascii` -- pass
- [x] `npm run lint:format` -- pass
- [x] `npm run lint:spec-patterns` -- pass
- [x] `npm run lint:prod-patterns` -- pass
- Docs-only change; no code paths affected.

## SemVer

No bump -- docs/process change, no public API or stored shape touched.

---
**Session**
- AI-Local: `9acca685-2884-43cc-bed6-2b2c01f08b9c`
- AI-Cloud: (none -- local-only session)
