### PR TITLE
Add PWA file_handlers + launchQueue for OS-level JSON file association

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -1408,6 +1408,82 @@ cannot confuse them for prod:
     own CSP context at script evaluation, that's how service workers
     work; it just never makes a fetch that would be subject to that
     context.
+  - **File handlers** (`manifest.webmanifest` -> `file_handlers` +
+    `launch_handler`): once the user installs JotJSON as a PWA on a
+    Chromium-based browser (Chrome, Edge, Brave, Arc, etc.) the
+    install registers JotJSON with the OS as a handler for
+    `.json`, `.jsonc`, `.json5`, and `.webmanifest`. The user can
+    then:
+    - Double-click a `.json` file in Explorer / Finder / a Linux
+      file manager and have it open in JotJSON, or
+    - Right-click -> Open with -> JotJSON, or
+    - Run `start data.json` (Windows) / `open -a JotJSON data.json`
+      (macOS) / `xdg-open data.json` (Linux desktop) from a terminal.
+    Mechanism: `file_handlers[].action: "/"` lands launches on the
+    home route; the W3C Launch Handler API's `window.launchQueue`
+    delivers `FileSystemFileHandle`s into the running app via a
+    `setConsumer` callback that runs at app boot. The
+    `LaunchQueueController` singleton in `core/upload/` registers
+    `setConsumer` once at app boot (under `isPlatformBrowser`); the
+    `HomeComponent` registers a handler with the controller in
+    `ngOnInit` and unregisters in `ngOnDestroy`. The ingress flows
+    through the same `onFilesReceived(files, 'osLaunch')` path as
+    drag-and-drop and the toolbar Upload button, so all existing
+    safety nets apply (binary-content detector, 5 MB upload cap,
+    extract-from-mixed-text banner, draft-overwrite Undo).
+    - **`client_mode: "navigate-new"`**: every OS launch opens a
+      **fresh** PWA window. This preserves any `/s/:slug` editing
+      context, unsaved drafts, and the snackbar Undo affordance in
+      an already-open JotJSON window.
+    - **`launch_type` is intentionally omitted** from the manifest -
+      the per-handler `launch_type` member is not part of the
+      stable Chromium spec; the default (one window per launch)
+      gives the right semantics.
+    - **Chromium-only**: Firefox and Safari do not implement the
+      W3C Launch Handler API. Non-Chromium users see zero behavior
+      change and continue to use drag-and-drop / Upload button /
+      paste / share-link to ingest JSON.
+    - **Install-time disclosure**: Chromium's install UI surfaces
+      the registered file-type associations to the user before
+      install. Including `.webmanifest` in `file_handlers[].accept`
+      is a deliberate developer-convenience choice (JotJSON viewing
+      another PWA's install manifest is a sensible default); users
+      who prefer to keep their existing `.webmanifest` association
+      can simply not install JotJSON, or override per-file via
+      "Open with -> Choose another application".
+    - **Multi-file launches**: Chromium does not currently deliver
+      multiple files to a single launch consumer call, but the
+      W3C spec allows it. The controller truncates at the handle
+      layer (only `getFile()` on the first handle) to avoid the
+      OS permission-prompt flood. The downstream `tooMany`
+      validator never trips because the controller has already
+      reduced the launch to a single file.
+    - **Error feedback**: if `FileSystemFileHandle.getFile()`
+      rejects (permission decline, file moved/deleted between
+      Explorer click and PWA focus), the controller delivers an
+      error event to the handler; `HomeComponent` opens a
+      dismissable "Could not open the file." snackbar and the
+      controller logs the `home.fileHandler.readFailed`
+      telemetry token (no filename or path is captured).
+    - **Manual verification recipe**:
+      1. Build and serve the app locally (or open the deployed
+         site) in a Chromium-based browser.
+      2. Install the PWA via the omnibox install icon (or via
+         the `beforeinstallprompt` path once the install affordance
+         lands).
+      3. Open Explorer / Finder; locate a `.json` file.
+      4. Double-click the file (or right-click -> Open with ->
+         JotJSON; or `start data.json` from a terminal). Confirm
+         that a fresh JotJSON window opens with the file content
+         loaded in the editor and the "Opened data.json." snackbar
+         visible.
+    - **Forward-compatibility hook**: the controller exposes a
+      `currentFileHandle: Signal<FileSystemFileHandle | null>`
+      that is set on every launch. v1 does not consume it; it
+      is reserved for a future write-back path (via
+      `FileSystemFileHandle.createWritable()`) that would
+      let the user save edits directly back to the launched
+      file without re-prompting via picker.
 - **Planned polish (post-v1):**
   - **Install button**: handle `beforeinstallprompt` in the header to offer a subtle "Install JotJSON" affordance; hide once installed. Today users get Chrome's omnibox install icon, which requires the minimal SW above - this is the **sole functional purpose** of `src/sw.worker.ts`. If Chromium ever decouples installability from the SW requirement, the SW becomes a candidate for deletion.
   - **Manifest screenshots**: add at least one wide and one narrow `screenshots` entry to the manifest for richer install prompts (not yet present in `manifest.webmanifest`).

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -508,6 +508,15 @@ retains `source: rowButton` for the decoded-pill cohort. Normalize the
 extract event before comparing pre- and post-deploy cohorts or joining
 across the two events.
 
+Separately, the `home.extract.banner.*` family and `upload.handle`
+share an additive source enum that was extended in v1.2 to include
+`'osLaunch'` (and the derived extract-source `'upload.osLaunch'`) for
+files delivered via the PWA file_handlers + `launchQueue` ingress.
+Existing dashboards that filter on `'drag'`/`'pick'` or
+`'upload.drag'`/`'upload.pick'` will silently exclude the new bucket;
+update those filters to include the new value (or switch to a
+`startswith "upload."` predicate) to keep totals consistent.
+
 ```kusto
 customEvents
 | where name == "tree.extract.click"

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -508,14 +508,32 @@ retains `source: rowButton` for the decoded-pill cohort. Normalize the
 extract event before comparing pre- and post-deploy cohorts or joining
 across the two events.
 
-Separately, the `home.extract.banner.*` family and `upload.handle`
-share an additive source enum that was extended in v1.2 to include
-`'osLaunch'` (and the derived extract-source `'upload.osLaunch'`) for
-files delivered via the PWA file_handlers + `launchQueue` ingress.
-Existing dashboards that filter on `'drag'`/`'pick'` or
-`'upload.drag'`/`'upload.pick'` will silently exclude the new bucket;
-update those filters to include the new value (or switch to a
-`startswith "upload."` predicate) to keep totals consistent.
+#### File-ingress source flow
+
+The `FileIngressSource` enum (`'pick'` / `'drag'` / `'osLaunch'`) is
+the canonical name for the upload-ingress dimension. Several
+telemetry events embed it verbatim or via a derived enum:
+
+| Event | Prop | Closed enum |
+|-------|------|-------------|
+| `upload.handle` | `source` | `'pick'` / `'drag'` / `'osLaunch'` |
+| `home.upload.undo` | `trigger` | `'pick'` / `'drag'` / `'osLaunch'` |
+| `home.extract.banner.{shown,accept,dismiss,undo}` | `pasteSource` | `'paste'` / `'editor.paste'` / `'upload.pick'` / `'upload.drag'` / `'upload.osLaunch'` |
+
+`'osLaunch'` (and the derived `'upload.osLaunch'`) was added in v1.2
+for files delivered via the PWA `file_handlers` + `launchQueue`
+ingress. The extension is additive: existing dashboards that filter
+on `'pick'` / `'drag'` (or `'upload.pick'` / `'upload.drag'`)
+continue to return correct counts but silently exclude the new
+bucket. To include OS-launched ingress, widen the filter or switch
+to a `startswith "upload."` / `in ('pick', 'drag', 'osLaunch')`
+predicate. `home.extract.banner.applyFailed` has no `pasteSource`
+prop and is correctly outside this cascade. Future ingress additions
+(e.g., a Web Share Target hook) should extend the
+`FileIngressSource` union at the source and update the three event
+prop docs above; the `FILE_INGRESS_TO_EXTRACT_SOURCE` and
+`FILE_INGRESS_TO_UNDO_TRIGGER` boundary maps in
+`home.component.ts` will fail to compile until updated.
 
 ```kusto
 customEvents

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "dependencies": {
         "@angular/animations": "^21.2.14",
         "@angular/cdk": "^21.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -8,6 +8,22 @@
   "background_color": "#1e1e1e",
   "theme_color": "#1e1e1e",
   "categories": ["developer-tools", "utilities"],
+  "file_handlers": [
+    {
+      "action": "/",
+      "accept": {
+        "application/json": [".json"],
+        "application/manifest+json": [".webmanifest"],
+        "application/json5": [".json5"],
+        "text/plain": [".jsonc"]
+      },
+      "icons": [
+        { "src": "icons/icon-192.png", "sizes": "192x192", "type": "image/png" },
+        { "src": "icons/icon-512.png", "sizes": "512x512", "type": "image/png" }
+      ]
+    }
+  ],
+  "launch_handler": { "client_mode": "navigate-new" },
   "icons": [
     {
       "src": "icons/icon-192.png",

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -637,6 +637,27 @@ export const TELEMETRY_MESSAGE_IDS = [
   'home.upload.readFailed',
 
   /**
+   * Severity: error
+   * Fired by: `LaunchQueueController` (`core/upload/launch-queue-controller.service.ts`)
+   *           when `FileSystemFileHandle.getFile()` rejects after an OS
+   *           file-association launch (PWA `file_handlers` +
+   *           `launchQueue`). Causes include: the user declined the
+   *           read permission in Chromium's prompt; the file was
+   *           renamed / moved / deleted between OS click and PWA
+   *           focus; transient disk I/O failure.
+   * Volume control: bounded-frequency. One per OS launch, only on the
+   *   error path; happy path emits `upload.handle` with
+   *   `source='osLaunch'`.
+   * Privacy: no filename, no path; the underlying rejection lands in
+   *   `exceptions` via `logger.error`'s second argument and the
+   *   `TelemetryService` privacy initializer still strips URLs /
+   *   query strings.
+   * Exception: the unknown rejection value from
+   *   `FileSystemFileHandle.getFile()`.
+   */
+  'home.fileHandler.readFailed',
+
+  /**
    * Severity: info
    * Fired by: `HomeComponent.onFilesReceived` (`binary` branch)
    *           (`features/home/home.component.ts`)
@@ -706,9 +727,14 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           (`tooLarge`, `binary`, `readFailed`) keep their
    *           existing warn tokens; this event counts only
    *           successful uploads.
-   * Props: { sizeBytesBucket: SizeBucket; source: 'drag' | 'pick' }.
+   * Props: { sizeBytesBucket: SizeBucket; source: 'drag' | 'pick' | 'osLaunch' }.
    *   `'drag'` = files via the document drag-drop controller;
-   *   `'pick'` = the toolbar Upload button (`<input type="file">`).
+   *   `'pick'` = the toolbar Upload button (`<input type="file">`);
+   *   `'osLaunch'` = files delivered via the OS file-association launch
+   *     (PWA `file_handlers` + `launchQueue`; Chromium-only, requires
+   *     PWA install). Additive enum extension: existing dashboards
+   *     filtering on `'drag'` / `'pick'` continue to return correct
+   *     results.
    * Measurements: { sizeBytes: number; fileReadMs: number;
    *   parseMs: number; syncHandlerMs: number; firstPaintMs: number }.
    *   See `paste.handle` for `parseMs` / `syncHandlerMs` /
@@ -724,10 +750,12 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           extracted-JSON candidate is installed and the M7p
    *           extract banner therefore becomes visible.
    * Props: { source: 'paste' | 'editor.paste' | 'upload.pick'
-   *   | 'upload.drag' }. `'paste'` = toolbar Paste button (clipboard
-   *   read); `'editor.paste'` = native Monaco paste inside the
-   *   editor; `'upload.pick'` = toolbar Upload button; `'upload.drag'`
-   *   = files dropped onto the document.
+   *   | 'upload.drag' | 'upload.osLaunch' }. `'paste'` = toolbar Paste
+   *   button (clipboard read); `'editor.paste'` = native Monaco paste
+   *   inside the editor; `'upload.pick'` = toolbar Upload button;
+   *   `'upload.drag'` = files dropped onto the document;
+   *   `'upload.osLaunch'` = files delivered via the OS file-association
+   *   launch (PWA `file_handlers` + `launchQueue`).
    * Measurements: { blockCount: number; preservesComments: 0 | 1;
    *   hasComments: 0 | 1; proseSegments: number }. `blockCount` is the
    *   number of JSON blocks the extractor recovered from the mixed
@@ -757,7 +785,8 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           NOT additionally fire `home.extract.banner.dismiss`
    *           with `reason='content.changed'` for this candidate.
    * Props: { source: 'paste' | 'editor.paste' | 'upload.pick'
-   *   | 'upload.drag' } - mirrors `home.extract.banner.shown`.
+   *   | 'upload.drag' | 'upload.osLaunch' } - mirrors
+   *   `home.extract.banner.shown`.
    * Measurements: { blockCount: number; preservesComments: 0 | 1;
    *   hasComments: 0 | 1; proseSegments: number } - mirrors
    *   `home.extract.banner.shown` so accept-rate by block-count,
@@ -780,7 +809,8 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           Accept does NOT emit this event - see
    *           `home.extract.banner.accept`.
    * Props: { source: 'paste' | 'editor.paste' | 'upload.pick'
-   *   | 'upload.drag'; reason: 'user.click' | 'content.changed' }.
+   *   | 'upload.drag' | 'upload.osLaunch'; reason: 'user.click'
+   *   | 'content.changed' }.
    *   `source` is whatever path produced the candidate that is now
    *   being dismissed (carried on the `extractedCandidate` signal).
    * Measurements: { blockCount: number; proseSegments: number }.
@@ -1529,7 +1559,7 @@ export const TELEMETRY_MESSAGE_IDS = [
    * Volume control: bounded-frequency. At most one undo per
    *   banner-accept extract; capped at 30s by `pendingExtractUndo`.
    * Props: { source: 'snackbar' | 'ctrlZ';
-   *          pasteSource: 'paste' | 'editor.paste' | 'upload.pick' | 'upload.drag';
+   *          pasteSource: 'paste' | 'editor.paste' | 'upload.pick' | 'upload.drag' | 'upload.osLaunch';
    *          undoLatencyMsBucket: '<1s' | '1-5s' | '5s+' }.
    *          `source` distinguishes the undo entry path; `pasteSource`
    *          mirrors `home.extract.banner.{shown,accept}` so an

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -1596,11 +1596,16 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           path) while the pending replace-undo window is still open.
    * Volume control: bounded-frequency. One event per upload replace
    *   action that is undone.
-   * Props: { source: 'snackbar' | 'ctrlZ'; trigger: 'pick' | 'drag';
-   *          undoLatencyMsBucket: '<1s' | '1-5s' | '5s+' }.
+   * Props: { source: 'snackbar' | 'ctrlZ'; trigger: 'pick' | 'drag'
+   *          | 'osLaunch'; undoLatencyMsBucket: '<1s' | '1-5s'
+   *          | '5s+' }.
    *          `source` distinguishes the undo entry path; `trigger`
    *          preserves whether the original replacement came from the
-   *          file picker or drag-drop; `undoLatencyMsBucket` supports
+   *          file picker, drag-drop, or OS file-association launch
+   *          (PWA `file_handlers` + `launchQueue`; Chromium-only,
+   *          requires PWA install). Additive enum extension: existing
+   *          dashboards filtering on `'pick'` / `'drag'` continue to
+   *          return correct results. `undoLatencyMsBucket` supports
    *          misclick-rate queries without using raw time as a
    *          dimension.
    * Measurements: { undoLatencyMs?: number }. Raw wall-clock latency

--- a/src/app/core/upload/launch-queue-controller.service.spec.ts
+++ b/src/app/core/upload/launch-queue-controller.service.spec.ts
@@ -1,0 +1,272 @@
+import { PLATFORM_ID } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { LoggerService } from '../telemetry/logger.service';
+import { LaunchQueueController, type LaunchEvent } from './launch-queue-controller.service';
+
+type Consumer = (params: LaunchParams) => void | Promise<void>;
+
+interface FakeLaunchQueue {
+  setConsumer(consumer: Consumer): void;
+}
+
+function makeHandle(file: File): FileSystemFileHandle {
+  return {
+    kind: 'file' as const,
+    name: file.name,
+    getFile: jasmine.createSpy('getFile').and.resolveTo(file),
+  } as unknown as FileSystemFileHandle;
+}
+
+function makeRejectingHandle(name: string, cause: unknown): FileSystemFileHandle {
+  return {
+    kind: 'file' as const,
+    name,
+    getFile: jasmine.createSpy('getFile').and.rejectWith(cause),
+  } as unknown as FileSystemFileHandle;
+}
+
+describe('LaunchQueueController', () => {
+  let logger: jasmine.SpyObj<LoggerService>;
+  let consumer: Consumer | null;
+  let setConsumerSpy: jasmine.Spy;
+
+  function installLaunchQueue(present: boolean): void {
+    consumer = null;
+    setConsumerSpy = jasmine.createSpy('setConsumer').and.callFake((cb: Consumer) => {
+      consumer = cb;
+    });
+    if (present) {
+      Object.defineProperty(window, 'launchQueue', {
+        configurable: true,
+        value: { setConsumer: setConsumerSpy } satisfies FakeLaunchQueue,
+      });
+    } else {
+      Object.defineProperty(window, 'launchQueue', {
+        configurable: true,
+        value: undefined,
+      });
+    }
+  }
+
+  function configureBrowserTestBed(): void {
+    TestBed.configureTestingModule({
+      providers: [
+        LaunchQueueController,
+        { provide: LoggerService, useValue: logger },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    });
+  }
+
+  async function flush(): Promise<void> {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  }
+
+  beforeEach(() => {
+    logger = jasmine.createSpyObj<LoggerService>('LoggerService', [
+      'error',
+      'warn',
+      'info',
+      'event',
+    ]);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'launchQueue', {
+      configurable: true,
+      value: undefined,
+    });
+  });
+
+  it('does not touch window.launchQueue under prerender', () => {
+    installLaunchQueue(true);
+    TestBed.configureTestingModule({
+      providers: [
+        LaunchQueueController,
+        { provide: LoggerService, useValue: logger },
+        { provide: PLATFORM_ID, useValue: 'server' },
+      ],
+    });
+    TestBed.inject(LaunchQueueController);
+    expect(setConsumerSpy).not.toHaveBeenCalled();
+  });
+
+  it('is a silent no-op when window.launchQueue is absent', () => {
+    installLaunchQueue(false);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    expect(controller.currentFileHandle()).toBeNull();
+    // No throw is the contract; the handler simply never fires.
+  });
+
+  it('registers a single setConsumer on the browser platform', () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    TestBed.inject(LaunchQueueController);
+    expect(setConsumerSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a launch event with files: []', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    const handler = jasmine.createSpy('handler');
+    controller.registerHandler(handler);
+
+    await consumer!({ files: [], targetURL: 'https://jotjson.com/' });
+    await flush();
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(controller.currentFileHandle()).toBeNull();
+  });
+
+  it('delivers a single file as a files-kind LaunchEvent', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    const file = new File(['{}'], 'data.json', { type: 'application/json' });
+    const handle = makeHandle(file);
+    const handler = jasmine.createSpy('handler').and.resolveTo();
+    controller.registerHandler(handler);
+
+    await consumer!({ files: [handle], targetURL: 'https://jotjson.com/' });
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.calls.mostRecent().args[0] as LaunchEvent;
+    expect(event.kind).toBe('files');
+    if (event.kind === 'files') {
+      expect(event.files.length).toBe(1);
+      expect(event.files[0]).toBe(file);
+    }
+    expect(controller.currentFileHandle()).toBe(handle);
+  });
+
+  it('truncates a multi-file launch to the first handle (only one getFile call)', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    const fileA = new File(['{}'], 'a.json');
+    const fileB = new File(['{}'], 'b.json');
+    const fileC = new File(['{}'], 'c.json');
+    const handleA = makeHandle(fileA);
+    const handleB = makeHandle(fileB);
+    const handleC = makeHandle(fileC);
+    const handler = jasmine.createSpy('handler').and.resolveTo();
+    controller.registerHandler(handler);
+
+    await consumer!({
+      files: [handleA, handleB, handleC],
+      targetURL: 'https://jotjson.com/',
+    });
+    await flush();
+
+    expect(handleA.getFile).toHaveBeenCalledTimes(1);
+    expect(handleB.getFile).not.toHaveBeenCalled();
+    expect(handleC.getFile).not.toHaveBeenCalled();
+    const event = handler.calls.mostRecent().args[0] as LaunchEvent;
+    expect(event.kind).toBe('files');
+    if (event.kind === 'files') {
+      expect(event.files.length).toBe(1);
+      expect(event.files[0]).toBe(fileA);
+    }
+  });
+
+  it('delivers an error event when getFile() rejects and fires home.fileHandler.readFailed', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    const cause = new DOMException('Permission denied', 'NotAllowedError');
+    const handle = makeRejectingHandle('data.json', cause);
+    const handler = jasmine.createSpy('handler').and.resolveTo();
+    controller.registerHandler(handler);
+
+    await consumer!({ files: [handle], targetURL: 'https://jotjson.com/' });
+    await flush();
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    const event = handler.calls.mostRecent().args[0] as LaunchEvent;
+    expect(event.kind).toBe('error');
+    if (event.kind === 'error') {
+      expect(event.cause).toBe(cause);
+    }
+    expect(logger.error).toHaveBeenCalledWith('home.fileHandler.readFailed', cause);
+    expect(controller.currentFileHandle()).toBe(handle);
+  });
+
+  it('replaces an active handler on re-register and emits a console warning', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    const warn = spyOn(console, 'warn');
+    const first = jasmine.createSpy('first').and.resolveTo();
+    const second = jasmine.createSpy('second').and.resolveTo();
+    controller.registerHandler(first);
+    controller.registerHandler(second);
+
+    const handle = makeHandle(new File(['{}'], 'x.json'));
+    await consumer!({ files: [handle], targetURL: 'https://jotjson.com/' });
+    await flush();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(warn).toHaveBeenCalled();
+  });
+
+  it('ignores a stale dispose so it does not clobber the newer handler', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    spyOn(console, 'warn');
+    const first = jasmine.createSpy('first').and.resolveTo();
+    const second = jasmine.createSpy('second').and.resolveTo();
+    const disposeFirst = controller.registerHandler(first);
+    controller.registerHandler(second);
+
+    disposeFirst();
+
+    const handle = makeHandle(new File(['{}'], 'x.json'));
+    await consumer!({ files: [handle], targetURL: 'https://jotjson.com/' });
+    await flush();
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops the active handler when its own dispose closure runs', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    const handler = jasmine.createSpy('handler').and.resolveTo();
+    const dispose = controller.registerHandler(handler);
+
+    dispose();
+
+    const handle = makeHandle(new File(['{}'], 'x.json'));
+    await consumer!({ files: [handle], targetURL: 'https://jotjson.com/' });
+    await flush();
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('exposes currentFileHandle reflecting the latest launched handle', async () => {
+    installLaunchQueue(true);
+    configureBrowserTestBed();
+    const controller = TestBed.inject(LaunchQueueController);
+    const handler = jasmine.createSpy('handler').and.resolveTo();
+    controller.registerHandler(handler);
+    expect(controller.currentFileHandle()).toBeNull();
+
+    const handleA = makeHandle(new File(['{}'], 'a.json'));
+    await consumer!({ files: [handleA], targetURL: 'https://jotjson.com/' });
+    await flush();
+    expect(controller.currentFileHandle()).toBe(handleA);
+
+    const handleB = makeHandle(new File(['[]'], 'b.json'));
+    await consumer!({ files: [handleB], targetURL: 'https://jotjson.com/' });
+    await flush();
+    expect(controller.currentFileHandle()).toBe(handleB);
+  });
+});

--- a/src/app/core/upload/launch-queue-controller.service.ts
+++ b/src/app/core/upload/launch-queue-controller.service.ts
@@ -1,0 +1,131 @@
+import { isPlatformBrowser } from '@angular/common';
+import { Injectable, PLATFORM_ID, Signal, inject, signal } from '@angular/core';
+import { LoggerService } from '../telemetry/logger.service';
+
+/**
+ * Singleton consumer of the W3C Web App Manifest "Launch Handler" API.
+ * Set-once at app boot under an `isPlatformBrowser` guard so the
+ * `window.launchQueue.setConsumer(...)` registration cannot race with
+ * component lifecycle (skeptic F3 in the M-PWA plan): if HomeComponent
+ * is destroyed and re-created across `client_mode: 'navigate-new'`
+ * tabs or during HMR, the launch consumer outlives the component and
+ * always delivers to whichever handler is currently registered.
+ *
+ * Mirrors the `DocumentDropController` pattern. HomeComponent registers
+ * a handler in `ngOnInit` and disposes it in `ngOnDestroy`. While a
+ * handler is registered, OS launches are forwarded to it as
+ * `LaunchEvent` tuples. While no handler is registered, launches are
+ * dropped silently (the toolbar Upload / drag-drop entry points are
+ * still available and don't depend on this controller).
+ *
+ * Prerender safety: the constructor's `isPlatformBrowser` check ensures
+ * `window.launchQueue` is never touched on the server platform; on the
+ * server / non-Chromium browsers / non-installed Chromium the
+ * controller is a no-op (advocate A3 + skeptic F9).
+ *
+ * Edge cases documented in step 12 of the M-PWA plan:
+ * - **HMR dev-only**: a stale `setConsumer` closure may outlive a
+ *   module swap. Benign (dev console only) - the rebuilt module
+ *   creates a fresh service instance and the old closure is GC'd
+ *   when the page is reloaded.
+ * - **File renamed / deleted between OS click and PWA focus**:
+ *   caught by the `getFile()` reject branch; surfaces the
+ *   `home.osLaunch.error.unreadable` snackbar via the `error` event.
+ * - **`.txt` containing JSON via "Choose another -> JotJSON" override**:
+ *   flows through unchanged; the existing `validateAndReadSingleFile`
+ *   binary detector accepts text content and the snackbar reads
+ *   "Opened config.txt." which is the correct behavior.
+ * - **Multi-file launch**: short-circuited at the handle layer to
+ *   avoid a permission-prompt flood; we deliver the first handle and
+ *   the downstream `tooMany` validator never gets a chance to trip.
+ */
+export type LaunchEvent =
+  | { kind: 'files'; files: readonly File[] }
+  | { kind: 'error'; cause: unknown };
+
+export type LaunchHandler = (event: LaunchEvent) => void | Promise<void>;
+
+@Injectable({ providedIn: 'root' })
+export class LaunchQueueController {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly logger = inject(LoggerService);
+
+  private activeHandler: LaunchHandler | null = null;
+  // Monotonic registration id; lets a stale dispose detect that a
+  // newer handler has taken over and bail out instead of clobbering
+  // it (mirrors DocumentDropController stale-dispose safety).
+  private registrationId = 0;
+
+  private readonly latestFileHandle = signal<FileSystemFileHandle | null>(null);
+
+  /**
+   * Read-only handle to the most recently opened file. Reserved for a
+   * future write-back follow-on (`createWritable()`); v1 does not
+   * consume it but keeping the handle alive on this signal avoids a
+   * second permission prompt when the feature lands (architect F8).
+   */
+  readonly currentFileHandle: Signal<FileSystemFileHandle | null> =
+    this.latestFileHandle.asReadonly();
+
+  constructor() {
+    if (!isPlatformBrowser(this.platformId)) return;
+    const launchQueue = window.launchQueue;
+    if (!launchQueue) return;
+    launchQueue.setConsumer((params) => {
+      void this.handleLaunch(params);
+    });
+  }
+
+  /**
+   * Registers a handler for OS-launched file events. Returns a dispose
+   * closure that clears the handler iff it is still the active one
+   * (i.e., the closure is stale-safe: if a newer handler has been
+   * registered, calling the closure is a no-op).
+   *
+   * A double-registration replaces the previous handler and emits a
+   * console warning, mirroring `DocumentDropController` semantics. In
+   * practice the only way this fires is a stale owner that forgot to
+   * dispose.
+   */
+  registerHandler(handler: LaunchHandler): () => void {
+    if (this.activeHandler) {
+      console.warn(
+        '[LaunchQueueController] replacing existing launch handler; ' +
+          'previous owner did not dispose.',
+      );
+    }
+    this.registrationId += 1;
+    const ownToken = this.registrationId;
+    this.activeHandler = handler;
+    return () => {
+      if (this.registrationId === ownToken) {
+        this.activeHandler = null;
+      }
+    };
+  }
+
+  private async handleLaunch(params: LaunchParams): Promise<void> {
+    const handles = params.files ?? [];
+    if (handles.length === 0) return;
+    // Short-circuit multi-file at the handle layer to avoid the
+    // permission-prompt flood (one prompt per `getFile()`). The
+    // downstream upload validator would surface `tooMany` anyway;
+    // truncating here keeps the user from re-confirming N prompts
+    // just to land on an error snackbar.
+    const handle = handles[0];
+    this.latestFileHandle.set(handle);
+    try {
+      const file = await handle.getFile();
+      await this.deliver({ kind: 'files', files: [file] });
+    } catch (cause) {
+      this.logger.error('home.fileHandler.readFailed', cause);
+      await this.deliver({ kind: 'error', cause });
+    }
+  }
+
+  private async deliver(event: LaunchEvent): Promise<void> {
+    const handler = this.activeHandler;
+    if (!handler) return;
+    await handler(event);
+  }
+}

--- a/src/app/features/home/home.component.spec.ts
+++ b/src/app/features/home/home.component.spec.ts
@@ -7071,6 +7071,42 @@ describe('HomeComponent banner-extract undo (M7v)', () => {
     });
   });
 
+  it('snackbar Undo on an upload.osLaunch-sourced banner emits home.extract.banner.undo with pasteSource=upload.osLaunch', () => {
+    const { component, snackHarness, eventSpy } = setup();
+    let nowMs = 1000;
+    spyOn(performance, 'now').and.callFake(() => nowMs);
+    const priorText = 'INFO log {"a":1}';
+    const candidateText = '{ "a": 1 }';
+    component.onValueChange(priorText);
+    component.extractedCandidate.set({
+      data: {
+        text: candidateText,
+        blockCount: 1,
+        preservesComments: true,
+        hasComments: false,
+      },
+      sourceVersion: 0,
+      source: 'upload.osLaunch',
+    });
+
+    nowMs = 1200;
+    component.onExtractAccept();
+    expect(component.content()).toBe(candidateText);
+
+    eventSpy.calls.reset();
+    nowMs = 2500;
+    snackHarness.action.next();
+
+    expect(component.content()).toBe(priorText);
+    expect(component.extractBannerVisible()).toBe(true);
+    expect(component.extractedCandidate()?.source).toBe('upload.osLaunch');
+    expect(eventSpy).toHaveBeenCalledWith('home.extract.banner.undo', {
+      source: 'snackbar',
+      pasteSource: 'upload.osLaunch',
+      undoLatencyMsBucket: '1-5s',
+    });
+  });
+
   it('content reverting to priorText (Ctrl+Z) emits home.extract.banner.undo with source=ctrlZ and re-arms the banner', () => {
     const { fixture, component, snackHarness, eventSpy } = setup();
     let nowMs = 1000;
@@ -7222,6 +7258,18 @@ describe('HomeComponent upload/format/minify/sort undo (issue #313)', () => {
     };
   }
 
+  class FakeLaunchQueueController {
+    registeredHandler?: LaunchHandler;
+    readonly currentFileHandle = signal<FileSystemFileHandle | null>(null);
+    readonly dispose = jasmine.createSpy('disposeLaunch');
+    readonly registerHandler = jasmine
+      .createSpy('registerHandler')
+      .and.callFake((handler: LaunchHandler) => {
+        this.registeredHandler = handler;
+        return this.dispose;
+      });
+  }
+
   interface ReplaceEditorStub {
     replaceAll: jasmine.Spy<(text: string, source: string) => ReplaceAllResult>;
   }
@@ -7271,6 +7319,7 @@ describe('HomeComponent upload/format/minify/sort undo (issue #313)', () => {
     editorStub: ReplaceEditorStub;
     eventSpy: jasmine.Spy;
     warnSpy: jasmine.Spy;
+    launch: FakeLaunchQueueController;
   }
 
   function setup(options: SetupOptions = {}): SetupResult {
@@ -7289,12 +7338,14 @@ describe('HomeComponent upload/format/minify/sort undo (issue #313)', () => {
       (message: string, action?: string, config?: unknown) => MatSnackBarRef<TextOnlySnackBar>
     >;
     const snack = { open: snackOpenSpy };
+    const fakeLaunch = new FakeLaunchQueueController();
     TestBed.configureTestingModule({
       imports: [HomeComponent],
       providers: [
         ...provideFakeAuth(),
         provideRouter([]),
         { provide: MatSnackBar, useValue: snack },
+        { provide: LaunchQueueController, useValue: fakeLaunch },
       ],
     });
     const logger = TestBed.inject(LoggerService);
@@ -7328,6 +7379,7 @@ describe('HomeComponent upload/format/minify/sort undo (issue #313)', () => {
       editorStub,
       eventSpy,
       warnSpy,
+      launch: fakeLaunch,
     };
   }
 
@@ -7417,6 +7469,69 @@ describe('HomeComponent upload/format/minify/sort undo (issue #313)', () => {
       jasmine.objectContaining({ undoLatencyMs: jasmine.any(Number) }),
     );
     // Snackbar should be dismissed when Ctrl+Z fires the undo path.
+    expect(snackHarnesses[0]!.dismissSpy).toHaveBeenCalled();
+  });
+
+  // --------------------------------------------------------------------
+  // OS-launch (PWA file_handlers + launchQueue) upload undo: ensure the
+  // `'osLaunch'` value flows through `FILE_INGRESS_TO_UNDO_TRIGGER` into
+  // `home.upload.undo.trigger` on both the snackbar-Undo and Ctrl+Z
+  // branches. These two emit sites are structurally independent
+  // (snackbar callback in `openReplaceUndoSnack` vs constructor
+  // `effect()` watching `priorText` revert), so both need explicit
+  // coverage to prevent silent regression when the FileIngressSource
+  // union widens further.
+  // --------------------------------------------------------------------
+
+  it('OS-launch upload + snackbar Undo emits home.upload.undo with trigger=osLaunch', async () => {
+    const priorText = '{"prior":true}';
+    const { component, snackHarnesses, eventSpy, launch } = setup({
+      initialContent: priorText,
+      initialLastFilename: 'old.json',
+    });
+
+    expect(launch.registeredHandler).toBeDefined();
+    const file = new File(['{"next":1}'], 'launched.json');
+    await launch.registeredHandler!({ kind: 'files', files: [file] });
+    expect(component.content()).toBe('{"next":1}');
+    expect(component.lastFilename()).toBe('launched.json');
+
+    eventSpy.calls.reset();
+    snackHarnesses[0]!.action.next();
+
+    expect(component.content()).toBe(priorText);
+    expect(component.lastFilename()).toBe('old.json');
+    expect(eventSpy).toHaveBeenCalledWith(
+      'home.upload.undo',
+      jasmine.objectContaining({ source: 'snackbar', trigger: 'osLaunch' }),
+      jasmine.objectContaining({ undoLatencyMs: jasmine.any(Number) }),
+    );
+  });
+
+  it('OS-launch upload + Ctrl+Z (re-emitted onValueChange) emits home.upload.undo with trigger=osLaunch', async () => {
+    const priorText = '{"prior":true}';
+    const { fixture, component, snackHarnesses, eventSpy, launch } = setup({
+      initialContent: priorText,
+      initialLastFilename: 'old.json',
+    });
+
+    expect(launch.registeredHandler).toBeDefined();
+    const file = new File(['{"next":2}'], 'launched.json');
+    await launch.registeredHandler!({ kind: 'files', files: [file] });
+    expect(component.content()).toBe('{"next":2}');
+
+    eventSpy.calls.reset();
+    component.onValueChange(priorText);
+    fixture.detectChanges();
+    TestBed.flushEffects();
+
+    expect(component.content()).toBe(priorText);
+    expect(component.lastFilename()).toBe('old.json');
+    expect(eventSpy).toHaveBeenCalledWith(
+      'home.upload.undo',
+      jasmine.objectContaining({ source: 'ctrlZ', trigger: 'osLaunch' }),
+      jasmine.objectContaining({ undoLatencyMs: jasmine.any(Number) }),
+    );
     expect(snackHarnesses[0]!.dismissSpy).toHaveBeenCalled();
   });
 

--- a/src/app/features/home/home.component.spec.ts
+++ b/src/app/features/home/home.component.spec.ts
@@ -32,6 +32,11 @@ import { QuotaNotificationService } from '../../core/quota/quota-notification.se
 import { bucketBytes } from '../../core/telemetry/buckets';
 import { LoggerService } from '../../core/telemetry/logger.service';
 import { DocumentDropController } from '../../core/upload/document-drop-controller.service';
+import {
+  LaunchQueueController,
+  type LaunchEvent,
+  type LaunchHandler,
+} from '../../core/upload/launch-queue-controller.service';
 import { MAX_UPLOAD_BYTES } from '../../core/upload/upload-file-validator';
 import type { ReplaceAllResult } from '../../shared/components/json-editor/json-editor.component';
 import {
@@ -4391,6 +4396,18 @@ describe('HomeComponent drag-drop upload (M7b)', () => {
       });
   }
 
+  class FakeLaunchQueueController {
+    registeredHandler?: LaunchHandler;
+    readonly currentFileHandle = signal<FileSystemFileHandle | null>(null);
+    readonly dispose = jasmine.createSpy('disposeLaunch');
+    readonly registerHandler = jasmine
+      .createSpy('registerHandler')
+      .and.callFake((handler: LaunchHandler) => {
+        this.registeredHandler = handler;
+        return this.dispose;
+      });
+  }
+
   function setup() {
     localStorage.removeItem(PREFS_KEY);
     localStorage.removeItem(DRAFT_KEY);
@@ -4398,6 +4415,7 @@ describe('HomeComponent drag-drop upload (M7b)', () => {
     localStorage.removeItem(PANE_VIS_KEY);
     TestBed.resetTestingModule();
     const fakeController = new FakeDropController();
+    const fakeLaunch = new FakeLaunchQueueController();
     const snack = { open: jasmine.createSpy('open') };
     TestBed.configureTestingModule({
       imports: [HomeComponent],
@@ -4405,12 +4423,13 @@ describe('HomeComponent drag-drop upload (M7b)', () => {
         ...provideFakeAuth(),
         provideRouter([]),
         { provide: DocumentDropController, useValue: fakeController },
+        { provide: LaunchQueueController, useValue: fakeLaunch },
         { provide: MatSnackBar, useValue: snack },
       ],
     });
     const fixture = TestBed.createComponent(HomeComponent);
     fixture.componentRef.changeDetectorRef.detectChanges();
-    return { fixture, fakeController, snack };
+    return { fixture, fakeController, fakeLaunch, snack };
   }
 
   function makeOversizedFile(): File {
@@ -4571,6 +4590,68 @@ describe('HomeComponent drag-drop upload (M7b)', () => {
     fakeController.dropActive.set(false);
     fixture.componentRef.changeDetectorRef.detectChanges();
     expect(overlay.visible()).toBe(false);
+  });
+
+  it('registers a launch handler with LaunchQueueController on init', () => {
+    const { fakeLaunch } = setup();
+    expect(fakeLaunch.registerHandler).toHaveBeenCalledTimes(1);
+    const handler = fakeLaunch.registerHandler.calls.mostRecent().args[0];
+    expect(typeof handler).toBe('function');
+  });
+
+  it('disposes the registered launch handler on destroy', () => {
+    const { fixture, fakeLaunch } = setup();
+    expect(fakeLaunch.dispose).not.toHaveBeenCalled();
+    fixture.destroy();
+    expect(fakeLaunch.dispose).toHaveBeenCalledTimes(1);
+  });
+
+  it('OS-launch files-kind event loads content and emits upload.handle with osLaunch source', async () => {
+    const { fixture, fakeLaunch, snack } = setup();
+    const eventSpy = spyOn(TestBed.inject(LoggerService), 'event');
+    const text = '{"a":1}';
+    const file = {
+      size: new Blob([text]).size,
+      name: 'opened.json',
+      text: () => Promise.resolve(text),
+      arrayBuffer: () => Promise.resolve(new TextEncoder().encode(text).buffer),
+    } as unknown as File;
+    const handler = fakeLaunch.registeredHandler!;
+    const event: LaunchEvent = { kind: 'files', files: [file] };
+    await handler(event);
+    await waitForTaskQueue();
+    await waitForDoubleAnimationFrame();
+    expect(fixture.componentInstance.content()).toBe(text);
+    expect(snack.open).toHaveBeenCalledTimes(1);
+    expect(snack.open.calls.mostRecent().args[0]).toContain('Opened opened.json');
+    expect(snack.open.calls.mostRecent().args[1]).toBe('Undo');
+    expect(eventSpy).toHaveBeenCalledOnceWith(
+      'upload.handle',
+      { sizeBytesBucket: bucketBytes(file.size), source: 'osLaunch' },
+      jasmine.objectContaining({
+        sizeBytes: file.size,
+        fileReadMs: jasmine.any(Number),
+        parseMs: jasmine.any(Number),
+        syncHandlerMs: jasmine.any(Number),
+        firstPaintMs: jasmine.any(Number),
+      }),
+    );
+  });
+
+  it('OS-launch error-kind event opens the unreadable snackbar and does not mutate content', async () => {
+    const { fixture, fakeLaunch, snack } = setup();
+    const before = fixture.componentInstance.content();
+    const eventSpy = spyOn(TestBed.inject(LoggerService), 'event');
+    const handler = fakeLaunch.registeredHandler!;
+    const cause = new DOMException('Permission denied', 'NotAllowedError');
+    const event: LaunchEvent = { kind: 'error', cause };
+    await handler(event);
+    await Promise.resolve();
+    expect(snack.open).toHaveBeenCalledTimes(1);
+    expect(snack.open.calls.mostRecent().args[0]).toContain('Could not open the file');
+    expect(snack.open.calls.mostRecent().args[1]).toBe('Dismiss');
+    expect(fixture.componentInstance.content()).toBe(before);
+    expect(eventSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -4947,22 +5028,37 @@ describe('HomeComponent extract-banner telemetry', () => {
       });
   }
 
+  class FakeLaunchQueueController {
+    registeredHandler?: LaunchHandler;
+    readonly currentFileHandle = signal<FileSystemFileHandle | null>(null);
+    readonly dispose = jasmine.createSpy('disposeLaunch');
+    readonly registerHandler = jasmine
+      .createSpy('registerHandler')
+      .and.callFake((handler: LaunchHandler) => {
+        this.registeredHandler = handler;
+        return this.dispose;
+      });
+  }
+
   function setupTelemetryBed(): {
     fixture: ReturnType<typeof TestBed.createComponent<HomeComponent>>;
     component: HomeComponent;
     eventSpy: jasmine.Spy;
     extractorSpy: jasmine.Spy;
     drop: FakeDropController;
+    launch: FakeLaunchQueueController;
   } {
     clearHomeStorage();
     TestBed.resetTestingModule();
     const drop = new FakeDropController();
+    const launch = new FakeLaunchQueueController();
     TestBed.configureTestingModule({
       imports: [HomeComponent],
       providers: [
         ...provideFakeAuth(),
         provideRouter([]),
         { provide: DocumentDropController, useValue: drop },
+        { provide: LaunchQueueController, useValue: launch },
       ],
     });
     const fixture = TestBed.createComponent(HomeComponent);
@@ -4976,7 +5072,7 @@ describe('HomeComponent extract-banner telemetry', () => {
     });
     fixture.detectChanges();
     const eventSpy = spyOn(TestBed.inject(LoggerService), 'event');
-    return { fixture, component, eventSpy, extractorSpy, drop };
+    return { fixture, component, eventSpy, extractorSpy, drop, launch };
   }
 
   function bannerCalls(spy: jasmine.Spy): unknown[][] {
@@ -5061,6 +5157,29 @@ describe('HomeComponent extract-banner telemetry', () => {
     expect(shownCalls[0]).toEqual([
       'home.extract.banner.shown',
       { source: 'upload.drag' },
+      { blockCount: 2, preservesComments: 0, hasComments: 0, proseSegments: 0 },
+    ]);
+  });
+
+  it('OS-launch fires shown with source="upload.osLaunch"', async () => {
+    const { eventSpy, launch } = setupTelemetryBed();
+    const file = new File(['INFO log {"a":1}'], 'capture.log', {
+      type: 'text/plain',
+    });
+    expect(launch.registeredHandler).toBeDefined();
+
+    await launch.registeredHandler!({ kind: 'files', files: [file] });
+    await waitForTaskQueue();
+    await waitForTaskQueue();
+    await waitForDoubleAnimationFrame();
+
+    const shownCalls = bannerCalls(eventSpy).filter(
+      (args) => args[0] === 'home.extract.banner.shown',
+    );
+    expect(shownCalls.length).toBe(1);
+    expect(shownCalls[0]).toEqual([
+      'home.extract.banner.shown',
+      { source: 'upload.osLaunch' },
       { blockCount: 2, preservesComments: 0, hasComments: 0, proseSegments: 0 },
     ]);
   });
@@ -5435,6 +5554,18 @@ describe('HomeComponent upload-error banner (#36)', () => {
       });
   }
 
+  class FakeLaunchQueueController {
+    registeredHandler?: LaunchHandler;
+    readonly currentFileHandle = signal<FileSystemFileHandle | null>(null);
+    readonly dispose = jasmine.createSpy('disposeLaunch');
+    readonly registerHandler = jasmine
+      .createSpy('registerHandler')
+      .and.callFake((handler: LaunchHandler) => {
+        this.registeredHandler = handler;
+        return this.dispose;
+      });
+  }
+
   function setup() {
     localStorage.removeItem(PREFS_KEY);
     localStorage.removeItem(DRAFT_KEY);
@@ -5442,6 +5573,7 @@ describe('HomeComponent upload-error banner (#36)', () => {
     localStorage.removeItem(PANE_VIS_KEY);
     TestBed.resetTestingModule();
     const fakeController = new FakeDropController();
+    const fakeLaunch = new FakeLaunchQueueController();
     const snack = { open: jasmine.createSpy('open') };
     TestBed.configureTestingModule({
       imports: [HomeComponent],
@@ -5449,6 +5581,7 @@ describe('HomeComponent upload-error banner (#36)', () => {
         ...provideFakeAuth(),
         provideRouter([]),
         { provide: DocumentDropController, useValue: fakeController },
+        { provide: LaunchQueueController, useValue: fakeLaunch },
         { provide: MatSnackBar, useValue: snack },
       ],
     });
@@ -5686,6 +5819,18 @@ describe('HomeComponent binary upload rejection (#62)', () => {
       });
   }
 
+  class FakeLaunchQueueController {
+    registeredHandler?: LaunchHandler;
+    readonly currentFileHandle = signal<FileSystemFileHandle | null>(null);
+    readonly dispose = jasmine.createSpy('disposeLaunch');
+    readonly registerHandler = jasmine
+      .createSpy('registerHandler')
+      .and.callFake((handler: LaunchHandler) => {
+        this.registeredHandler = handler;
+        return this.dispose;
+      });
+  }
+
   function setup() {
     localStorage.removeItem(PREFS_KEY);
     localStorage.removeItem(DRAFT_KEY);
@@ -5693,6 +5838,7 @@ describe('HomeComponent binary upload rejection (#62)', () => {
     localStorage.removeItem(PANE_VIS_KEY);
     TestBed.resetTestingModule();
     const fakeController = new FakeDropController();
+    const fakeLaunch = new FakeLaunchQueueController();
     const snack = { open: jasmine.createSpy('open') };
     TestBed.configureTestingModule({
       imports: [HomeComponent],
@@ -5700,6 +5846,7 @@ describe('HomeComponent binary upload rejection (#62)', () => {
         ...provideFakeAuth(),
         provideRouter([]),
         { provide: DocumentDropController, useValue: fakeController },
+        { provide: LaunchQueueController, useValue: fakeLaunch },
         { provide: MatSnackBar, useValue: snack },
       ],
     });

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -169,6 +169,34 @@ const FILE_INGRESS_TO_EXTRACT_SOURCE: Readonly<Record<FileIngressSource, Extract
   osLaunch: 'upload.osLaunch',
 };
 
+/**
+ * Closed-enum label for the `trigger` prop on `home.upload.undo`
+ * telemetry. Declared as its own type (rather than a passthrough of
+ * `FileIngressSource`) so the next `FileIngressSource` widen forces a
+ * compile-time decision at `FILE_INGRESS_TO_UNDO_TRIGGER` below
+ * rather than silently widening the documented closed-enum on
+ * `home.upload.undo.trigger` via `pending.uploadTrigger`. Mirrors the
+ * boundary discipline already established by
+ * `FILE_INGRESS_TO_EXTRACT_SOURCE` (six lines above) for
+ * `home.extract.banner.*.pasteSource`.
+ */
+type UploadTriggerLabel = 'drag' | 'pick' | 'osLaunch';
+
+/**
+ * Closed-enum mapping from a `FileIngressSource` (user action that
+ * delivered the files) to the `trigger` prop on `home.upload.undo`
+ * telemetry. Identity-mapped today; the indirection exists so the
+ * next `FileIngressSource` addition (e.g., a future Web Share Target
+ * ingress) fails to compile here rather than silently flowing through
+ * `pending.uploadTrigger` into the telemetry event. Mirrors
+ * `FILE_INGRESS_TO_EXTRACT_SOURCE` above.
+ */
+const FILE_INGRESS_TO_UNDO_TRIGGER: Readonly<Record<FileIngressSource, UploadTriggerLabel>> = {
+  drag: 'drag',
+  pick: 'pick',
+  osLaunch: 'osLaunch',
+};
+
 type SignInRestoreSnapshot = {
   slug: string | null;
   content: string;
@@ -264,7 +292,7 @@ type PendingReplaceUndoUploadExtras = {
   priorExtractedCandidate: ExtractedCandidate | null;
   priorUploadError: { filename: string } | null;
   /** Whether the upload originated from the file-picker, a drag-drop, or an OS launch. */
-  uploadTrigger: FileIngressSource;
+  uploadTrigger: UploadTriggerLabel;
 };
 
 type PendingReplaceUndoFormatExtras = {
@@ -2842,7 +2870,7 @@ export class HomeComponent implements OnInit, OnDestroy {
             priorSuggestedTitles,
             priorExtractedCandidate,
             priorUploadError,
-            uploadTrigger: source,
+            uploadTrigger: FILE_INGRESS_TO_UNDO_TRIGGER[source],
             // `applyReplaceWithFallback` bumps `viewResetToken` (either
             // via `replaceAll`'s mirror at line 1672 or the legacy
             // `setContent`+token bump fallback). Record the post-bump

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -68,6 +68,7 @@ import type { TelemetryMeasurements } from '../../core/telemetry/telemetry.servi
 import { TitleSuggesterService } from '../../core/title-suggester/title-suggester.service';
 import type { SuggestionCandidate } from '../../core/title-suggester/types';
 import { DocumentDropController } from '../../core/upload/document-drop-controller.service';
+import { LaunchQueueController } from '../../core/upload/launch-queue-controller.service';
 import { validateAndReadSingleFile } from '../../core/upload/upload-file-validator';
 import { AppHeaderComponent } from '../../shared/components/app-header/app-header.component';
 import { JsonEditorComponent } from '../../shared/components/json-editor/json-editor.component';
@@ -122,7 +123,20 @@ const SK_EOF = 17;
  * persisted shape is independent of the UI surface.
  */
 type PaneVisibility = 'both' | 'editor-only' | 'tree-only';
-type UploadSource = 'drag' | 'pick';
+/**
+ * The user-action that delivered files into the home editor. Closed-enum
+ * so telemetry dimensions are queryable:
+ * - `'drag'`: files dropped onto the document.
+ * - `'pick'`: toolbar Upload button (`<input type="file">`).
+ * - `'osLaunch'`: files delivered via the OS file-association launch
+ *   (PWA `file_handlers` + `launchQueue`; Chromium-only).
+ *
+ * Renamed from `UploadSource` after the M-PWA plan added `'osLaunch'`:
+ * the OS launch path isn't really an upload (no `<input type=file>`,
+ * no drop overlay), so the type name now describes the broader
+ * "anything that lands files in the editor" surface.
+ */
+type FileIngressSource = 'drag' | 'pick' | 'osLaunch';
 
 type ColdBootClipboardCandidate = {
   text: string;
@@ -139,7 +153,21 @@ type ColdBootClipboardReadRaceResult =
  * to gate the auto-focus-on-show behaviour (only `'paste'` auto-focuses
  * so Ctrl+V or drag-drop don't steal focus from a typing user).
  */
-type ExtractSource = 'paste' | 'editor.paste' | 'upload.pick' | 'upload.drag';
+type ExtractSource = 'paste' | 'editor.paste' | 'upload.pick' | 'upload.drag' | 'upload.osLaunch';
+
+/**
+ * Closed-enum mapping from a `FileIngressSource` (user action that
+ * delivered the files) to the `ExtractSource` dimension carried on the
+ * three `home.extract.banner.{shown,accept,dismiss}` telemetry events.
+ * Replaces the previous `source === 'pick' ? 'upload.pick' : 'upload.drag'`
+ * ternaries that silently mis-bucketed the new `'osLaunch'` value as
+ * `'upload.drag'` (advocate A1 in the M-PWA plan).
+ */
+const FILE_INGRESS_TO_EXTRACT_SOURCE: Readonly<Record<FileIngressSource, ExtractSource>> = {
+  drag: 'upload.drag',
+  pick: 'upload.pick',
+  osLaunch: 'upload.osLaunch',
+};
 
 type SignInRestoreSnapshot = {
   slug: string | null;
@@ -235,8 +263,8 @@ type PendingReplaceUndoUploadExtras = {
   priorSuggestedTitles: readonly SuggestionCandidate[];
   priorExtractedCandidate: ExtractedCandidate | null;
   priorUploadError: { filename: string } | null;
-  /** Whether the upload originated from the file-picker or a drag-drop. */
-  uploadTrigger: UploadSource;
+  /** Whether the upload originated from the file-picker, a drag-drop, or an OS launch. */
+  uploadTrigger: FileIngressSource;
 };
 
 type PendingReplaceUndoFormatExtras = {
@@ -383,6 +411,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   private readonly clipboardCopy = inject(ClipboardCopyService);
   private readonly logger = inject(LoggerService);
   private readonly dropController = inject(DocumentDropController);
+  private readonly launchQueueController = inject(LaunchQueueController);
   private readonly beaconNav = inject(BeaconNavigationService);
   private readonly loadingSplash = inject(LoadingSplashService);
   protected readonly isBrowser = isPlatformBrowser(inject(PLATFORM_ID));
@@ -391,6 +420,7 @@ export class HomeComponent implements OnInit, OnDestroy {
   readonly dropActive = this.dropController.dropActive;
 
   private disposeDropHandler?: () => void;
+  private disposeLaunchHandler?: () => void;
   private destroyed = false;
   private coldBootClipboardEvaluated = false;
   private coldBootClipboardCandidate: ColdBootClipboardCandidate | null = null;
@@ -2736,19 +2766,32 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.disposeDropHandler = this.dropController.registerEditorHandler((files) => {
       void this.onFilesReceived(files, 'drag');
     });
+    this.disposeLaunchHandler = this.launchQueueController.registerHandler(async (event) => {
+      if (event.kind === 'error') {
+        this.snack.open(
+          $localize`:@@home.osLaunch.error.unreadable:Could not open the file.`,
+          $localize`:@@common.dismiss:Dismiss`,
+          { duration: 6000 },
+        );
+        return;
+      }
+      await this.onFilesReceived(event.files, 'osLaunch');
+    });
   }
 
   ngOnDestroy(): void {
     this.destroyed = true;
     this.disposeDropHandler?.();
     this.disposeDropHandler = undefined;
+    this.disposeLaunchHandler?.();
+    this.disposeLaunchHandler = undefined;
   }
 
   async onUpload(file: File): Promise<void> {
     await this.onFilesReceived([file], 'pick');
   }
 
-  private async onFilesReceived(files: readonly File[], source: UploadSource): Promise<void> {
+  private async onFilesReceived(files: readonly File[], source: FileIngressSource): Promise<void> {
     const handlerStartedAt = performance.now();
     const fileReadStartedAt = performance.now();
     const result = await validateAndReadSingleFile(files);
@@ -2773,7 +2816,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         if (unescaped === priorText) {
           this.suggestedTitlesForMenu.set([]);
           this.lastFilename.set(filename);
-          this.runExtractorOnCurrentContent(source === 'pick' ? 'upload.pick' : 'upload.drag');
+          this.runExtractorOnCurrentContent(FILE_INGRESS_TO_EXTRACT_SOURCE[source]);
         } else {
           // Capture the full pre-upload side-state for snackbar Undo /
           // Ctrl+Z. Six fields mutated by the happy path:
@@ -2812,9 +2855,11 @@ export class HomeComponent implements OnInit, OnDestroy {
           this.resetHighlightsForDocumentReplacement();
           this.lastFilename.set(filename);
           this.suggestedTitlesForMenu.set([]);
-          this.runExtractorOnCurrentContent(source === 'pick' ? 'upload.pick' : 'upload.drag');
+          this.runExtractorOnCurrentContent(FILE_INGRESS_TO_EXTRACT_SOURCE[source]);
           this.openReplaceUndoSnack(
-            $localize`:@@home.upload.snackbar.uploaded:Uploaded ${this.formatFilenameForSnack(filename)}:filename:.`,
+            source === 'osLaunch'
+              ? $localize`:@@home.osLaunch.snackbar.opened:Opened ${this.formatFilenameForSnack(filename)}:filename:.`
+              : $localize`:@@home.upload.snackbar.uploaded:Uploaded ${this.formatFilenameForSnack(filename)}:filename:.`,
             $localize`:@@home.upload.snackbar.undo:Undo`,
           );
         }

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -114,39 +114,43 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1921</context>
+          <context context-type="linenumber">1963</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2852</context>
+          <context context-type="linenumber">2778</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2862</context>
+          <context context-type="linenumber">2909</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2870</context>
+          <context context-type="linenumber">2919</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2880</context>
+          <context context-type="linenumber">2927</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3252</context>
+          <context context-type="linenumber">2937</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3262</context>
+          <context context-type="linenumber">3309</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3298</context>
+          <context context-type="linenumber">3319</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3308</context>
+          <context context-type="linenumber">3355</context>
+        </context-group>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">3365</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/rule-sets-toolbar/rule-sets-toolbar.component.ts</context>
@@ -586,7 +590,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3278</context>
+          <context context-type="linenumber">3335</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.cancel" datatype="html">
@@ -605,7 +609,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3279</context>
+          <context context-type="linenumber">3336</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/rule-sets-toolbar/clone-preset-dialog.component.ts</context>
@@ -620,7 +624,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3297</context>
+          <context context-type="linenumber">3354</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.failed" datatype="html">
@@ -631,7 +635,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3307</context>
+          <context context-type="linenumber">3364</context>
         </context-group>
       </trans-unit>
       <trans-unit id="formattingRules.title" datatype="html">
@@ -2094,267 +2098,281 @@
         <source>JotJSON - JSON viewer, formatter, and tree explorer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">845</context>
+          <context context-type="linenumber">887</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.title.untitled" datatype="html">
         <source>Untitled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1035</context>
+          <context context-type="linenumber">1077</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.coldBootClipboard.snackbar.pasted" datatype="html">
         <source>Pasted from clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1398</context>
+          <context context-type="linenumber">1440</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.coldBootClipboard.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1399</context>
+          <context context-type="linenumber">1441</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.toast" datatype="html">
         <source>Reloaded - this blob was changed in another tab</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1920</context>
+          <context context-type="linenumber">1962</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.title" datatype="html">
         <source>Blob changed in another tab</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2003</context>
+          <context context-type="linenumber">2045</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.message" datatype="html">
         <source>Your local changes conflict with the latest version. Discard your changes or replace the remote version on your next save?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2004</context>
+          <context context-type="linenumber">2046</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.replaceRemote" datatype="html">
         <source>Replace remote</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2005</context>
+          <context context-type="linenumber">2047</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.discardMine" datatype="html">
         <source>Discard my changes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2006</context>
+          <context context-type="linenumber">2048</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.extract.snackbar.applied" datatype="html">
         <source>Extracted embedded JSON into the document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2322</context>
+          <context context-type="linenumber">2364</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2677</context>
+          <context context-type="linenumber">2719</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.extract.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2323</context>
+          <context context-type="linenumber">2365</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2678</context>
+          <context context-type="linenumber">2720</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sortKeys.snackbar.applied" datatype="html">
         <source>Sorted this object&apos;s keys.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2393</context>
+          <context context-type="linenumber">2435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sortKeys.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2394</context>
+          <context context-type="linenumber">2436</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="home.osLaunch.error.unreadable" datatype="html">
+        <source>Could not open the file.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">2777</context>
+        </context-group>
+      </trans-unit>
+      <trans-unit id="home.osLaunch.snackbar.opened" datatype="html">
+        <source>Opened <x id="filename" equiv-text="this.formatFilenameForSnack(filename)"/>.</source>
+        <context-group purpose="location">
+          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
+          <context context-type="linenumber">2866</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.snackbar.uploaded" datatype="html">
         <source>Uploaded <x id="filename" equiv-text="this.formatFilenameForSnack(filename)"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2810</context>
+          <context context-type="linenumber">2867</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2811</context>
+          <context context-type="linenumber">2868</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.tooMany" datatype="html">
         <source>Please drop one file at a time.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2851</context>
+          <context context-type="linenumber">2908</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.tooLarge" datatype="html">
         <source>File too large - max 5 MB</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2861</context>
+          <context context-type="linenumber">2918</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.binary" datatype="html">
         <source>File does not appear to be a text file - upload was ignored.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2869</context>
+          <context context-type="linenumber">2926</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.readFailed" datatype="html">
         <source>Could not read file</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2879</context>
+          <context context-type="linenumber">2936</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.quotaExceeded" datatype="html">
         <source>Blob limit reached - delete one from your saved blobs to save a new blob.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3052</context>
+          <context context-type="linenumber">3109</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.signIn" datatype="html">
         <source>Please sign in to save</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3070</context>
+          <context context-type="linenumber">3127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.forbidden" datatype="html">
         <source>You do not own this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3073</context>
+          <context context-type="linenumber">3130</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.generic" datatype="html">
         <source>Could not save - please try again</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3075</context>
+          <context context-type="linenumber">3132</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.format.snackbar.applied" datatype="html">
         <source>Formatted document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3099</context>
+          <context context-type="linenumber">3156</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.format.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3100</context>
+          <context context-type="linenumber">3157</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.minify.snackbar.applied" datatype="html">
         <source>Minified document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3134</context>
+          <context context-type="linenumber">3191</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.minify.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3135</context>
+          <context context-type="linenumber">3192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sort.snackbar.applied" datatype="html">
         <source>Sorted keys.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3172</context>
+          <context context-type="linenumber">3229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sort.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3173</context>
+          <context context-type="linenumber">3230</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.success" datatype="html">
         <source>Share link copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3227</context>
+          <context context-type="linenumber">3284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.failed" datatype="html">
         <source>Failed to copy share link.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3228</context>
+          <context context-type="linenumber">3285</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3229</context>
+          <context context-type="linenumber">3286</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.public" datatype="html">
         <source>Blob is now public.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3250</context>
+          <context context-type="linenumber">3307</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.private" datatype="html">
         <source>Blob is now private.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3251</context>
+          <context context-type="linenumber">3308</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.visibility.failed" datatype="html">
         <source>Failed to update visibility.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3261</context>
+          <context context-type="linenumber">3318</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.title" datatype="html">
         <source>Delete this blob?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3276</context>
+          <context context-type="linenumber">3333</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.message" datatype="html">
         <source>&quot;<x id="name" equiv-text="label"/>&quot; will be permanently deleted. This cannot be undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3277</context>
+          <context context-type="linenumber">3334</context>
         </context-group>
       </trans-unit>
       <trans-unit id="formattingRules.clone.title" datatype="html">

--- a/src/types/launch-queue.d.ts
+++ b/src/types/launch-queue.d.ts
@@ -1,0 +1,29 @@
+/**
+ * Ambient declarations for the W3C Web App Manifest "Launch Handler" API
+ * (Chromium 102+). The PWA `file_handlers` + `launch_handler` manifest
+ * members route OS file-association launches (right-click -> Open With ->
+ * JotJSON, or `start data.json` from a terminal) into the running app via
+ * `window.launchQueue`. The API is not yet in `lib.dom.d.ts` (TS 5.x), so
+ * the surface is declared here as the single source of truth, avoiding
+ * inline `Window` casts in service / component code (skeptic F7).
+ *
+ * Spec: https://wicg.github.io/web-app-launch/
+ * Chromium impl: https://developer.chrome.com/docs/web-platform/launch-handler
+ *
+ * Only present in Chromium when the app is installed as a PWA. Firefox,
+ * Safari, and non-installed Chromium all leave `window.launchQueue`
+ * undefined; the controller checks for that before calling `setConsumer`.
+ */
+
+interface LaunchParams {
+  readonly files: readonly FileSystemFileHandle[];
+  readonly targetURL: string;
+}
+
+interface LaunchQueue {
+  setConsumer(consumer: (params: LaunchParams) => void | Promise<void>): void;
+}
+
+interface Window {
+  readonly launchQueue?: LaunchQueue;
+}

--- a/why-jotjson.md
+++ b/why-jotjson.md
@@ -166,6 +166,18 @@ months), and you can choose friendly phrases ("yesterday") vs. always-
 numeric ("in 1 day"). Plus separate toggles for whether unzoned ISO
 strings are read as UTC or local.
 
+### Install once, open `.json` from your OS
+
+Install JotJSON as a PWA in any Chromium-based browser and your OS
+registers it as a real handler for `.json`, `.jsonc`, `.json5`, and
+`.webmanifest`. Double-click a JSON file in Explorer or Finder, pick
+JotJSON from the right-click "Open with" menu, or run
+`start data.json` (Windows) / `open -a JotJSON data.json` (macOS) /
+`xdg-open data.json` (Linux desktop) from your terminal -- the file
+opens in a fresh JotJSON window with the editor already loaded.
+Competing online JSON tools don't register as a file handler, so
+they're locked behind a browser-tab + manual-upload step every time.
+
 ---
 
 ## Plus the basics, done well


### PR DESCRIPTION
## Summary

After installing JotJSON as a PWA in a Chromium-based browser, the
user can now open a `.json` / `.jsonc` / `.json5` / `.webmanifest`
file directly into JotJSON by:

- Double-clicking the file in Explorer / Finder / a Linux file manager
- Right-click -> "Open with -> JotJSON"
- `start data.json` (Windows) / `open -a JotJSON data.json` (macOS) /
  `xdg-open data.json` (Linux desktop) from a terminal

Non-Chromium users (Firefox, Safari) see zero behavior change.

## Mechanism

- `manifest.webmanifest` declares `file_handlers` for the four
  extensions with `action: "/"` and `launch_handler.client_mode:
  "navigate-new"` (every OS launch opens a fresh PWA window, so any
  `/s/:slug` editing context or unsaved drafts in an already-open
  window are preserved).
- A new singleton `LaunchQueueController` in `core/upload/` registers
  `window.launchQueue.setConsumer` once at app boot under
  `isPlatformBrowser`. Mirrors the existing `DocumentDropController`
  pattern (registration ID + stale-dispose safety).
- `HomeComponent` registers a handler with the controller in
  `ngOnInit` and disposes in `ngOnDestroy`. The ingress flows through
  the same `onFilesReceived(files, 'osLaunch')` path as drag-and-drop
  and the toolbar Upload button -- so binary-content rejection, 5 MB
  cap, extract-from-mixed-text banner, and draft-overwrite Undo all
  Just Work.
- Multi-file launches are truncated at the handle layer (only
  `getFile()` on the first handle) to avoid the OS permission-prompt
  flood.
- `getFile()` rejection (permission decline / file moved or deleted
  between Explorer click and PWA focus) delivers an error event to the
  handler; HomeComponent opens a dismissable "Could not open the file."
  snackbar and the controller logs the `home.fileHandler.readFailed`
  telemetry token (no filename or path captured).

## Forward-compatibility hook

`LaunchQueueController.currentFileHandle: Signal<FileSystemFileHandle | null>`
is set on every launch but not yet consumed. It is reserved for a
future write-back path (`createWritable()`) that would let the user
save edits directly back to the launched file without re-prompting via
picker.

## What's NOT in this PR (deliberate)

- **In-app install-discovery** -- the user's framing was "if it is
  installed as an app." Install-discovery UX (toolbar nudges, etc.)
  is a separate feature. File as a follow-up `enhancement` issue.
- **`FileSystemFileHandle.createWritable()` write-back** -- adds
  permission-prompt UX, save-state reconciliation with the cloud-blob
  save flow, and conflict semantics. The signal hook above keeps the
  path open without making it part of v1 scope.
- **Renaming `core/upload/` -> `core/files/`** -- architecturally
  correct but rename's blast radius across many imports buys nothing
  today. Rename when next-touched.

## Snackbar copy

The existing "Uploaded data.json." snackbar reads "Opened data.json."
when sourced from an OS launch. The "Opened" verb pairs naturally with
a future "Saved" once write-back lands.

```
+-----------------------------------------------+
| Opened data.json.                       UNDO  |
+-----------------------------------------------+
```

## Telemetry

- Additive enum extension on `upload.handle` (`source`):
  `'drag' | 'pick' | 'osLaunch'`.
- Additive enum extension on `home.extract.banner.*` (`pasteSource`):
  adds `'upload.osLaunch'`.
- New `home.fileHandler.readFailed` token (severity error; no
  filename / path captured) for the `getFile()` reject path.
- Two ternary mis-bucket sites in `home.component.ts` that previously
  silently mapped any non-`'pick'` source to `'upload.drag'` are
  replaced with a closed-enum map (caught by rubber-duck advocate A1,
  HIGH-priority finding).
- `docs/telemetry.md` includes a forward-pointing note so dashboards
  filtering on `'drag'`/`'pick'` know to update their predicates.

## SemVer

Minor: `1.1.0` -> `1.2.0`. Additive, opt-in, gated on PWA install +
Chromium.

## Verification

- `npm run lint:all`: green (ASCII, spec patterns, prod patterns,
  CSP hashes, SWA config, lockfile, prettier, api workspace).
- `npm test`: 3138 passed / 1 skipped / 0 failed (full root suite).
- `npm run build`: production bundle generates; prerender of `/` and
  `/404` succeeds; service worker emitted.
- `npm --prefix api test`: 465 passed.

Manual-verify recipe (Chromium PWA install):

1. Build and serve the app locally (or open the deployed site).
2. Install the PWA via the omnibox install icon.
3. Open Explorer / Finder; locate a `.json` file.
4. Double-click the file (or right-click -> "Open with -> JotJSON";
   or `start data.json` from a terminal). Confirm that a fresh JotJSON
   window opens with the file content loaded and the "Opened
   data.json." snackbar visible.

---
**Session**
- AI-Local: `fd6404f3-3600-4f07-bde4-6efcca325485`
- AI-Cloud: `3611407b-1883-474d-a51f-bbe78588c908`