### PR TITLE
Add theme.applied telemetry for resolved color scheme

### DIFF
--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -596,6 +596,65 @@ customEvents
             count_ = count()
 ```
 
+#### `theme.applied`
+
+**Kind:** event   **Level:** info   **Cold flag:** no   **Sampling:** 100% (unsampled)
+
+Fired from `PreferencesService` (`core/preferences/preferences.service.ts`)
+at the lifecycle moments when the resolved (effective) color theme
+has been applied to the user's view:
+
+- Once at service construction (`source: 'boot'`), browser-only.
+  Always emits; this is the per-session baseline so every session
+  has one data point regardless of subsequent activity.
+- When the OS `prefers-color-scheme` flips while the stored pref
+  is `'system'` (`source: 'osChange'`). Dedupe drops the emit when
+  the resolved theme is unchanged.
+- When `applyPrefs` mutates state in a way that moves the effective
+  theme; `source` mirrors the upstream `PreferenceChangeSource`
+  (`'user' | 'init' | 'sync'`) so a user clicking the theme toggle
+  is distinguished from sign-in hydration / sign-out reset
+  (`'init'`) and a future server-pushed sync (`'sync'`). Dedupe
+  drops the emit when the resolved theme is unchanged.
+
+This event exists because `pref.changed` records the stored
+preference (`'system' | 'dark' | 'light'`), which is dominated by
+`'system'` (the default) -- so it cannot answer "what color scheme
+is actually being rendered?". `theme.applied` records the resolved
+value after `matchMedia('(prefers-color-scheme: light)')` is
+consulted.
+
+Bounded-frequency: boot is one-shot per service instance (~1 per
+browser tab). OS-flips and user pref clicks are user-bounded;
+`init` is bounded by auth-state transitions per session.
+
+**Properties:**
+
+| name | type | values |
+| --- | --- | --- |
+| effective | string | `'dark'` or `'light'` -- the resolved theme actually applied to `document.body`. |
+| pref | string | `'system'`, `'dark'`, or `'light'` -- the stored `UserPreferences.theme` value at emit time. |
+| source | string | `'boot'`, `'osChange'`, `'user'`, `'init'`, or `'sync'` -- which lifecycle moment caused the emit. |
+
+**Measurements:** none.
+
+**Example: dark vs light distribution at session start**
+
+```kusto
+customEvents
+| where name == "theme.applied" and customDimensions.source == "boot"
+| summarize sessions = dcount(session_Id)
+    by effective = tostring(customDimensions.effective)
+```
+
+**Example: how often does the OS flip the theme mid-session?**
+
+```kusto
+customEvents
+| where name == "theme.applied" and customDimensions.source == "osChange"
+| summarize flips = count(), sessions = dcount(session_Id)
+```
+
 ### SW migration verification
 
 After the `@angular/service-worker` -> minimal pass-through SW

--- a/src/app/app.component.spec.ts
+++ b/src/app/app.component.spec.ts
@@ -114,7 +114,7 @@ describe('AppComponent', () => {
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(loggerServiceSpy.event).toHaveBeenCalledOnceWith(
+    expect(loggerServiceSpy.event).toHaveBeenCalledWith(
       'app.boot',
       {
         version: jasmine.any(String),
@@ -129,6 +129,13 @@ describe('AppComponent', () => {
       },
       undefined,
     );
+    // PreferencesService also emits `theme.applied` (source: 'boot') during
+    // construction, so the spy receives more than one call. Verify
+    // `app.boot` itself was emitted exactly once.
+    const appBootCalls = loggerServiceSpy.event.calls
+      .allArgs()
+      .filter((args) => args[0] === 'app.boot');
+    expect(appBootCalls.length).toBe(1);
     expect(callOrder).toEqual(['event', 'connect']);
   });
 

--- a/src/app/core/preferences/preferences.service.spec.ts
+++ b/src/app/core/preferences/preferences.service.spec.ts
@@ -1,5 +1,5 @@
 import { HttpErrorResponse } from '@angular/common/http';
-import { signal } from '@angular/core';
+import { PLATFORM_ID, signal } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { of, Subject, throwError } from 'rxjs';
 import type { User, UserPreferences } from '../api/models';
@@ -433,12 +433,24 @@ describe('PreferencesService', () => {
   });
 
   describe('pref.changed telemetry', () => {
-    it('emits a string event for a changed theme', () => {
+    // The PreferencesService constructor emits a `theme.applied`
+    // event with `source: 'boot'` (see `theme.applied telemetry`
+    // describe below). Tests in this block focus on `pref.changed`
+    // and reset the spy after construction so existing assertions
+    // about the call count / shape of `pref.changed` are not
+    // affected by the boot emit.
+    function injectPrefs(): PreferencesService {
       const svc = TestBed.inject(PreferencesService);
+      logger.event.calls.reset();
+      return svc;
+    }
+
+    it('emits a string event for a changed theme', () => {
+      const svc = injectPrefs();
 
       svc.update({ theme: 'dark' });
 
-      expect(logger.event).toHaveBeenCalledOnceWith(
+      expect(logger.event).toHaveBeenCalledWith(
         'pref.changed',
         { key: 'theme', source: 'user', kind: 'string', value: 'dark' },
         undefined,
@@ -446,7 +458,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a string event for a changed coldBootClipboardAutoPaste', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ coldBootClipboardAutoPaste: 'always' });
 
@@ -463,7 +475,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a string event for a changed searchMatchMode', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ searchMatchMode: 'starts_with' });
 
@@ -475,7 +487,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a number event with bucket and measurement for editorFontSize', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ editorFontSize: 18 });
 
@@ -487,7 +499,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a count event with bucket and measurement for activeRuleSetIds', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ activeRuleSetIds: ['a', 'b'] });
 
@@ -499,7 +511,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a count event with enabled-unit measurement for treeDateAnnotationUnits', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update(makeTreeDateAnnotationUnitsPatch({ year: false, second: false }));
 
@@ -516,7 +528,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits boolean dimensions as strings', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ treeShowTypeLabels: false });
 
@@ -528,7 +540,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a boolean event for treeDateAnnotationFriendlyForms', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ treeDateAnnotationFriendlyForms: false });
 
@@ -545,7 +557,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits only the changed treeHighlightColors leaf', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update(makeTreeHighlightPatch({ dark: { selectionColor: '#ff0000' } }));
 
@@ -563,7 +575,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a color event when dark manualHighlightColor changes', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update(makeTreeHighlightPatch({ dark: { manualHighlightColor: '#ff0000' } }));
 
@@ -581,7 +593,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a color event when light manualHighlightColor changes', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update(makeTreeHighlightPatch({ light: { manualHighlightColor: '#00ff00' } }));
 
@@ -599,20 +611,22 @@ describe('PreferencesService', () => {
     });
 
     it('reset emits one user-sourced event per key that differs from defaults', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
       svc.update({ theme: 'dark', editorFontSize: 18, treeShowTypeLabels: false });
       logger.event.calls.reset();
 
       svc.reset();
 
-      const calls = logger.event.calls.allArgs();
-      expect(calls.length).toBe(3);
-      expect(calls.map((callArguments) => callArguments[1]?.['source'])).toEqual([
+      const prefChangedCalls = logger.event.calls
+        .allArgs()
+        .filter((args) => args[0] === 'pref.changed');
+      expect(prefChangedCalls.length).toBe(3);
+      expect(prefChangedCalls.map((callArguments) => callArguments[1]?.['source'])).toEqual([
         'user',
         'user',
         'user',
       ]);
-      expect(calls.map((callArguments) => callArguments[1]?.['key'])).toEqual([
+      expect(prefChangedCalls.map((callArguments) => callArguments[1]?.['key'])).toEqual([
         'theme',
         'editorFontSize',
         'treeShowTypeLabels',
@@ -620,14 +634,17 @@ describe('PreferencesService', () => {
     });
 
     it('sign-in hydration emits init-sourced events for remote preference diffs', async () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
       api.getMe.and.returnValue(of(makeUserResponse({ theme: 'dark', editorFontSize: 18 })));
 
       auth.signInAs('u-1');
       TestBed.flushEffects();
       await svc.__waitForSync();
 
-      expect(logger.event).toHaveBeenCalledTimes(2);
+      const prefChangedCalls = logger.event.calls
+        .allArgs()
+        .filter((args) => args[0] === 'pref.changed');
+      expect(prefChangedCalls.length).toBe(2);
       expect(logger.event).toHaveBeenCalledWith(
         'pref.changed',
         { key: 'theme', source: 'init', kind: 'string', value: 'dark' },
@@ -641,7 +658,7 @@ describe('PreferencesService', () => {
     });
 
     it('sign-out reset emits init-sourced events for non-default current prefs', async () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
       api.getMe.and.returnValue(of(makeUserResponse({ theme: 'dark', editorFontSize: 18 })));
       auth.signInAs('u-1');
       TestBed.flushEffects();
@@ -651,7 +668,10 @@ describe('PreferencesService', () => {
       auth.signOut();
       TestBed.flushEffects();
 
-      expect(logger.event).toHaveBeenCalledTimes(2);
+      const prefChangedCalls = logger.event.calls
+        .allArgs()
+        .filter((args) => args[0] === 'pref.changed');
+      expect(prefChangedCalls.length).toBe(2);
       expect(logger.event).toHaveBeenCalledWith(
         'pref.changed',
         { key: 'theme', source: 'init', kind: 'string', value: 'system' },
@@ -665,11 +685,14 @@ describe('PreferencesService', () => {
     });
 
     it('emits one event for each changed key in a multi-key patch', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ theme: 'dark', editorFontSize: 18 });
 
-      expect(logger.event).toHaveBeenCalledTimes(2);
+      const prefChangedCalls = logger.event.calls
+        .allArgs()
+        .filter((args) => args[0] === 'pref.changed');
+      expect(prefChangedCalls.length).toBe(2);
       expect(logger.event).toHaveBeenCalledWith(
         'pref.changed',
         { key: 'theme', source: 'user', kind: 'string', value: 'dark' },
@@ -683,7 +706,7 @@ describe('PreferencesService', () => {
     });
 
     it('does not emit when theme is already system', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ theme: 'system' });
 
@@ -691,7 +714,7 @@ describe('PreferencesService', () => {
     });
 
     it('does not emit for an empty patch', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({});
 
@@ -699,17 +722,23 @@ describe('PreferencesService', () => {
     });
 
     it('does not emit when editorFontSize is unchanged', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ editorFontSize: 14 });
 
       expect(logger.event).not.toHaveBeenCalled();
     });
 
-    it('does not emit during constructor initial load', () => {
+    it('does not emit pref.changed during constructor initial load', () => {
       TestBed.inject(PreferencesService);
 
-      expect(logger.event).not.toHaveBeenCalled();
+      // The constructor emits exactly one `theme.applied` boot event;
+      // it must NOT emit any `pref.changed` events because no
+      // preference actually changed (only resolution happened).
+      const prefChangedCalls = logger.event.calls
+        .allArgs()
+        .filter((args) => args[0] === 'pref.changed');
+      expect(prefChangedCalls.length).toBe(0);
     });
 
     it('does not emit when matchMedia recomputes the system theme', () => {
@@ -750,11 +779,15 @@ describe('PreferencesService', () => {
       TestBed.flushEffects();
 
       expect(svc.prefs().theme).toBe('system');
+      // matchMedia.matches stays true across the synthetic change, so
+      // effective theme stays 'light' and `theme.applied` dedupes
+      // away. `pref.changed` never fires either because the stored
+      // pref didn't change.
       expect(logger.event).not.toHaveBeenCalled();
     });
 
     it('does not emit when a treeHighlightColors leaf is unchanged', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update(makeTreeHighlightPatch({ dark: { selectionColor: '#264f78' } }));
 
@@ -762,7 +795,7 @@ describe('PreferencesService', () => {
     });
 
     it('emits a boolean event for treeAutoFitToWindow', () => {
-      const svc = TestBed.inject(PreferencesService);
+      const svc = injectPrefs();
 
       svc.update({ treeAutoFitToWindow: false });
 
@@ -771,6 +804,243 @@ describe('PreferencesService', () => {
         { key: 'treeAutoFitToWindow', source: 'user', kind: 'boolean', value: 'false' },
         undefined,
       );
+    });
+  });
+
+  describe('theme.applied telemetry', () => {
+    /**
+     * Stubs `window.matchMedia` deterministically so dedupe behavior
+     * across boot / osChange / pref-change emits is observable. The
+     * returned `fireChange()` invokes every registered `'change'`
+     * listener once.
+     */
+    function stubMatchMedia(initialPrefersLight: boolean): { fireChange: () => void } {
+      let prefersLight = initialPrefersLight;
+      const changeListeners: Array<EventListenerOrEventListenerObject> = [];
+      spyOn(window, 'matchMedia').and.callFake(
+        (query: string): MediaQueryList => ({
+          get matches(): boolean {
+            // Only the `(prefers-color-scheme: light)` query is
+            // meaningful for this test; default everything else to false.
+            return query.includes('light') ? prefersLight : false;
+          },
+          media: query,
+          onchange: null,
+          addEventListener: (
+            type: string,
+            listener: EventListenerOrEventListenerObject | null,
+          ): void => {
+            if (type === 'change' && listener !== null) {
+              changeListeners.push(listener);
+            }
+          },
+          removeEventListener: (): void => undefined,
+          dispatchEvent: (): boolean => true,
+          addListener: (): void => undefined,
+          removeListener: (): void => undefined,
+        }),
+      );
+      return {
+        fireChange: (): void => {
+          prefersLight = !prefersLight;
+          const event = new Event('change');
+          for (const listener of changeListeners) {
+            if (typeof listener === 'function') listener(event);
+            else listener.handleEvent(event);
+          }
+        },
+      };
+    }
+
+    function themeAppliedCalls(): Array<{
+      effective: 'dark' | 'light';
+      pref: UserPreferences['theme'];
+      source: string;
+    }> {
+      return logger.event.calls.allArgs().reduce<
+        Array<{
+          effective: 'dark' | 'light';
+          pref: UserPreferences['theme'];
+          source: string;
+        }>
+      >((acc, args) => {
+        if (args[0] !== 'theme.applied') return acc;
+        const props = args[1] as {
+          effective: 'dark' | 'light';
+          pref: UserPreferences['theme'];
+          source: string;
+        };
+        acc.push({ effective: props.effective, pref: props.pref, source: props.source });
+        return acc;
+      }, []);
+    }
+
+    it('boot emit on explicit dark pref', () => {
+      stubMatchMedia(true);
+      localStorage.setItem(STORAGE_KEY, JSON.stringify({ theme: 'dark' }));
+
+      TestBed.inject(PreferencesService);
+
+      expect(themeAppliedCalls()).toEqual([{ effective: 'dark', pref: 'dark', source: 'boot' }]);
+    });
+
+    it('boot emit on system pref reads matchMedia', () => {
+      stubMatchMedia(true);
+
+      TestBed.inject(PreferencesService);
+
+      expect(themeAppliedCalls()).toEqual([{ effective: 'light', pref: 'system', source: 'boot' }]);
+    });
+
+    it('boot emit falls back to dark when matchMedia is absent', () => {
+      // Older browsers / non-DOM contexts. The fallback at
+      // resolveEffectiveTheme line 124 returns 'dark'.
+      const originalMatchMedia = window.matchMedia;
+      (window as { matchMedia?: typeof window.matchMedia }).matchMedia =
+        undefined as unknown as typeof window.matchMedia;
+      try {
+        TestBed.inject(PreferencesService);
+
+        expect(themeAppliedCalls()).toEqual([
+          { effective: 'dark', pref: 'system', source: 'boot' },
+        ]);
+      } finally {
+        window.matchMedia = originalMatchMedia;
+      }
+    });
+
+    it('boot emit still fires when localStorage is corrupt (defaults apply)', () => {
+      stubMatchMedia(false);
+      localStorage.setItem(STORAGE_KEY, '{not json');
+
+      TestBed.inject(PreferencesService);
+
+      // mergeWithDefaults wraps in try/catch and yields DEFAULTS
+      // (`theme: 'system'`); matchMedia stub returns dark.
+      expect(themeAppliedCalls()).toEqual([{ effective: 'dark', pref: 'system', source: 'boot' }]);
+    });
+
+    it('osChange emit on matchMedia flip while pref is system', () => {
+      const { fireChange } = stubMatchMedia(false);
+
+      TestBed.inject(PreferencesService);
+      logger.event.calls.reset();
+
+      fireChange();
+      TestBed.flushEffects();
+
+      expect(themeAppliedCalls()).toEqual([
+        { effective: 'light', pref: 'system', source: 'osChange' },
+      ]);
+    });
+
+    it('osChange dedupes when effective theme does not change', () => {
+      // matchMedia change fires but `matches` stays the same:
+      // effective is still dark, dedupe skips the emit.
+      let prefersLight = false;
+      const changeListeners: Array<EventListenerOrEventListenerObject> = [];
+      spyOn(window, 'matchMedia').and.callFake(
+        (query: string): MediaQueryList => ({
+          get matches(): boolean {
+            return query.includes('light') ? prefersLight : false;
+          },
+          media: query,
+          onchange: null,
+          addEventListener: (
+            type: string,
+            listener: EventListenerOrEventListenerObject | null,
+          ): void => {
+            if (type === 'change' && listener !== null) changeListeners.push(listener);
+          },
+          removeEventListener: (): void => undefined,
+          dispatchEvent: (): boolean => true,
+          addListener: (): void => undefined,
+          removeListener: (): void => undefined,
+        }),
+      );
+      TestBed.inject(PreferencesService);
+      logger.event.calls.reset();
+
+      // Fire the synthetic change WITHOUT toggling prefersLight: the
+      // listener resignals but `effectiveTheme()` is still 'dark'.
+      void prefersLight;
+      for (const listener of changeListeners) {
+        const event = new Event('change');
+        if (typeof listener === 'function') listener(event);
+        else listener.handleEvent(event);
+      }
+      TestBed.flushEffects();
+
+      expect(themeAppliedCalls()).toEqual([]);
+    });
+
+    it('user-source emit when pref change moves effective theme', () => {
+      stubMatchMedia(false);
+      const svc = TestBed.inject(PreferencesService);
+      logger.event.calls.reset();
+
+      svc.update({ theme: 'light' });
+
+      expect(themeAppliedCalls()).toEqual([{ effective: 'light', pref: 'light', source: 'user' }]);
+    });
+
+    it('dedupes when pref change does not move effective theme', () => {
+      // matchMedia returns dark; boot emits dark. User flips
+      // pref to 'system' -- effective resolves to dark again, so
+      // the dedupe drops the emit.
+      stubMatchMedia(false);
+      const svc = TestBed.inject(PreferencesService);
+      logger.event.calls.reset();
+
+      svc.update({ theme: 'system' });
+
+      expect(themeAppliedCalls()).toEqual([]);
+    });
+
+    it('init-source emit on sign-in hydration that moves effective theme', async () => {
+      stubMatchMedia(true); // boot resolves to 'light'
+      const svc = TestBed.inject(PreferencesService);
+      api.getMe.and.returnValue(of(makeUserResponse({ theme: 'dark' })));
+      logger.event.calls.reset();
+
+      auth.signInAs('u-1');
+      TestBed.flushEffects();
+      await svc.__waitForSync();
+
+      expect(themeAppliedCalls()).toEqual([{ effective: 'dark', pref: 'dark', source: 'init' }]);
+    });
+
+    it('init-source emit on sign-out reset that moves effective theme', async () => {
+      stubMatchMedia(true); // anon resolves to 'light' on system pref
+      const svc = TestBed.inject(PreferencesService);
+      api.getMe.and.returnValue(of(makeUserResponse({ theme: 'dark' })));
+      auth.signInAs('u-1');
+      TestBed.flushEffects();
+      await svc.__waitForSync();
+      logger.event.calls.reset();
+
+      auth.signOut();
+      TestBed.flushEffects();
+
+      // Defaults reapply (theme: 'system'); matchMedia stub returns
+      // 'light', so effective swings dark -> light.
+      expect(themeAppliedCalls()).toEqual([{ effective: 'light', pref: 'system', source: 'init' }]);
+    });
+
+    it('does not emit on the server platform', () => {
+      TestBed.resetTestingModule();
+      TestBed.configureTestingModule({
+        providers: [
+          { provide: AuthService, useValue: auth },
+          { provide: UserApiService, useValue: api },
+          { provide: LoggerService, useValue: logger },
+          { provide: PLATFORM_ID, useValue: 'server' },
+        ],
+      });
+
+      TestBed.inject(PreferencesService);
+
+      expect(themeAppliedCalls()).toEqual([]);
     });
   });
 

--- a/src/app/core/preferences/preferences.service.spec.ts
+++ b/src/app/core/preferences/preferences.service.spec.ts
@@ -450,6 +450,14 @@ describe('PreferencesService', () => {
 
       svc.update({ theme: 'dark' });
 
+      // `update({ theme: 'dark' })` also triggers `theme.applied` when
+      // the effective theme moves, so the global spy can see more than
+      // one call. Still assert exactly one `pref.changed` so a
+      // regression that duplicates the pref-change emit would fail.
+      const prefChangedCalls = logger.event.calls
+        .allArgs()
+        .filter((args) => args[0] === 'pref.changed');
+      expect(prefChangedCalls.length).toBe(1);
       expect(logger.event).toHaveBeenCalledWith(
         'pref.changed',
         { key: 'theme', source: 'user', kind: 'string', value: 'dark' },

--- a/src/app/core/preferences/preferences.service.spec.ts
+++ b/src/app/core/preferences/preferences.service.spec.ts
@@ -822,10 +822,13 @@ describe('PreferencesService', () => {
      * returned `fireChange()` invokes every registered `'change'`
      * listener once.
      */
-    function stubMatchMedia(initialPrefersLight: boolean): { fireChange: () => void } {
+    function stubMatchMedia(initialPrefersLight: boolean): {
+      fireChange: () => void;
+      matchMediaSpy: jasmine.Spy<typeof window.matchMedia>;
+    } {
       let prefersLight = initialPrefersLight;
       const changeListeners: Array<EventListenerOrEventListenerObject> = [];
-      spyOn(window, 'matchMedia').and.callFake(
+      const matchMediaSpy = spyOn(window, 'matchMedia').and.callFake(
         (query: string): MediaQueryList => ({
           get matches(): boolean {
             // Only the `(prefers-color-scheme: light)` query is
@@ -857,6 +860,7 @@ describe('PreferencesService', () => {
             else listener.handleEvent(event);
           }
         },
+        matchMediaSpy,
       };
     }
 
@@ -971,7 +975,6 @@ describe('PreferencesService', () => {
 
       // Fire the synthetic change WITHOUT toggling prefersLight: the
       // listener resignals but `effectiveTheme()` is still 'dark'.
-      void prefersLight;
       for (const listener of changeListeners) {
         const event = new Event('change');
         if (typeof listener === 'function') listener(event);
@@ -1049,6 +1052,29 @@ describe('PreferencesService', () => {
       TestBed.inject(PreferencesService);
 
       expect(themeAppliedCalls()).toEqual([]);
+    });
+
+    it('applyPrefs reads cached effectiveTheme to avoid redundant matchMedia (regression guard for #374)', () => {
+      // Perf invariant: when a user edits a non-theme preference
+      // while `theme === 'system'`, `applyPrefs` must consult the OS
+      // (`matchMedia`) at most once via the cached `effectiveTheme()`
+      // computed. The emit's read seeds the cache; the body-class
+      // and highlight-color effects then hit cache. If a future
+      // change reverts the emit to call `resolveEffectiveTheme`
+      // directly, this assertion catches it.
+      const { matchMediaSpy } = stubMatchMedia(false);
+      const svc = TestBed.inject(PreferencesService);
+      // Explicit precondition: the assertion below assumes the
+      // resolved-theme code path actually consults matchMedia, which
+      // only happens when `pref === 'system'`. If `DEFAULT_PREFERENCES`
+      // ever drifts away from 'system', this guard surfaces it.
+      expect(svc.prefs().theme).toBe('system');
+      matchMediaSpy.calls.reset();
+
+      svc.update({ editorFontSize: 18 });
+      TestBed.flushEffects();
+
+      expect(matchMediaSpy.calls.count()).toBe(1);
     });
   });
 

--- a/src/app/core/preferences/preferences.service.ts
+++ b/src/app/core/preferences/preferences.service.ts
@@ -207,6 +207,18 @@ function mergeWithDefaults(remote: Partial<UserPreferences>): UserPreferences {
 }
 
 type PreferenceChangeSource = 'user' | 'init' | 'sync';
+
+/**
+ * Source dimension for the `theme.applied` event. Extends
+ * `PreferenceChangeSource` with two lifecycle moments that do not
+ * flow through `applyPrefs`:
+ * - `'boot'`: synchronous emit in the constructor for the initial
+ *   resolved theme; always emits (skips dedupe) so every session
+ *   has a baseline data point.
+ * - `'osChange'`: the matchMedia `'change'` handler fired while
+ *   the stored pref is `'system'`.
+ */
+type ThemeAppliedSource = 'boot' | 'osChange' | PreferenceChangeSource;
 type TopLevelPreferenceKey = Exclude<keyof UserPreferences, 'treeHighlightColors'>;
 type TreeDateAnnotationUnits = UserPreferences['treeDateAnnotationUnits'];
 type PartialTreeDateAnnotationUnits = Partial<TreeDateAnnotationUnits>;
@@ -391,6 +403,15 @@ export class PreferencesService {
   private pendingDirty = false;
   private lastUserId: string | null = null;
 
+  /**
+   * Last resolved theme that `emitThemeApplied` actually emitted.
+   * Used to dedupe `osChange` / `user` / `init` / `sync` emits so a
+   * pref or OS change that doesn't move the effective theme (e.g.,
+   * `dark` -> `system` on a dark-mode OS) does NOT fire. `'boot'`
+   * always emits and updates this baseline.
+   */
+  private lastEmittedTheme: 'dark' | 'light' | null = null;
+
   private readonly events = new Subject<PreferencesEvent>();
   /**
    * Emits when a write is rejected with 412 because preferences were
@@ -452,6 +473,11 @@ export class PreferencesService {
       media.addEventListener?.('change', () => {
         if (this._prefs().theme === 'system') {
           this._prefs.set({ ...this._prefs() });
+          this.emitThemeApplied(
+            resolveEffectiveTheme(this._prefs().theme),
+            this._prefs().theme,
+            'osChange',
+          );
         }
       });
     }
@@ -487,6 +513,13 @@ export class PreferencesService {
         if (document.visibilityState === 'hidden') flushOnHide();
       });
     }
+
+    // Emit the boot baseline last so all constructor wiring is in
+    // place first (matchMedia listener, auth effect, sync effect).
+    // Browser-only via `emitThemeApplied`'s own `isBrowser` guard;
+    // prerender skips this emit.
+    const bootPref = this._prefs().theme;
+    this.emitThemeApplied(resolveEffectiveTheme(bootPref), bootPref, 'boot');
   }
 
   update(patch: Partial<UserPreferences>): void {
@@ -502,6 +535,14 @@ export class PreferencesService {
     const mergedPreferences = mergePreferencePatch(previousPreferences, next);
     this.emitPreferenceChanges(previousPreferences, mergedPreferences, source);
     this._prefs.set(mergedPreferences);
+    // After `_prefs.set` so `resolveEffectiveTheme` reads the post-mutation
+    // pref. Helper dedupes against `lastEmittedTheme`, so a pref change
+    // that doesn't move the resolved theme is a no-op here.
+    this.emitThemeApplied(
+      resolveEffectiveTheme(mergedPreferences.theme),
+      mergedPreferences.theme,
+      source,
+    );
   }
 
   private emitPreferenceChanges(
@@ -708,6 +749,26 @@ export class PreferencesService {
       { key, source, kind: 'count', countBucket: bucketCount(count) },
       { count },
     );
+  }
+
+  /**
+   * Emits a `theme.applied` event for the resolved color theme. See
+   * the JSDoc for `'theme.applied'` in
+   * `core/telemetry/telemetry-message-ids.ts` for the contract.
+   *
+   * Takes `effective` and `pref` as explicit arguments rather than
+   * reading `effectiveTheme()` / `_prefs()` to avoid stale reads
+   * from callers that emit between mutation steps.
+   */
+  private emitThemeApplied(
+    effective: 'dark' | 'light',
+    pref: UserPreferences['theme'],
+    source: ThemeAppliedSource,
+  ): void {
+    if (!this.isBrowser) return;
+    if (source !== 'boot' && effective === this.lastEmittedTheme) return;
+    this.lastEmittedTheme = effective;
+    this.loggerService.event('theme.applied', { effective, pref, source }, undefined);
   }
 
   private loadLocal(): UserPreferences {

--- a/src/app/core/preferences/preferences.service.ts
+++ b/src/app/core/preferences/preferences.service.ts
@@ -473,11 +473,15 @@ export class PreferencesService {
       media.addEventListener?.('change', () => {
         if (this._prefs().theme === 'system') {
           this._prefs.set({ ...this._prefs() });
-          this.emitThemeApplied(
-            resolveEffectiveTheme(this._prefs().theme),
-            this._prefs().theme,
-            'osChange',
-          );
+          // The spread above is load-bearing: it produces a new object
+          // reference, which (with default Object.is equality on the
+          // `_prefs` signal) invalidates the `effectiveTheme` computed
+          // so the next read recomputes from the new matchMedia state.
+          // Do NOT remove the resignal and do NOT add a custom `equal`
+          // to `_prefs` without rewriting this listener.
+          const effective = this.effectiveTheme();
+          const pref = this._prefs().theme;
+          this.emitThemeApplied(effective, pref, 'osChange');
         }
       });
     }
@@ -516,10 +520,15 @@ export class PreferencesService {
 
     // Emit the boot baseline last so all constructor wiring is in
     // place first (matchMedia listener, auth effect, sync effect).
+    // Read `effectiveTheme()` (the cached computed) rather than
+    // `resolveEffectiveTheme` directly so the matchMedia call is
+    // shared with the body-class / highlight-color effects' first
+    // reads of the same computed on their initial flush.
     // Browser-only via `emitThemeApplied`'s own `isBrowser` guard;
     // prerender skips this emit.
-    const bootPref = this._prefs().theme;
-    this.emitThemeApplied(resolveEffectiveTheme(bootPref), bootPref, 'boot');
+    const effective = this.effectiveTheme();
+    const pref = this._prefs().theme;
+    this.emitThemeApplied(effective, pref, 'boot');
   }
 
   update(patch: Partial<UserPreferences>): void {
@@ -535,14 +544,14 @@ export class PreferencesService {
     const mergedPreferences = mergePreferencePatch(previousPreferences, next);
     this.emitPreferenceChanges(previousPreferences, mergedPreferences, source);
     this._prefs.set(mergedPreferences);
-    // After `_prefs.set` so `resolveEffectiveTheme` reads the post-mutation
-    // pref. Helper dedupes against `lastEmittedTheme`, so a pref change
-    // that doesn't move the resolved theme is a no-op here.
-    this.emitThemeApplied(
-      resolveEffectiveTheme(mergedPreferences.theme),
-      mergedPreferences.theme,
-      source,
-    );
+    // Read the cached `effectiveTheme()` computed after `_prefs.set`
+    // so the matchMedia call is shared with the body-class /
+    // highlight-color effects' reads of the same computed. The helper
+    // dedupes against `lastEmittedTheme`, so a pref change that
+    // doesn't move the resolved theme is a no-op here.
+    const effective = this.effectiveTheme();
+    const pref = mergedPreferences.theme;
+    this.emitThemeApplied(effective, pref, source);
   }
 
   private emitPreferenceChanges(

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -1240,6 +1240,54 @@ export const TELEMETRY_MESSAGE_IDS = [
    */
   'pref.changed',
 
+  /**
+   * Kind: event
+   * Fired by: `PreferencesService` (`core/preferences/preferences.service.ts`)
+   *           at the three lifecycle moments when the resolved
+   *           ("effective") color theme has been applied to the
+   *           user's view:
+   *           - Once at service construction (`source: 'boot'`),
+   *             browser-only.
+   *           - When the OS `prefers-color-scheme` flips while the
+   *             stored preference is `'system'` (`source: 'osChange'`).
+   *           - When `applyPrefs` mutates state in a way that moves
+   *             the effective theme; `source` mirrors the
+   *             upstream `PreferenceChangeSource` (`'user' | 'init'
+   *             | 'sync'`) so sign-in hydration and a future
+   *             server-pushed sync are correctly distinguished from
+   *             a user click. `'init'` covers both sign-in
+   *             hydration and sign-out reset.
+   *
+   * This event exists because `pref.changed` records the stored
+   * preference (`'system' | 'dark' | 'light'`), which is dominated
+   * by `'system'` (the default) -- so it cannot answer "what color
+   * scheme is actually being rendered?". `theme.applied` records
+   * the resolved value after `matchMedia('(prefers-color-scheme:
+   * light)')` is consulted.
+   *
+   * Dedupe: emits only when the resolved theme differs from the
+   * last emitted value, except `source: 'boot'` always emits (so
+   * every session has a baseline data point). The dedupe means
+   * `applyPrefs` calls that don't move the effective theme
+   * (e.g., `dark` -> `system` on a dark-mode OS) do NOT fire.
+   *
+   * Volume control: bounded-frequency. Boot is one-shot per
+   * service-instance (~1 per browser tab). OS-flips and user pref
+   * clicks are user-bounded; `init` is bounded by auth-state
+   * transitions per session.
+   *
+   * Props: {
+   *   effective: 'dark' | 'light';
+   *   pref: 'system' | 'dark' | 'light';
+   *   source: 'boot' | 'osChange' | 'user' | 'init' | 'sync';
+   * }
+   *   All closed-enum. Cardinality bound: 2 x 3 x 5 = 30 combos;
+   *   reachable combos are fewer because `pref in {dark, light}`
+   *   pins `effective`. No PII, no per-user / per-session IDs.
+   * Measurements: none.
+   */
+  'theme.applied',
+
   // Formatting rule sets (M6g-1)
 
   /**

--- a/src/app/shared/components/json-editor/json-editor.component.spec.ts
+++ b/src/app/shared/components/json-editor/json-editor.component.spec.ts
@@ -417,10 +417,17 @@ describe('JsonEditorComponent', () => {
     installMonacoLoaderScriptPlaceholder();
     installRequireThatLoadsFakeMonaco();
     await create();
-    expect(logger.event).toHaveBeenCalledOnceWith('monaco.loaded', undefined, {
+    expect(logger.event).toHaveBeenCalledWith('monaco.loaded', undefined, {
       loadTimeMs: jasmine.any(Number),
     });
-    const measurements = logger.event.calls.mostRecent().args[2];
+    // PreferencesService also emits `theme.applied` (source: 'boot')
+    // during construction, so the spy receives more than one call.
+    // Verify `monaco.loaded` itself was emitted exactly once.
+    const monacoLoadedCalls = logger.event.calls
+      .allArgs()
+      .filter((args) => args[0] === 'monaco.loaded');
+    expect(monacoLoadedCalls.length).toBe(1);
+    const measurements = monacoLoadedCalls[0]?.[2];
     if (!measurements) {
       fail('monaco.loaded measurements were not captured');
       return;


### PR DESCRIPTION
## Summary

Adds a new `theme.applied` telemetry event that records the **resolved** (`dark` | `light`) color scheme actually applied to the user's view -- not the stored preference, which is dominated by `'system'` (the default) and cannot answer "what is the user actually seeing?".

## Motivation

The existing `pref.changed` event records the stored `theme` preference (`'system' | 'dark' | 'light'`). Because `'system'` is the default and the majority value, today's data cannot answer the basic product question "how many sessions render in dark vs light?". `PreferencesService.effectiveTheme()` already computes the resolved value via `matchMedia('(prefers-color-scheme: light)')`, but it was never logged.

## Approach

Emit `theme.applied` from `PreferencesService` at three lifecycle moments:

- `source: 'boot'` -- once at service construction (browser-only, always emits).
- `source: 'osChange'` -- when the OS `prefers-color-scheme` flips while the stored pref is `'system'`.
- `source: 'user' | 'init' | 'sync'` -- on `applyPrefs` that moves the effective theme; mirrors the existing `PreferenceChangeSource` so sign-in hydration / sign-out reset are correctly labeled `'init'` rather than collapsed under a user-driven bucket.

Dedupe: non-boot emits skip when the resolved theme hasn't moved since the last emit.

## Event shape

| field | values |
| --- | --- |
| `effective` | `'dark' \| 'light'` |
| `pref` | `'system' \| 'dark' \| 'light'` |
| `source` | `'boot' \| 'osChange' \| 'user' \| 'init' \| 'sync'` |

All closed-enum. No PII, no per-user / per-session IDs. Volume control: boot one-shot per service instance (~1 per tab); other sources are user-bounded.

## Files

- `src/app/core/telemetry/telemetry-message-ids.ts` -- new `'theme.applied'` token + full JSDoc.
- `src/app/core/preferences/preferences.service.ts` -- new `emitThemeApplied` helper (takes explicit args, no signal reads), wired into constructor (boot), matchMedia listener (osChange), and `applyPrefs` after `_prefs.set` (user/init/sync).
- `src/app/core/preferences/preferences.service.spec.ts` -- 11 new specs (boot variants incl. matchMedia-absent and corrupt-localStorage, osChange + dedupe, user pref change + dedupe, sign-in hydration, sign-out reset, server-platform suppression).
- `src/app/app.component.spec.ts`, `src/app/shared/components/json-editor/json-editor.component.spec.ts` -- two unrelated specs relaxed from `toHaveBeenCalledOnceWith` to per-event count filter, because the boot emit fires whenever `PreferencesService` is constructed.
- `docs/telemetry.md` -- new `#### theme.applied` section with KQL snippets.

## Query to answer the original question

```kql
customEvents
| where name == "theme.applied" and customDimensions.source == "boot"
| summarize sessions = dcount(session_Id)
    by effective = tostring(customDimensions.effective)
```

## Notes

- **SemVer bump**: none (internal telemetry only; no user-visible behavior change).
- **why-jotjson.md**: not updated (no user-facing feature change).
- **DoD**: `npm run lint:all` ok, `npm test` 2992/2992 ok, `npm run build` ok.
- **Rubber-duck**: `deep-review:skeptic` invoked during planning; 1 blocker (stale-read in `applyPrefs`) + 2 material (source-taxonomy collapse, hydration test gap) + minor/discuss findings all addressed before implementation. Full disposition in the session plan.

---
**Session**
- AI-Local: `57c1fe08-c66d-4d10-a8bc-2dd42823f070`
- AI-Cloud: `66dc8d07-26e3-4fb4-863d-dde00a4aba9f`
