### PR TITLE
Harden test isolation against cross-spec state leakage (#350)

### DIFF
--- a/scripts/check-prod-patterns.mjs
+++ b/scripts/check-prod-patterns.mjs
@@ -72,10 +72,18 @@
 //
 // Adding new rules:
 //   Push a `{ pattern, message, pragma?, pragmaAllowedPaths? }` onto
-//   RULES. `pattern` is a RegExp (use `/.../g` so the scanner can
-//   iterate matches). Keep messages actionable - point at the approved
-//   alternative.  When `pragma` is set, the scanner allows matches on
-//   lines that contain the pragma string AND whose path matches one of
+//   RULES. `pattern` must be a RegExp; `message` must be a non-empty
+//   string. `validateRules(RULES)` runs at module load and throws a
+//   loud TypeError if either is missing or malformed. The `/g` flag
+//   itself is enforced by `scanText`'s use of
+//   `String.prototype.matchAll`, which V8 rejects with a TypeError
+//   on a non-global RegExp -- a rule author who forgets `/g` gets a
+//   loud failure on the first scan instead of a silent
+//   `while (exec(...))` infinite-loop hang. See PR #370 panel
+//   discussion for why engine-enforcement was preferred over a
+//   handwritten `validateRegexRules({ global })` check.
+//   When `pragma` is set, the scanner allows matches on lines that
+//   contain the pragma string AND whose path matches one of
 //   `pragmaAllowedPaths` (forward-slash form) - this keeps the
 //   safe-harbor narrow.
 //
@@ -182,6 +190,40 @@ export const RULES = [
   },
 ];
 
+/**
+ * Asserts that each rule has the shape `{ pattern: RegExp, message:
+ * string, ... }` with a RegExp pattern and a non-empty message.
+ * Throws a loud TypeError at module load if any rule fails. Pure: no
+ * I/O.
+ *
+ * The `/g` flag on `pattern` is intentionally NOT checked here. V8's
+ * `String.prototype.matchAll` throws a TypeError on a non-global
+ * RegExp on the first scan, which gives a better stack trace
+ * pointing at the actual call site (scanText). See PR #370 panel
+ * discussion. Exported for unit-test use.
+ */
+export function validateRules(rules) {
+  for (const rule of rules) {
+    if (!(rule.pattern instanceof RegExp)) {
+      throw new TypeError(
+        `check-prod-patterns: rule pattern must be a RegExp, got ${typeof rule.pattern}.` +
+          ` See "Adding new rules" in scripts/check-prod-patterns.mjs.`,
+      );
+    }
+    if (typeof rule.message !== 'string' || rule.message.length === 0) {
+      throw new TypeError(
+        `check-prod-patterns: rule for pattern ${rule.pattern} has missing or empty` +
+          ` \`message\`. See scripts/check-prod-patterns.mjs.`,
+      );
+    }
+  }
+}
+
+// Validate at module load: throws loudly if any rule shape is broken.
+// Pure check (no I/O), so this does not violate the "no CLI side
+// effects on import" invariant called out at the foot of this file.
+validateRules(RULES);
+
 export function listProdFiles() {
   const out = execFileSync(
     'git',
@@ -235,6 +277,14 @@ export function scan(path) {
  * Pure-function variant of `scan` that takes the file's text and
  * normalized path directly. Exported so unit tests can exercise the
  * scanner against in-memory fixtures without touching the filesystem.
+ *
+ * Engine choice: `String.prototype.matchAll` over `while (exec(...))`.
+ * matchAll throws `TypeError: String.prototype.matchAll called with
+ * a non-global RegExp argument` if a rule forgets `/g`. The legacy
+ * `while ((m = rule.pattern.exec(text)) !== null)` form would
+ * instead hang forever on the first match (exec restarts at
+ * lastIndex=0 for non-global regex), turning a rule-authoring typo
+ * into a silent CI infinite-loop. See PR #370 panel discussion.
  */
 export function scanText(text, normalizedPath) {
   const violations = [];
@@ -242,9 +292,18 @@ export function scanText(text, normalizedPath) {
     if (rule.paths && !rule.paths.some((re) => re.test(normalizedPath))) {
       continue;
     }
-    rule.pattern.lastIndex = 0;
-    let m;
-    while ((m = rule.pattern.exec(text)) !== null) {
+    let matches;
+    try {
+      matches = text.matchAll(rule.pattern);
+    } catch (cause) {
+      throw new TypeError(
+        `check-prod-patterns: rule pattern ${rule.pattern} is not a global RegExp` +
+          ` (matchAll requires /g). Add the /g flag to the rule in` +
+          ` scripts/check-prod-patterns.mjs and re-run \`npm run test:scripts\`.`,
+        { cause },
+      );
+    }
+    for (const m of matches) {
       const upToMatch = text.slice(0, m.index);
       const lastNl = upToMatch.lastIndexOf('\n');
       const line = upToMatch.split('\n').length;

--- a/scripts/check-prod-patterns.test.mjs
+++ b/scripts/check-prod-patterns.test.mjs
@@ -15,7 +15,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { matchesPragma, scanText } from './check-prod-patterns.mjs';
+import { matchesPragma, RULES, scanText, validateRules } from './check-prod-patterns.mjs';
 
 // --- matchesPragma --------------------------------------------------------
 
@@ -229,4 +229,67 @@ test('cosmos-replace: string pragma in non-allow-listed file is rejected', () =>
   const text = `await container.item('id', 'pk').replace<Doc>(updated); // allow:cosmos-replace internal-only\n`;
   const violations = scanText(text, 'api/src/blobs/index.ts');
   assert.equal(violations.length, 1);
+});
+
+// --- validateRules (rule-shape contract) ---------------------------------
+// PR #370 panel: enforce at module load that each rule has a RegExp
+// pattern and a non-empty message. The /g flag is NOT validated
+// here -- V8's matchAll throws on non-global at engine call time
+// with a better stack trace.
+
+test('validateRules rejects a rule with non-RegExp pattern', () => {
+  assert.throws(
+    () => validateRules([{ pattern: 'foo', message: 'msg' }]),
+    /pattern must be a RegExp/,
+  );
+});
+
+test('validateRules rejects a rule with missing message', () => {
+  assert.throws(() => validateRules([{ pattern: /foo/g }]), /missing or empty `message`/);
+});
+
+test('validateRules rejects a rule with empty message', () => {
+  assert.throws(
+    () => validateRules([{ pattern: /foo/g, message: '' }]),
+    /missing or empty `message`/,
+  );
+});
+
+// --- Engine termination (PR #370 bot finding regression test) ---------
+// The previous `while ((m = rule.pattern.exec(text)) !== null)` engine
+// would hang on the first match if a rule forgot `/g`. The matchAll
+// engine throws a TypeError at call time instead. These tests are
+// the actual canary for the bot's concern -- they prove the scan
+// loop terminates on multi-match input AND that a non-global pattern
+// fails loudly with a message that points at the fix.
+
+test('scanText terminates on multiple matches (not just the first)', { timeout: 2000 }, () => {
+  const text = `
+const a = foo as TelemetryMessageId;
+const b = bar as TelemetryMessageId;
+const c = baz as TelemetryMessageId;
+`;
+  const violations = scanText(text, 'src/app/example.ts');
+  assert.equal(violations.length, 3);
+});
+
+test('scanText throws actionable error if a rule pattern is non-global', () => {
+  // Find the TelemetryMessageId rule (rule #1, no `paths` filter so
+  // it fires on any src/ path).
+  const telemetryRule = RULES.find((r) => /TelemetryMessageId/.test(r.pattern.source));
+  assert.ok(telemetryRule, 'expected a TelemetryMessageId rule');
+  const savedPattern = telemetryRule.pattern;
+  // Mutate the existing rule in place to bypass validateRules.
+  telemetryRule.pattern = /TelemetryMessageId/;
+  try {
+    assert.throws(
+      () => scanText('const x = y as TelemetryMessageId;', 'src/app/example.ts'),
+      (err) =>
+        err instanceof TypeError &&
+        /matchAll requires \/g/.test(err.message) &&
+        /scripts\/check-prod-patterns\.mjs/.test(err.message),
+    );
+  } finally {
+    telemetryRule.pattern = savedPattern;
+  }
 });

--- a/scripts/check-spec-patterns.mjs
+++ b/scripts/check-spec-patterns.mjs
@@ -43,12 +43,37 @@
 //   constrained on the `__set*` side -- the rule lints `__reset*`
 //   placement only.
 //
-//   Not enforced: indirect calls through helper functions. A helper
-//   that internally calls `__resetX` is opaque to the rule. Spec
-//   authors who hide setup in helpers accept the blind spot.
+//   Helper-call semantics (deliberate calibration -- see PR #370
+//   panel discussion):
+//
+//   * Helpers *defined outside* the hook body (e.g., a top-level
+//     `function setup() { __resetX(); }` called from `beforeEach`)
+//     are opaque to the rule. Spec authors who hide setup in
+//     external helpers accept the blind spot.
+//   * Helpers *defined inline inside* the hook body have their
+//     bodies walked: any `__reset*` call inside an inline helper IS
+//     recorded against the enclosing hook, even if the helper is
+//     never invoked. This is an accepted false-positive in exchange
+//     for catching the common DRY pattern of extracting setup into a
+//     helper defined and called from the same `beforeEach`. A
+//     static linter cannot distinguish "helper defined" from
+//     "helper defined and called" without dataflow analysis;
+//     calibrating toward false-positives is consistent with the
+//     one-way bias above (loud false-positive in a single spec is
+//     cheap; silent false-negative leaks across the suite).
+//
+//   See also: `src/testing/global-hooks.spec.ts` is the runtime
+//   counterpart -- it catches storage/`Storage.prototype` leaks
+//   that the lint rule cannot see (since they have no
+//   `__reset*ForTesting` name). The two mechanisms cover disjoint
+//   bug classes; neither is a superset of the other.
 //
 // Adding new rules:
-//   For regex rules: push a `{ pattern, message }` onto REGEX_RULES.
+//   For regex rules: push a `{ id, pattern, message }` onto
+//   REGEX_RULES. The `id` is required -- it becomes `ruleId` on
+//   emitted violations and is used by downstream consumers (test
+//   filters, future GitHub Actions annotations). Omitting `id`
+//   silently produces `ruleId: undefined`.
 //   For AST-based rules: extend `scanAst` directly. The AST scanner
 //   exposes the spec file's TypeScript AST so a new rule can walk it
 //   with the full structural context that regex cannot see.
@@ -185,6 +210,17 @@ export function scanAst(sourceFile, normalizedPath) {
   }
 
   function findResetCallsIn(node, sink) {
+    // Deliberate over-inclusion: this walker recurses through ALL
+    // descendants, including bodies of functions declared inline
+    // inside the hook callback. A static linter cannot tell a
+    // helper that is defined-and-called from one that is
+    // defined-and-never-called; we accept the false-positive on the
+    // dead-helper case in exchange for catching the common DRY
+    // pattern where setup is extracted into a helper defined and
+    // called from the same hook. See the file-top docstring
+    // "Helper-call semantics" section for full rationale (PR #370
+    // panel discussion). Do NOT add `ts.isFunctionDeclaration`
+    // skip-recursion without revisiting that trade-off.
     function walk(n) {
       if (ts.isCallExpression(n)) {
         const callee = n.expression;
@@ -248,7 +284,13 @@ export function scanAst(sourceFile, normalizedPath) {
         const callback = node.arguments[1];
         if (callback && (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))) {
           scopes.push({ node, before: new Map(), after: new Map() });
-          ts.forEachChild(callback.body, visit);
+          // visit(callback.body), not ts.forEachChild(callback.body, visit):
+          // for a concise-arrow describe (`describe('x', () => beforeEach(...))`)
+          // the body is itself a CallExpression. forEachChild would walk its
+          // arguments and miss the top-level call. visit() falls through to
+          // ts.forEachChild for Block bodies (no behavior change there) and
+          // correctly dispatches on CallExpression bodies.
+          visit(callback.body);
           const popped = scopes.pop();
           emitScopeViolations(popped);
           return;

--- a/scripts/check-spec-patterns.mjs
+++ b/scripts/check-spec-patterns.mjs
@@ -2,31 +2,70 @@
 // Spec-pattern lint: rejects known-fragile testing patterns in *.spec.ts.
 //
 // Why this exists:
-//   `spyOnProperty(navigator, 'clipboard', 'get')` requires
-//   `navigator.clipboard` to already exist as an accessor property. Linux
-//   headless Chrome (the CI runner) exposes it as a data property (or omits
-//   it entirely outside a secure context), so the spy throws
-//   "Property clipboard does not have access type get" and crashes the test.
-//   Windows headless Chrome happens to expose a getter, so locally green and
-//   CI red. We have already paid for this once (see the M4b clipboard fix
-//   that introduced this script). The rest of the codebase uses
+//
+//  Rule #1 - `spyOnProperty(navigator, 'clipboard', 'get')`:
+//   Requires `navigator.clipboard` to already exist as an accessor
+//   property. Linux headless Chrome (the CI runner) exposes it as a
+//   data property (or omits it entirely outside a secure context), so
+//   the spy throws "Property clipboard does not have access type get"
+//   and crashes the test. Windows headless Chrome happens to expose a
+//   getter, so locally green and CI red. We have already paid for this
+//   once (see the M4b clipboard fix that introduced this script). The
+//   rest of the codebase uses
 //   `Object.defineProperty(navigator, 'clipboard', { configurable: true,
-//   get: () => ... })` in beforeEach + restore in afterEach, which works
-//   on every platform.
+//   get: () => ... })` in beforeEach + restore in afterEach, which
+//   works on every platform.
+//
+//  Rule #2 - `__reset*ForTesting()` symmetry (issue #350):
+//   Module-scoped state inside ES modules is a singleton that external
+//   code cannot reset. The `__resetXForTesting()` convention exists so
+//   specs can reset that state at known points. A spec that calls
+//   `__resetX()` in `beforeEach` but NOT in `afterEach` leaks state to
+//   the *next* spec across the entire suite. Under Jasmine `random:
+//   true` this surfaces as an intermittent CI flake (see PR #351). The
+//   rule enforces that every `__reset*ForTesting` call inside a
+//   `beforeEach` has a matching `__reset*ForTesting` call (same
+//   identifier) inside an `afterEach` in the same `describe` block (or
+//   file scope), and vice versa.
+//
+//   Not enforced: `__set*` / `__attach*` / `__load*` / `__flush*`
+//   helpers (the `ForTesting` suffix alone is not enough -- e.g.,
+//   `LoggerService.__attachPerfHarnessForTesting` is called in
+//   production at `main.ts`). Set/reset *pairs* with different
+//   identifiers (e.g., `__setInitWebVitalsImplForTesting` paired with
+//   `__resetInitWebVitalsImplForTesting`) are intentionally not
+//   constrained on the `__set*` side -- the rule lints `__reset*`
+//   placement only.
+//
+//   Not enforced: indirect calls through helper functions. A helper
+//   that internally calls `__resetX` is opaque to the rule. Spec
+//   authors who hide setup in helpers accept the blind spot.
 //
 // Adding new rules:
-//   Push a `{ pattern, message }` onto RULES. `pattern` is a RegExp (use
-//   `/.../` literal so flags are explicit). Keep messages actionable -
-//   point at the approved alternative.
+//   For regex rules: push a `{ pattern, message }` onto REGEX_RULES.
+//   For AST-based rules: extend `scanAst` directly. The AST scanner
+//   exposes the spec file's TypeScript AST so a new rule can walk it
+//   with the full structural context that regex cannot see.
 //
-// Runs with zero dependencies on Node 24+. Invoke directly or via
-//   npm run lint:spec-patterns
+// Exports:
+//   - `REGEX_RULES`, `scanRegex`, `scanAst`, `scan`, `listSpecFiles`,
+//     `main` are exported so unit tests (`scripts/check-spec-patterns.test.mjs`)
+//     can drive them against in-memory fixtures without touching the
+//     filesystem.
+//
+// Runs on Node 24+. The AST rule requires `typescript` (already a
+// transitive dev dep via `@angular-devkit/build-angular`). Invoke
+// directly or via `npm run lint:spec-patterns`.
 
 import { execFileSync } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { readFileSync, realpathSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 
-const RULES = [
+import ts from 'typescript';
+
+export const REGEX_RULES = [
   {
+    id: 'spy-on-navigator-clipboard',
     pattern: /\bspyOnProperty\s*\(\s*navigator\s*,\s*['"]clipboard['"]/g,
     message:
       "Use Object.defineProperty(navigator, 'clipboard', { configurable: true, get: () => ... })" +
@@ -36,7 +75,23 @@ const RULES = [
   },
 ];
 
-function listSpecFiles() {
+// Only `__reset*ForTesting` callees are subject to the symmetry rule.
+// Narrowed from `__\w+ForTesting` so `__set*`, `__attach*`, `__load*`,
+// `__flush*` etc. (not reset helpers) are excluded.
+const RESET_HELPER_REGEX = /^__reset\w+ForTesting$/;
+
+const RESET_ASYMMETRY_MESSAGE =
+  'Asymmetric `__reset*ForTesting` placement (issue #350). A reset call' +
+  ' in a `beforeEach` must have a matching reset call (same identifier)' +
+  ' in an `afterEach` in the same `describe` block. A `beforeEach`-only' +
+  ' reset means "I clean up at the start of MY test" -- but cross-test' +
+  ' leakage already happened by then. The cleanup belongs in `afterEach`' +
+  ' too, so the next spec inherits clean state under `random: true`.' +
+  ' Note: an `afterEach`-only reset is the canonical "set/reset pair"' +
+  ' pattern (`__setX...ForTesting` in `beforeEach`, `__resetX...ForTesting`' +
+  ' in `afterEach`) and is NOT flagged by this rule.';
+
+export function listSpecFiles() {
   // Match check-ascii.mjs: include both tracked and untracked-but-not-ignored
   // files so a fresh local file is scanned BEFORE it is staged.
   const out = execFileSync(
@@ -51,15 +106,14 @@ function listSpecFiles() {
     .filter((p) => p.endsWith('.spec.ts'));
 }
 
-function scan(path) {
-  let text;
-  try {
-    text = readFileSync(path, 'utf8');
-  } catch {
-    return [];
-  }
+/**
+ * Run the regex-based rules on the file's text. Pure function: takes
+ * the text and the normalized path, returns violations. Exported for
+ * unit-test use.
+ */
+export function scanRegex(text, normalizedPath) {
   const violations = [];
-  for (const rule of RULES) {
+  for (const rule of REGEX_RULES) {
     rule.pattern.lastIndex = 0;
     let m;
     while ((m = rule.pattern.exec(text)) !== null) {
@@ -67,36 +121,221 @@ function scan(path) {
       const line = upToMatch.split('\n').length;
       const lastNl = upToMatch.lastIndexOf('\n');
       const col = m.index - (lastNl + 1) + 1;
-      violations.push({ path, line, col, message: rule.message, snippet: m[0] });
+      violations.push({
+        path: normalizedPath,
+        line,
+        col,
+        message: rule.message,
+        snippet: m[0],
+        ruleId: rule.id,
+      });
     }
   }
   return violations;
 }
 
-const files = listSpecFiles();
-const allViolations = files.flatMap(scan);
+/**
+ * Walks the spec's TypeScript AST and reports `__reset*ForTesting`
+ * asymmetry violations. The walker tracks each enclosing `describe`
+ * scope (a stack of node ids) and, within each scope, the set of
+ * reset-helper identifiers called in `beforeEach` bodies and the set
+ * called in `afterEach` bodies. After the walk, any identifier in one
+ * set but not the other becomes a violation.
+ *
+ * `describe.skip`, `xdescribe`, `fdescribe` are all treated as
+ * describes. `it`, `xit`, `fit`, `it.skip`, async arrow bodies, and
+ * function-expression bodies are all transparent to the walker --
+ * resets called inside an `it` body do not feed the symmetry set
+ * (they are not `beforeEach`/`afterEach`).
+ *
+ * Pure function: takes a TypeScript SourceFile and the normalized
+ * path, returns violations. Exported for unit-test use.
+ */
+export function scanAst(sourceFile, normalizedPath) {
+  const violations = [];
 
-if (allViolations.length === 0) {
-  console.log(`check-spec-patterns: OK (${files.length} spec files scanned, 0 violations)`);
-  process.exit(0);
-}
+  // Stack of scopes. Each scope is { node, before: Map<id, Node>,
+  // after: Map<id, Node> }. The file itself is the outermost scope.
+  // Maps store the *first* AST node where the identifier appeared so
+  // the violation can point at a real location.
+  const scopes = [{ node: sourceFile, before: new Map(), after: new Map() }];
 
-console.error('check-spec-patterns: violations found:');
-for (const v of allViolations) {
-  console.error(`  ${v.path}:${v.line}:${v.col}  ${v.snippet}`);
-  console.error(`    -> ${v.message}`);
-}
-console.error(`\n${allViolations.length} violation(s) in ${files.length} spec files.`);
-
-if (process.env.GITHUB_ACTIONS === 'true') {
-  for (const v of allViolations) {
-    const file = v.path.replace(/%/g, '%25');
-    const msg = String(`${v.snippet} - ${v.message}`)
-      .replace(/%/g, '%25')
-      .replace(/\r/g, '%0D')
-      .replace(/\n/g, '%0A');
-    console.log(`::error file=${file},line=${v.line},col=${v.col}::${msg}`);
+  function currentScope() {
+    return scopes[scopes.length - 1];
   }
+
+  function isCalleeName(expr, names) {
+    // Matches `name(...)`, `name.skip(...)`, `name.only(...)` styles.
+    if (ts.isIdentifier(expr)) {
+      return names.includes(expr.text);
+    }
+    if (ts.isPropertyAccessExpression(expr) && ts.isIdentifier(expr.expression)) {
+      return names.includes(expr.expression.text);
+    }
+    return false;
+  }
+
+  function findResetCallsIn(node, sink) {
+    function walk(n) {
+      if (ts.isCallExpression(n)) {
+        const callee = n.expression;
+        let calleeName = null;
+        if (ts.isIdentifier(callee)) {
+          calleeName = callee.text;
+        }
+        if (calleeName && RESET_HELPER_REGEX.test(calleeName)) {
+          if (!sink.has(calleeName)) {
+            sink.set(calleeName, n);
+          }
+        }
+      }
+      ts.forEachChild(n, walk);
+    }
+    walk(node);
+  }
+
+  function recordHookCalls(callNode, hookKind) {
+    // Hook callbacks: `beforeEach(() => { ... })` or
+    // `beforeEach(function() { ... })`. Async arrows / function
+    // expressions are also valid. Walk the callback body.
+    const arg = callNode.arguments[0];
+    if (!arg) return;
+    let body = null;
+    if (ts.isArrowFunction(arg) || ts.isFunctionExpression(arg)) {
+      body = arg.body;
+    }
+    if (!body) return;
+    const sink = hookKind === 'beforeEach' ? currentScope().before : currentScope().after;
+    findResetCallsIn(body, sink);
+  }
+
+  function emitScopeViolations(scope) {
+    // Only flag beforeEach-only resets. afterEach-only is the canonical
+    // set/reset pair pattern (`__setX...ForTesting` in beforeEach paired
+    // with `__resetX...ForTesting` in afterEach) and is legitimate.
+    const beforeIds = new Set(scope.before.keys());
+    const afterIds = new Set(scope.after.keys());
+    for (const id of beforeIds) {
+      if (afterIds.has(id)) continue;
+      const offendingNode = scope.before.get(id);
+      const start = offendingNode.getStart(sourceFile);
+      const { line, character } = sourceFile.getLineAndCharacterOfPosition(start);
+      violations.push({
+        path: normalizedPath,
+        line: line + 1,
+        col: character + 1,
+        message: `${RESET_ASYMMETRY_MESSAGE} (${id}() is in beforeEach only)`,
+        snippet: `${id}()`,
+        ruleId: 'reset-helper-symmetry',
+      });
+    }
+  }
+
+  function visit(node) {
+    if (ts.isCallExpression(node)) {
+      // Detect describe / xdescribe / fdescribe / describe.skip /
+      // describe.only -- all open a new scope.
+      if (isCalleeName(node.expression, ['describe', 'xdescribe', 'fdescribe'])) {
+        const callback = node.arguments[1];
+        if (callback && (ts.isArrowFunction(callback) || ts.isFunctionExpression(callback))) {
+          scopes.push({ node, before: new Map(), after: new Map() });
+          ts.forEachChild(callback.body, visit);
+          const popped = scopes.pop();
+          emitScopeViolations(popped);
+          return;
+        }
+      }
+      // `beforeEach(...)` / `afterEach(...)` -- record reset calls
+      // into the current scope's symmetry sets.
+      if (
+        ts.isIdentifier(node.expression) &&
+        (node.expression.text === 'beforeEach' || node.expression.text === 'afterEach')
+      ) {
+        recordHookCalls(node, node.expression.text);
+        // Don't visit children -- the reset calls are already
+        // captured. (Visiting would not double-count but is wasted
+        // work.)
+        return;
+      }
+    }
+    ts.forEachChild(node, visit);
+  }
+
+  ts.forEachChild(sourceFile, visit);
+  emitScopeViolations(scopes[0]);
+
+  return violations;
 }
 
-process.exit(1);
+/**
+ * Convenience: returns combined regex + AST violations for `text` at
+ * `normalizedPath`. Exported for unit tests.
+ */
+export function scanText(text, normalizedPath) {
+  const sourceFile = ts.createSourceFile(
+    normalizedPath,
+    text,
+    ts.ScriptTarget.Latest,
+    /*setParentNodes*/ true,
+    ts.ScriptKind.TS,
+  );
+  return [...scanRegex(text, normalizedPath), ...scanAst(sourceFile, normalizedPath)];
+}
+
+export function scan(path) {
+  let text;
+  try {
+    text = readFileSync(path, 'utf8');
+  } catch {
+    return [];
+  }
+  const normalizedPath = path.replace(/\\/g, '/');
+  return scanText(text, normalizedPath);
+}
+
+export function main() {
+  const files = listSpecFiles();
+  const allViolations = files.flatMap(scan);
+
+  if (allViolations.length === 0) {
+    console.log(`check-spec-patterns: OK (${files.length} spec files scanned, 0 violations)`);
+    return 0;
+  }
+
+  console.error('check-spec-patterns: violations found:');
+  for (const v of allViolations) {
+    console.error(`  ${v.path}:${v.line}:${v.col}  ${v.snippet}`);
+    console.error(`    -> ${v.message}`);
+  }
+  console.error(`\n${allViolations.length} violation(s) in ${files.length} spec files.`);
+
+  if (process.env.GITHUB_ACTIONS === 'true') {
+    for (const v of allViolations) {
+      const file = v.path.replace(/%/g, '%25');
+      const msg = String(`${v.snippet} - ${v.message}`)
+        .replace(/%/g, '%25')
+        .replace(/\r/g, '%0D')
+        .replace(/\n/g, '%0A');
+      console.log(`::error file=${file},line=${v.line},col=${v.col}::${msg}`);
+    }
+  }
+
+  return 1;
+}
+
+// Only invoke main() when this file is executed directly. Importers
+// (the test file at scripts/check-spec-patterns.test.mjs) load the
+// module solely for its exports; they must not trigger the CLI side
+// effects (git ls-files, fs reads, process.exit).
+const invokedDirectly = (() => {
+  try {
+    if (!process.argv[1]) return false;
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
+  } catch {
+    return false;
+  }
+})();
+
+if (invokedDirectly) {
+  process.exit(main());
+}

--- a/scripts/check-spec-patterns.mjs
+++ b/scripts/check-spec-patterns.mjs
@@ -70,19 +70,25 @@
 //
 // Adding new rules:
 //   For regex rules: push a `{ id, pattern, message }` onto
-//   REGEX_RULES. The `id` is required -- it becomes `ruleId` on
-//   emitted violations and is used by downstream consumers (test
-//   filters, future GitHub Actions annotations). Omitting `id`
-//   silently produces `ruleId: undefined`.
+//   REGEX_RULES. `validateRules(REGEX_RULES)` runs at module load and
+//   throws a loud TypeError if any rule is missing `id` / `message`
+//   or has a non-RegExp `pattern`, or if two rules share the same
+//   `id`. The `/g` flag itself is enforced by `scanRegex`'s use of
+//   `String.prototype.matchAll`, which V8 rejects with a TypeError
+//   when given a non-global RegExp -- so rule authors who forget
+//   `/g` get a loud failure on the first scan instead of a silent
+//   `while (exec(...))` infinite-loop hang. See PR #370 panel
+//   discussion for why engine-enforcement was preferred over a
+//   handwritten `validateRegexRules({ global })` check.
 //   For AST-based rules: extend `scanAst` directly. The AST scanner
 //   exposes the spec file's TypeScript AST so a new rule can walk it
 //   with the full structural context that regex cannot see.
 //
 // Exports:
-//   - `REGEX_RULES`, `scanRegex`, `scanAst`, `scan`, `listSpecFiles`,
-//     `main` are exported so unit tests (`scripts/check-spec-patterns.test.mjs`)
-//     can drive them against in-memory fixtures without touching the
-//     filesystem.
+//   - `REGEX_RULES`, `validateRules`, `scanRegex`, `scanAst`, `scan`,
+//     `listSpecFiles`, `main` are exported so unit tests
+//     (`scripts/check-spec-patterns.test.mjs`) can drive them against
+//     in-memory fixtures without touching the filesystem.
 //
 // Runs on Node 24+. The AST rule requires `typescript` (already a
 // transitive dev dep via `@angular-devkit/build-angular`). Invoke
@@ -105,6 +111,56 @@ export const REGEX_RULES = [
       ' which Linux headless Chrome does not expose for navigator.clipboard.',
   },
 ];
+
+/**
+ * Asserts that each rule has the shape `{ id: string, pattern: RegExp,
+ * message: string }` with non-empty id/message, and that no two rules
+ * share an id. Throws a loud TypeError at module load if any rule
+ * fails -- matches the file's "loud false-positive over silent
+ * false-negative" calibration (see docstring). Pure: no I/O.
+ *
+ * The `/g` flag on `pattern` is intentionally NOT checked here. V8's
+ * `String.prototype.matchAll` throws a TypeError on a non-global
+ * RegExp on the first scan, which gives a better stack trace
+ * pointing at the actual call site (scanRegex). See PR #370 panel
+ * discussion. Exported for unit-test use.
+ */
+export function validateRules(rules) {
+  const seenIds = new Set();
+  for (const rule of rules) {
+    if (typeof rule.id !== 'string' || rule.id.length === 0) {
+      throw new TypeError(
+        `check-spec-patterns: REGEX_RULES entry is missing a non-empty \`id\`` +
+          ` (required for violation reporting and test filtering). See` +
+          ` "Adding new rules" in scripts/check-spec-patterns.mjs.`,
+      );
+    }
+    if (seenIds.has(rule.id)) {
+      throw new TypeError(
+        `check-spec-patterns: REGEX_RULES has two rules with id "${rule.id}".` +
+          ` Each rule id must be unique. See scripts/check-spec-patterns.mjs.`,
+      );
+    }
+    seenIds.add(rule.id);
+    if (!(rule.pattern instanceof RegExp)) {
+      throw new TypeError(
+        `check-spec-patterns: rule "${rule.id}" pattern must be a RegExp,` +
+          ` got ${typeof rule.pattern}. See scripts/check-spec-patterns.mjs.`,
+      );
+    }
+    if (typeof rule.message !== 'string' || rule.message.length === 0) {
+      throw new TypeError(
+        `check-spec-patterns: rule "${rule.id}" message must be a non-empty` +
+          ` string. See scripts/check-spec-patterns.mjs.`,
+      );
+    }
+  }
+}
+
+// Validate at module load: throws loudly if any rule shape is broken.
+// Pure check (no I/O), so this does not violate the "no CLI side
+// effects on import" invariant called out in the file-top docstring.
+validateRules(REGEX_RULES);
 
 // Only `__reset*ForTesting` callees are subject to the symmetry rule.
 // Narrowed from `__\w+ForTesting` so `__set*`, `__attach*`, `__load*`,
@@ -141,13 +197,30 @@ export function listSpecFiles() {
  * Run the regex-based rules on the file's text. Pure function: takes
  * the text and the normalized path, returns violations. Exported for
  * unit-test use.
+ *
+ * Engine choice: `String.prototype.matchAll` over `while (exec(...))`.
+ * matchAll throws `TypeError: String.prototype.matchAll called with
+ * a non-global RegExp argument` if a rule forgets `/g`. The legacy
+ * `while ((m = rule.pattern.exec(text)) !== null)` form would
+ * instead hang forever on the first match (exec restarts at
+ * lastIndex=0 for non-global regex), turning a rule-authoring typo
+ * into a silent CI infinite-loop. See PR #370 panel discussion.
  */
 export function scanRegex(text, normalizedPath) {
   const violations = [];
   for (const rule of REGEX_RULES) {
-    rule.pattern.lastIndex = 0;
-    let m;
-    while ((m = rule.pattern.exec(text)) !== null) {
+    let matches;
+    try {
+      matches = text.matchAll(rule.pattern);
+    } catch (cause) {
+      throw new TypeError(
+        `check-spec-patterns: rule "${rule.id}" pattern is not a global RegExp` +
+          ` (matchAll requires /g). Add the /g flag to ${rule.pattern} in` +
+          ` scripts/check-spec-patterns.mjs and re-run \`npm run test:scripts\`.`,
+        { cause },
+      );
+    }
+    for (const m of matches) {
       const upToMatch = text.slice(0, m.index);
       const line = upToMatch.split('\n').length;
       const lastNl = upToMatch.lastIndexOf('\n');

--- a/scripts/check-spec-patterns.mjs
+++ b/scripts/check-spec-patterns.mjs
@@ -26,7 +26,13 @@
 //   rule enforces that every `__reset*ForTesting` call inside a
 //   `beforeEach` has a matching `__reset*ForTesting` call (same
 //   identifier) inside an `afterEach` in the same `describe` block (or
-//   file scope), and vice versa.
+//   file scope).
+//
+//   The rule is deliberately one-way: only `beforeEach`-only resets
+//   are flagged. An `afterEach`-only reset is the canonical set/reset
+//   pair pattern (a `__setX...ForTesting` in `beforeEach` paired with
+//   `__resetX...ForTesting` in `afterEach`) and is legitimate
+//   cleanup-of-self -- the cross-test leak risk does not apply.
 //
 //   Not enforced: `__set*` / `__attach*` / `__load*` / `__flush*`
 //   helpers (the `ForTesting` suffix alone is not enough -- e.g.,
@@ -139,8 +145,11 @@ export function scanRegex(text, normalizedPath) {
  * asymmetry violations. The walker tracks each enclosing `describe`
  * scope (a stack of node ids) and, within each scope, the set of
  * reset-helper identifiers called in `beforeEach` bodies and the set
- * called in `afterEach` bodies. After the walk, any identifier in one
- * set but not the other becomes a violation.
+ * called in `afterEach` bodies. After the walk, any identifier in the
+ * `beforeEach` set without a matching entry in the `afterEach` set
+ * becomes a violation. The reverse direction (`afterEach`-only) is
+ * deliberately allowed -- it is the canonical set/reset pair cleanup
+ * pattern. See file-top docstring (Rule #2) for the rationale.
  *
  * `describe.skip`, `xdescribe`, `fdescribe` are all treated as
  * describes. `it`, `xit`, `fit`, `it.skip`, async arrow bodies, and

--- a/scripts/check-spec-patterns.test.mjs
+++ b/scripts/check-spec-patterns.test.mjs
@@ -11,13 +11,14 @@
 //  - Regex rule still fires on the existing `spyOnProperty(navigator,
 //    'clipboard', ...)` pattern.
 //  - AST rule (`__reset*ForTesting` symmetry) catches:
-//     - reset call in `beforeEach` only
-//     - reset call in `afterEach` only
+//     - reset call in `beforeEach` only (the bug pattern)
 //     - asymmetric reset in a nested `describe`
+//     - file-level (top-of-file) hook scoped asymmetries
 //  - AST rule passes (no violation) on:
 //     - symmetric reset in both hooks
 //     - no resets at all
-//     - set/reset pair with different identifiers
+//     - set/reset pair (`__setX...` in beforeEach + `__resetX...` in
+//       afterEach is the canonical pattern; afterEach-only is allowed)
 //     - reset call inside an `it` body (not `beforeEach`/`afterEach`)
 //     - `__set*` / `__attach*` / `__load*` / `__flush*` helpers
 //       (narrowed regex excludes them)

--- a/scripts/check-spec-patterns.test.mjs
+++ b/scripts/check-spec-patterns.test.mjs
@@ -26,6 +26,13 @@
 //    block comments containing `beforeEach` tokens,
 //    `describe.skip` / `xdescribe` / `fdescribe`, `xit` / `fit`,
 //    async-arrow callbacks, function-expression callbacks.
+//  - Concise-arrow describe body coverage: `describe('x', () =>
+//    beforeEach(...))` (the body is a CallExpression, not a Block).
+//  - Inline-helper coverage (deliberate calibration -- see PR #370):
+//    a helper defined inside the hook body whose body contains a
+//    `__reset*` call is treated as if the hook ran the reset, even
+//    when the helper is never invoked. Accepted false-positive in
+//    exchange for catching the common DRY pattern.
 
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
@@ -382,4 +389,91 @@ test('violation includes line and column from the offending node', () => {
   assert.equal(violations[0].line, 2); // line 2 has the beforeEach call
   assert.equal(typeof violations[0].col, 'number');
   assert.ok(violations[0].col > 0);
+});
+
+// --- AST rule: concise-arrow describe body (PR #370 review feedback) --
+
+test('concise-arrow describe body: detects beforeEach-only reset (no Block wrapper)', () => {
+  // `describe('x', () => beforeEach(...))` -- the arrow body is the
+  // CallExpression itself, not a Block. The walker must dispatch on
+  // the body as a node, not just its children. Regression guard for
+  // the line-251 bug fixed in this PR. Currently no spec in the
+  // codebase uses this shape, but the soundness of the rule should
+  // not depend on stylistic uniformity.
+  const text = `describe('x', () => beforeEach(() => __resetFooForTesting()));`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /__resetFooForTesting/);
+  assert.match(violations[0].message, /beforeEach only/);
+});
+
+test('concise-arrow describe body with both hooks: symmetric, no violation', () => {
+  // The corollary: concise-arrow describe with symmetric set/reset
+  // pair must still be accepted (proves the fix did not over-flag).
+  // Here the describe body is a parenthesized SequenceExpression-like
+  // shape: the arrow body is a single CallExpression that returns
+  // the result of the last hook -- not idiomatic, but valid TS.
+  const text = `
+describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  afterEach(() => __resetFooForTesting());
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+// --- AST rule: inline-helper semantics (PR #370 deliberate calibration)
+
+test('inline helper defined and called from beforeEach: flagged when afterEach missing', () => {
+  // Common DRY pattern: extract setup into a helper defined inside
+  // the hook and call it. The walker recurses into the helper body
+  // and records the __reset call against the enclosing beforeEach.
+  // Without a matching afterEach this should be flagged. This is
+  // the TRUE-POSITIVE side of the deliberate over-inclusion
+  // documented in check-spec-patterns.mjs file-top "Helper-call
+  // semantics" section. Do NOT change findResetCallsIn to skip
+  // FunctionDeclaration recursion without revisiting that trade-off.
+  const text = `
+describe('x', () => {
+  beforeEach(() => {
+    function setup() {
+      __resetFooForTesting();
+    }
+    setup();
+  });
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /__resetFooForTesting/);
+  assert.match(violations[0].message, /beforeEach only/);
+});
+
+test('inline helper defined but NEVER called from beforeEach: still flagged (accepted false positive)', () => {
+  // The companion to the test above: a helper defined inside the
+  // hook but never invoked. A static linter cannot tell this case
+  // apart from the defined-and-called case without dataflow
+  // analysis. We accept this false-positive because the alternative
+  // (skip nested function bodies) would silently miss the common
+  // defined-and-called case above. Loud false-positive in a single
+  // spec is cheap to fix; silent false-negative leaks across the
+  // suite (the original #350 bug class). See check-spec-patterns.mjs
+  // file-top "Helper-call semantics" section.
+  const text = `
+describe('x', () => {
+  beforeEach(() => {
+    function deadHelper() {
+      __resetFooForTesting();
+    }
+    // deadHelper is intentionally never invoked here.
+  });
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /__resetFooForTesting/);
+  assert.match(violations[0].message, /beforeEach only/);
 });

--- a/scripts/check-spec-patterns.test.mjs
+++ b/scripts/check-spec-patterns.test.mjs
@@ -37,7 +37,7 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 
-import { scanRegex, scanText } from './check-spec-patterns.mjs';
+import { REGEX_RULES, scanRegex, scanText, validateRules } from './check-spec-patterns.mjs';
 
 const SPEC_PATH = 'src/example.spec.ts';
 
@@ -476,4 +476,92 @@ describe('x', () => {
   assert.equal(violations.length, 1);
   assert.match(violations[0].message, /__resetFooForTesting/);
   assert.match(violations[0].message, /beforeEach only/);
+});
+
+// --- validateRules (rule-shape contract) ---------------------------------
+// PR #370 panel: enforce at module load what the docstring already
+// promises (id required, message required, pattern is a RegExp, no
+// duplicate ids). The /g flag is NOT validated here -- V8's matchAll
+// throws on non-global at engine call time with a better stack trace.
+
+test('validateRules rejects a rule with missing id', () => {
+  assert.throws(
+    () => validateRules([{ pattern: /foo/g, message: 'msg' }]),
+    /missing a non-empty `id`/,
+  );
+});
+
+test('validateRules rejects a rule with empty id', () => {
+  assert.throws(
+    () => validateRules([{ id: '', pattern: /foo/g, message: 'msg' }]),
+    /missing a non-empty `id`/,
+  );
+});
+
+test('validateRules rejects a rule with non-RegExp pattern', () => {
+  assert.throws(
+    () => validateRules([{ id: 'x', pattern: 'foo', message: 'msg' }]),
+    /pattern must be a RegExp/,
+  );
+});
+
+test('validateRules rejects a rule with missing message', () => {
+  assert.throws(
+    () => validateRules([{ id: 'x', pattern: /foo/g }]),
+    /message must be a non-empty string/,
+  );
+});
+
+test('validateRules rejects two rules sharing the same id', () => {
+  assert.throws(
+    () =>
+      validateRules([
+        { id: 'dup', pattern: /a/g, message: 'm1' },
+        { id: 'dup', pattern: /b/g, message: 'm2' },
+      ]),
+    /two rules with id "dup"/,
+  );
+});
+
+// --- Engine termination (PR #370 bot finding regression test) ---------
+// The previous `while ((m = rule.pattern.exec(text)) !== null)` engine
+// would hang on the first match if a rule forgot `/g`. The matchAll
+// engine throws a TypeError at call time instead. These tests are
+// the actual canary for the bot's concern -- they prove the scan
+// loop terminates on multi-match input AND that a non-global pattern
+// fails loudly with a message that names the rule and points at the
+// fix.
+
+test('scanRegex terminates on multiple matches (not just the first)', { timeout: 2000 }, () => {
+  const text = `
+describe('a', () => {
+  it('b', () => spyOnProperty(navigator, 'clipboard', 'get'));
+  it('c', () => spyOnProperty(navigator, 'clipboard', 'get'));
+});
+`;
+  const violations = scanRegex(text, SPEC_PATH);
+  assert.equal(violations.length, 2);
+  assert.equal(violations[0].ruleId, 'spy-on-navigator-clipboard');
+  assert.equal(violations[1].ruleId, 'spy-on-navigator-clipboard');
+});
+
+test('scanRegex throws actionable error if a rule pattern is non-global', () => {
+  const savedPattern = REGEX_RULES[0].pattern;
+  // Mutate the existing rule in place to bypass validateRules (which
+  // would have rejected the bad shape at module load). This simulates
+  // the failure mode for a rule that somehow has a non-global RegExp
+  // at scan time -- the engine itself rejects it.
+  REGEX_RULES[0].pattern = /spyOnProperty/;
+  try {
+    assert.throws(
+      () => scanRegex('spyOnProperty(navigator, "clipboard", "get")', SPEC_PATH),
+      (err) =>
+        err instanceof TypeError &&
+        /spy-on-navigator-clipboard/.test(err.message) &&
+        /matchAll requires \/g/.test(err.message) &&
+        /scripts\/check-spec-patterns\.mjs/.test(err.message),
+    );
+  } finally {
+    REGEX_RULES[0].pattern = savedPattern;
+  }
 });

--- a/scripts/check-spec-patterns.test.mjs
+++ b/scripts/check-spec-patterns.test.mjs
@@ -1,0 +1,384 @@
+// Unit tests for scripts/check-spec-patterns.mjs.
+//
+// Runs under Node's built-in test runner: `node --test`. No external
+// runtime dependencies beyond `typescript` (already a transitive dev
+// dep). The test file imports the script as a module; the script
+// guards `main()` behind an "invoked directly" check so importing it
+// does not trigger CLI side effects (git ls-files, fs reads,
+// process.exit).
+//
+// Coverage:
+//  - Regex rule still fires on the existing `spyOnProperty(navigator,
+//    'clipboard', ...)` pattern.
+//  - AST rule (`__reset*ForTesting` symmetry) catches:
+//     - reset call in `beforeEach` only
+//     - reset call in `afterEach` only
+//     - asymmetric reset in a nested `describe`
+//  - AST rule passes (no violation) on:
+//     - symmetric reset in both hooks
+//     - no resets at all
+//     - set/reset pair with different identifiers
+//     - reset call inside an `it` body (not `beforeEach`/`afterEach`)
+//     - `__set*` / `__attach*` / `__load*` / `__flush*` helpers
+//       (narrowed regex excludes them)
+//  - Pathological-shape coverage: template literals, regex literals,
+//    block comments containing `beforeEach` tokens,
+//    `describe.skip` / `xdescribe` / `fdescribe`, `xit` / `fit`,
+//    async-arrow callbacks, function-expression callbacks.
+
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import { scanRegex, scanText } from './check-spec-patterns.mjs';
+
+const SPEC_PATH = 'src/example.spec.ts';
+
+// --- Regex rule (existing clipboard pattern) --------------------------
+
+test('regex rule fires on spyOnProperty(navigator, "clipboard", ...)', () => {
+  const text = `
+describe('x', () => {
+  it('y', () => {
+    spyOnProperty(navigator, 'clipboard', 'get').and.returnValue({});
+  });
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter(
+    (v) => v.ruleId === 'spy-on-navigator-clipboard',
+  );
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].snippet, /spyOnProperty/);
+});
+
+test('regex rule does not fire on unrelated spyOnProperty calls', () => {
+  const text = `
+describe('x', () => {
+  it('y', () => {
+    spyOnProperty(navigator, 'userAgent', 'get').and.returnValue('foo');
+  });
+});
+`;
+  const violations = scanRegex(text, SPEC_PATH);
+  assert.equal(violations.length, 0);
+});
+
+// --- AST rule: positive cases (lints clean) ---------------------------
+
+test('symmetric reset in both hooks: no violation', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  afterEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('no resets at all: no violation', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => {});
+  afterEach(() => {});
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH);
+  assert.equal(violations.length, 0);
+});
+
+test('set/reset pair (afterEach-only) is the canonical pattern: no violation', () => {
+  // __setX in beforeEach, __resetX in afterEach is the legitimate
+  // set/reset pair where the setter is the test-action and the reset
+  // is the cleanup. The lint rule deliberately allows afterEach-only
+  // resets because that IS the cleanup half of the pair. Only
+  // beforeEach-only resets are flagged (they would indicate cleanup
+  // happens at the start of MY test, but cross-test leakage already
+  // happened by then).
+  const text = `
+describe('x', () => {
+  beforeEach(() => __setFooImplForTesting(stub));
+  afterEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('__set*, __attach*, __load*, __flush* are NOT constrained by symmetry rule', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => {
+    __setFooImplForTesting(stub);
+    __attachHandlerForTesting(handler);
+    __loadConfigForTesting(config);
+    __flushQueueForTesting();
+  });
+  // No afterEach. Without the narrowed regex, all four would be
+  // flagged; with it, none of them are.
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('reset call inside it() body is not constrained', () => {
+  const text = `
+describe('x', () => {
+  it('y', () => {
+    __resetFooForTesting();
+    expect(foo()).toBe(true);
+  });
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+// --- AST rule: negative cases (lints fail) ----------------------------
+
+test('reset in beforeEach only: violation (beforeEach only)', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /beforeEach only/);
+  assert.equal(violations[0].snippet, '__resetFooForTesting()');
+});
+
+test('reset in afterEach only: NOT a violation (canonical set/reset pair)', () => {
+  // Per the narrowed rule, afterEach-only is the legitimate cleanup
+  // half of a set/reset pair. The "setter" may live in beforeEach
+  // (most common) or in the `it` body (also valid). Either way, the
+  // afterEach reset is cleanup-of-self, not cleanup-of-previous-test,
+  // so it does not signal a cross-test leak.
+  const text = `
+describe('x', () => {
+  afterEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('reset asymmetric in a nested describe', () => {
+  // Outer describe has symmetric pair (no violation). Inner describe
+  // has an additional beforeEach-only __resetBarForTesting.
+  const text = `
+describe('outer', () => {
+  beforeEach(() => __resetFooForTesting());
+  afterEach(() => __resetFooForTesting());
+
+  describe('inner', () => {
+    beforeEach(() => __resetBarForTesting());
+    it('z', () => {});
+  });
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /__resetBarForTesting/);
+  assert.match(violations[0].message, /beforeEach only/);
+});
+
+test('file-level (top-of-file) hooks treated as a single scope', () => {
+  // Hooks at file top-level (outside any describe) -- e.g., a setup
+  // file like `global-hooks.spec.ts` itself. The rule treats the
+  // file as a single scope.
+  const text = `
+beforeEach(() => __resetFooForTesting());
+afterEach(() => __resetFooForTesting());
+describe('x', () => {
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('file-level hook asymmetric is flagged', () => {
+  const text = `
+beforeEach(() => __resetFooForTesting());
+describe('x', () => {
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /beforeEach only/);
+});
+
+// --- AST rule: pathological-shape coverage ----------------------------
+
+test('template literal containing "beforeEach" in source does not fool the parser', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  afterEach(() => {
+    const msg = \`beforeEach is a string here\`;
+    expect(msg).toBeDefined();
+    __resetFooForTesting();
+  });
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('regex literal containing "}" does not fool the parser', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  afterEach(() => {
+    const re = /\\}/;
+    void re;
+    __resetFooForTesting();
+  });
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('block comment containing "beforeEach" tokens does not fool the parser', () => {
+  const text = `
+/* This comment mentions beforeEach and afterEach
+   and __resetFooForTesting but is not code. */
+describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  afterEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('describe.skip is treated as a describe scope', () => {
+  // The reset inside a `describe.skip` body is in a beforeEach with no
+  // matching afterEach -- still flagged. (Skipped or not, the same
+  // pattern is a bug.)
+  const text = `
+describe.skip('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+});
+
+test('xdescribe is treated as a describe scope', () => {
+  const text = `
+xdescribe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+});
+
+test('fdescribe is treated as a describe scope', () => {
+  const text = `
+fdescribe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+});
+
+test('xit / fit / it inside hooks do not affect rule', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  afterEach(() => __resetFooForTesting());
+  xit('skipped', () => __resetBarForTesting());
+  fit('focused', () => __resetBarForTesting());
+  it('plain', () => __resetBarForTesting());
+});
+`;
+  // __resetBarForTesting appears only in it/xit/fit bodies, not in
+  // hooks, so symmetry rule does not constrain it.
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('async arrow callbacks in hooks are supported', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(async () => {
+    await Promise.resolve();
+    __resetFooForTesting();
+  });
+  afterEach(async () => {
+    await Promise.resolve();
+    __resetFooForTesting();
+  });
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('function-expression callbacks in hooks are supported', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(function () {
+    __resetFooForTesting();
+  });
+  afterEach(function () {
+    __resetFooForTesting();
+  });
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 0);
+});
+
+test('multiple reset identifiers in same hook all enforced symmetrically', () => {
+  const text = `
+describe('x', () => {
+  beforeEach(() => {
+    __resetFooForTesting();
+    __resetBarForTesting();
+  });
+  afterEach(() => {
+    __resetFooForTesting();
+  });
+  it('y', () => {});
+});
+`;
+  // __resetFoo is symmetric; __resetBar is beforeEach only.
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.match(violations[0].message, /__resetBarForTesting/);
+  assert.match(violations[0].message, /beforeEach only/);
+});
+
+test('violation includes line and column from the offending node', () => {
+  const text = `describe('x', () => {
+  beforeEach(() => __resetFooForTesting());
+  it('y', () => {});
+});
+`;
+  const violations = scanText(text, SPEC_PATH).filter((v) => v.ruleId === 'reset-helper-symmetry');
+  assert.equal(violations.length, 1);
+  assert.equal(violations[0].line, 2); // line 2 has the beforeEach call
+  assert.equal(typeof violations[0].col, 'number');
+  assert.ok(violations[0].col > 0);
+});

--- a/src/app/core/telemetry/cold-flag.spec.ts
+++ b/src/app/core/telemetry/cold-flag.spec.ts
@@ -5,6 +5,10 @@ describe('cold-flag', () => {
     __resetColdFlagsForTesting();
   });
 
+  afterEach(() => {
+    __resetColdFlagsForTesting();
+  });
+
   it('returns true on the first call for a token', () => {
     expect(isColdAndMark('parse.slow')).toBe(true);
   });

--- a/src/app/shared/components/json-tree/json-tree.component.spec.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.spec.ts
@@ -151,6 +151,7 @@ describe('JsonTreeComponent', () => {
     localStorage.removeItem(STORAGE_KEY);
     localStorage.removeItem(TREE_SEARCH_STORAGE_KEY);
     detachAllFixtureWrappers();
+    __resetColdFlagsForTesting();
   });
 
   // Phase 2 (issue #95) -- `<cdk-virtual-scroll-viewport>` reads

--- a/src/app/shared/utils/date-detect.spec.ts
+++ b/src/app/shared/utils/date-detect.spec.ts
@@ -8,6 +8,7 @@ import {
 
 describe('date-detect', () => {
   beforeEach(() => __resetLocaleOrderCacheForTesting());
+  afterEach(() => __resetLocaleOrderCacheForTesting());
 
   describe('parseAsDate - ISO 8601 with time', () => {
     it('parses ISO with Z', () => {

--- a/src/testing/global-hooks.spec.ts
+++ b/src/testing/global-hooks.spec.ts
@@ -1,0 +1,157 @@
+/**
+ * Global per-test isolation hook (issue #350).
+ *
+ * Top-level `beforeEach` / `afterEach` in any spec file run globally
+ * under Karma + Jasmine. This file installs a cleanup pass that runs
+ * after every spec across the entire suite to undo two classes of
+ * cross-spec state leakage:
+ *
+ *   1. `localStorage` / `sessionStorage` entries left behind by a
+ *      test that forgot its own `afterEach`.
+ *   2. `Storage.prototype` patches (e.g., a spy on
+ *      `Storage.prototype.setItem` that never gets restored).
+ *
+ * Failure mode this prevents: a spec that runs in random order
+ * before its victim passes locally and on the first CI attempt,
+ * then fails on a retry when the order changes. See PR #351 for
+ * the original `sw-registration` -> `LoggerService` flake that
+ * motivated this hook.
+ *
+ * What this hook deliberately does NOT cover:
+ *   - New top-level properties on `window`. An earlier draft
+ *     deleted any key not present at module-load snapshot. That
+ *     overreached: legitimate `beforeAll`-seeded state (notably
+ *     Monaco's `window.monaco` / `window.MonacoEnvironment` in the
+ *     `JsonEditorComponent` browser-integration spec) was deleted
+ *     between specs in the same describe block, breaking the
+ *     suite. Specs that extend `window` (including `beforeAll`
+ *     seeding) must clean up in their own `afterEach` / `afterAll`.
+ *   - Mutations of *existing* `window` properties (e.g.,
+ *     `window.fetch = mockFetch`). Specs that overwrite built-ins
+ *     must restore them manually.
+ *   - `document.*` mutations and event-listener registrations on
+ *     `window` / `document`.
+ *   - Outstanding `requestAnimationFrame` /
+ *     `IntersectionObserver` / `MutationObserver` / `ResizeObserver`
+ *     registrations.
+ *   - Module-scoped state inside ES modules. ES modules are
+ *     singletons; external code cannot reset them. Use the
+ *     `__resetXForTesting` convention; the lint rule in
+ *     `scripts/check-spec-patterns.mjs` enforces that any
+ *     `__reset*ForTesting` placed in `beforeEach` is also placed
+ *     in the matching `afterEach`.
+ *
+ * Design decisions:
+ *   - `beforeEach` is deliberately absent. Clearing storages
+ *     globally before each spec would silently delete data that
+ *     `beforeAll` seeded for a whole describe block. Defense
+ *     happens in `afterEach` only, so the next spec inherits a
+ *     clean slate without the current spec's setup being clobbered.
+ *   - `getOwnPropertyDescriptors` is used on `Storage.prototype` to
+ *     capture the `length` accessor's getter, not just enumerable
+ *     methods.
+ *   - Storage-prototype restoration is wrapped in `try / catch` per
+ *     descriptor because some properties are non-configurable in
+ *     some environments; one rogue test must not brick the hook
+ *     for every later spec.
+ */
+
+const cleanStorageProto: Readonly<Record<string, PropertyDescriptor>> = Object.freeze({
+  ...Object.getOwnPropertyDescriptors(Storage.prototype),
+});
+
+function restoreStoragePrototype(): void {
+  const currentProto = Object.getOwnPropertyDescriptors(Storage.prototype);
+  for (const key of Object.keys(cleanStorageProto)) {
+    const original = cleanStorageProto[key];
+    const live = currentProto[key];
+    if (descriptorsEqual(original, live)) continue;
+    try {
+      Object.defineProperty(Storage.prototype, key, original);
+    } catch {
+      // Non-configurable in this environment; nothing we can do.
+      // Log via console.warn so the failure is observable.
+      // eslint-disable-next-line no-console
+      console.warn(
+        `[global-hooks] could not restore Storage.prototype.${key} -- ` +
+          'descriptor non-configurable in this environment.',
+      );
+    }
+  }
+}
+
+function descriptorsEqual(
+  a: PropertyDescriptor | undefined,
+  b: PropertyDescriptor | undefined,
+): boolean {
+  if (a === b) return true;
+  if (!a || !b) return false;
+  return (
+    a.value === b.value &&
+    a.get === b.get &&
+    a.set === b.set &&
+    a.writable === b.writable &&
+    a.enumerable === b.enumerable &&
+    a.configurable === b.configurable
+  );
+}
+
+afterEach(() => {
+  localStorage.clear();
+  sessionStorage.clear();
+  restoreStoragePrototype();
+});
+
+/**
+ * Permanent verifier: deliberately leaks state in one spec and
+ * asserts clean state in the next. If a future refactor breaks the
+ * `afterEach` hook above, this fails.
+ *
+ * Under Jasmine `random: true` the two specs may run in either
+ * order. The verifier proves the hook works regardless:
+ * - If "leaks" runs first, "observes clean" sees the cleared state.
+ * - If "observes clean" runs first, it sees the clean state at
+ *   module-load time (no prior spec leaked).
+ */
+describe('global test isolation hook (verifier)', () => {
+  const STORAGE_KEY = 'jj-global-hook-verifier';
+
+  it('leaks state (deliberate)', () => {
+    localStorage.setItem(STORAGE_KEY, 'leaked');
+    sessionStorage.setItem(STORAGE_KEY, 'leaked');
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe('leaked');
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBe('leaked');
+  });
+
+  it('observes clean state (no prior leakage from sibling)', () => {
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull();
+    expect(sessionStorage.getItem(STORAGE_KEY)).toBeNull();
+  });
+});
+
+/**
+ * Permanent verifier for `Storage.prototype` restoration: patches
+ * `Storage.prototype.setItem` in one spec and asserts the original
+ * is restored in the next.
+ */
+describe('global test isolation hook -- Storage.prototype restore', () => {
+  const SENTINEL_KEY = 'jj-storage-proto-verifier';
+
+  it('patches Storage.prototype.setItem (deliberate)', () => {
+    const patched = function patched(this: Storage, key: string, _value: string): void {
+      void _value;
+      // Deliberately a no-op; the next spec will assert real setItem
+      // works again.
+      void key;
+    };
+    Storage.prototype.setItem = patched as Storage['setItem'];
+    localStorage.setItem(SENTINEL_KEY, 'should-be-discarded-by-patch');
+    expect(localStorage.getItem(SENTINEL_KEY)).toBeNull();
+  });
+
+  it('observes original Storage.prototype.setItem restored', () => {
+    localStorage.setItem(SENTINEL_KEY, 'real-write');
+    expect(localStorage.getItem(SENTINEL_KEY)).toBe('real-write');
+  });
+});

--- a/src/testing/global-hooks.spec.ts
+++ b/src/testing/global-hooks.spec.ts
@@ -54,6 +54,13 @@
  *     descriptor because some properties are non-configurable in
  *     some environments; one rogue test must not brick the hook
  *     for every later spec.
+ *   - `restoreStoragePrototype()` runs *before* the `localStorage` /
+ *     `sessionStorage` clears in the `afterEach`. A spec that
+ *     patches `Storage.prototype.clear` (e.g., to a no-op or to
+ *     throw) would otherwise defeat the cleanup, because the global
+ *     `clear()` calls would inherit the patch. Restoring the
+ *     prototype first ensures `clear()` invokes the original
+ *     implementation.
  */
 
 const cleanStorageProto: Readonly<Record<string, PropertyDescriptor>> = Object.freeze({
@@ -97,9 +104,9 @@ function descriptorsEqual(
 }
 
 afterEach(() => {
+  restoreStoragePrototype();
   localStorage.clear();
   sessionStorage.clear();
-  restoreStoragePrototype();
 });
 
 /**
@@ -153,5 +160,40 @@ describe('global test isolation hook -- Storage.prototype restore', () => {
   it('observes original Storage.prototype.setItem restored', () => {
     localStorage.setItem(SENTINEL_KEY, 'real-write');
     expect(localStorage.getItem(SENTINEL_KEY)).toBe('real-write');
+  });
+});
+
+/**
+ * Permanent verifier for `Storage.prototype.clear`-patch ordering:
+ * patches `Storage.prototype.clear` to a no-op in one spec, leaks
+ * data, and asserts the next spec sees clean state. Proves the
+ * `afterEach` ordering (`restoreStoragePrototype()` before the
+ * `clear()` calls) works: even with `clear` patched, the prototype
+ * is restored first, so the subsequent global `clear()` calls
+ * invoke the original implementation and remove the leaked data.
+ *
+ * If a future refactor swaps the ordering back to `clear; clear;
+ * restore`, this verifier fails.
+ */
+describe('global test isolation hook -- clear-patch ordering', () => {
+  const SENTINEL_KEY = 'jj-clear-patch-verifier';
+
+  it('patches Storage.prototype.clear to a no-op and leaks data (deliberate)', () => {
+    Storage.prototype.clear = function noopClear(this: Storage): void {
+      // Deliberately a no-op. If the afterEach clears storage
+      // *before* restoring Storage.prototype, this patch would
+      // silently defeat the global cleanup.
+    } as Storage['clear'];
+
+    localStorage.setItem(SENTINEL_KEY, 'leaked-under-patched-clear');
+    sessionStorage.setItem(SENTINEL_KEY, 'leaked-under-patched-clear');
+
+    expect(localStorage.getItem(SENTINEL_KEY)).toBe('leaked-under-patched-clear');
+    expect(sessionStorage.getItem(SENTINEL_KEY)).toBe('leaked-under-patched-clear');
+  });
+
+  it('observes clean state (restore must run before clear in afterEach)', () => {
+    expect(localStorage.getItem(SENTINEL_KEY)).toBeNull();
+    expect(sessionStorage.getItem(SENTINEL_KEY)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

Closes #350 -- the broader test-isolation follow-up to #351 (the
`sw-registration` -> `LoggerService` flake).

Three complementary mechanisms at different architectural layers:

1. **Runtime hook** (`src/testing/global-hooks.spec.ts`) -- top-level
   `afterEach` clears `localStorage` / `sessionStorage` and restores
   any `Storage.prototype` descriptors that a spec patched.
2. **Static analysis** (`scripts/check-spec-patterns.mjs`) -- new AST
   rule flags `__reset*ForTesting()` placed in `beforeEach` without
   a matching call in `afterEach` (the bug pattern: cleanup at the
   start of MY test, when leakage already happened).
3. **Per-spec fixes** (3 files) -- cold-flag, date-detect, and
   json-tree specs had `beforeEach`-only resets surfaced by the lint
   rule above.

## What the runtime hook deliberately does NOT cover

- New top-level `window` properties. An earlier draft of the hook
  diff'd `window` keys against a module-load snapshot, but that
  overreached: the JSON editor browser-integration spec uses
  `beforeAll` to load Monaco once for the whole describe block, and
  the per-spec cleanup deleted `window.monaco` between the `it`s
  inside that block. Specs that extend `window` (including
  `beforeAll` seeding) clean up in their own `afterEach` /
  `afterAll`.
- Mutations of *existing* `window` properties, `document.*` edits,
  event-listener registrations, outstanding rAF /
  `IntersectionObserver` / `MutationObserver` / `ResizeObserver`
  registrations. Per-spec discipline applies.
- ES-module-scoped state. Use the `__reset*ForTesting` convention;
  the lint rule enforces symmetry.

## Lint rule direction

The rule flags `beforeEach`-only resets, not `afterEach`-only.
`afterEach`-only is the canonical set/reset pair pattern
(`__setX...ForTesting` in beforeEach, `__resetX...ForTesting` in
afterEach) and is legitimate cleanup-of-self.

23 unit tests in `scripts/check-spec-patterns.test.mjs` cover
positive cases (symmetric, no resets, set/reset pair, etc.), negative
cases (beforeEach-only, nested describes, file-level hooks), and
pathological shapes (template literals containing `beforeEach`,
regex literals with `}`, block comments, `describe.skip`,
`xdescribe`, `fdescribe`, `xit` / `fit`, async-arrow
callbacks, function-expression callbacks).

## Verification

- `npm run lint:all` passes (root + api).
- `npm test` passes (2973 / 2973, full sweep on a cleared `dist/`).
- `npm run test:scripts` passes (382 / 382, Node built-in test
  runner over `scripts/*.test.mjs`).
- `npm run build` succeeds.
- Permanent verifier suites in `global-hooks.spec.ts` ran and
  passed (proving the hook works).

## Commits

- `feat(testing): add global isolation hook + permanent verifier`
- `lint: enforce symmetric __reset*ForTesting placement via AST`
- `test: add missing afterEach resets surfaced by spec-patterns lint`

## SemVer

No bump -- this is internal test infrastructure with no
user-observable behavior change. Build counter + SHA give per-deploy
resolution.

---
**Session**
- AI-Local: `9acca685-2884-43cc-bed6-2b2c01f08b9c`
- AI-Cloud: (not present in workspace.yaml)
