### PR TITLE
Set existingDnsZoneRg in dev.bicepparam (Phase 0 step 6 prep)

### DIFF
--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -232,6 +232,12 @@ jobs:
           ENTRA_SPA_CLIENT_ID: ${{ secrets.ENTRA_SPA_CLIENT_ID }}
           ENTRA_API_CLIENT_ID: ${{ secrets.ENTRA_API_CLIENT_ID }}
           ENTRA_API_AUDIENCE: ${{ secrets.ENTRA_API_AUDIENCE }}
+        # NEVER add `--mode Complete` to this command. rg-jotjson-dev
+        # contains resources (currently: Azure DNS zone jotjson.com) that
+        # are intentionally unmanaged by this template -- see
+        # infra/parameters/dev.bicepparam:existingDnsZoneRg and
+        # docs/migration-westus2.md Phase 0 step 6. Complete mode would
+        # delete them. Incremental mode (the default) is required.
         run: |
           az deployment group create \
             --resource-group rg-jotjson-dev \

--- a/.github/workflows/infra.yml
+++ b/.github/workflows/infra.yml
@@ -232,12 +232,15 @@ jobs:
           ENTRA_SPA_CLIENT_ID: ${{ secrets.ENTRA_SPA_CLIENT_ID }}
           ENTRA_API_CLIENT_ID: ${{ secrets.ENTRA_API_CLIENT_ID }}
           ENTRA_API_AUDIENCE: ${{ secrets.ENTRA_API_AUDIENCE }}
-        # NEVER add `--mode Complete` to this command. rg-jotjson-dev
-        # contains resources (currently: Azure DNS zone jotjson.com) that
-        # are intentionally unmanaged by this template -- see
-        # infra/parameters/dev.bicepparam:existingDnsZoneRg and
-        # docs/migration-westus2.md Phase 0 step 6. Complete mode would
-        # delete them. Incremental mode (the default) is required.
+        # NEVER add `--mode Complete` to this command. Complete mode
+        # deletes resources in rg-jotjson-dev that are not declared in
+        # this deployment template. The template intentionally does
+        # not manage Azure-auto-created resources such as Application
+        # Insights Smart Detection action groups; the `jotjson.com`
+        # DNS zone is also not managed by this template (suppressed via
+        # `existingDnsZoneRg` in infra/parameters/dev.bicepparam; see
+        # docs/migration-westus2.md Phase 0 step 6). Incremental mode
+        # (the default) leaves them alone.
         run: |
           az deployment group create \
             --resource-group rg-jotjson-dev \

--- a/infra/README.md
+++ b/infra/README.md
@@ -173,15 +173,20 @@ the zone to Azure nameservers.
 
 **One-time setup:**
 
-1. Deploy infra (`infra.yml` workflow, or the manual command above). Azure
-   DNS zone `jotjson.com` is **not** managed by this template -- it lives
-   in `rg-jotjson-dns` and was relocated there in Phase 0 of the westus2
-   region migration (see `docs/migration-westus2.md` Phase 0 step 6).
-   `dev.bicepparam` sets `existingDnsZoneRg = 'rg-jotjson-dns'`, which
-   makes the `dns` module conditional skip; the `dnsNameServers`
-   deployment output therefore returns `[]`. To read the live
-   nameservers, use the Azure portal -> DNS zones -> `jotjson.com` ->
-   Overview, or `az network dns zone show -g rg-jotjson-dns -n jotjson.com --query nameServers`.
+1. Deploy infra (`infra.yml` workflow, or the manual command above). The
+   `jotjson.com` Azure DNS zone is **not** managed by this template
+   (`dev.bicepparam` sets `existingDnsZoneRg`, which conditionally skips
+   the `dns` module). To find which resource group currently hosts the
+   zone and read its delegated nameservers, run:
+
+   ```sh
+   az network dns zone list \
+     --query "[?name=='jotjson.com'].{rg:resourceGroup, ns:nameServers}" \
+     -o table
+   ```
+
+   See `docs/migration-westus2.md` Phase 0 step 6 for the ownership
+   boundary and migration history.
 2. Log into GoDaddy -> **Domains -> jotjson.com -> Nameservers -> Change**.
    Replace GoDaddy's defaults with the 4 Azure nameservers. Save.
 3. Wait for propagation (usually 15-60 min, up to 48h). Verify with

--- a/infra/README.md
+++ b/infra/README.md
@@ -173,11 +173,15 @@ the zone to Azure nameservers.
 
 **One-time setup:**
 
-1. Deploy infra (`infra.yml` workflow, or the manual command above). Bicep
-   creates the `jotjson.com` DNS zone in `rg-jotjson-dev`. The deployment
-   output `dnsNameServers` lists 4 Azure nameservers, e.g.
-   `ns1-xx.azure-dns.com`, `ns2-xx.azure-dns.net`, etc. (Also visible in the
-   Azure portal -> DNS zone -> Overview.)
+1. Deploy infra (`infra.yml` workflow, or the manual command above). Azure
+   DNS zone `jotjson.com` is **not** managed by this template -- it lives
+   in `rg-jotjson-dns` and was relocated there in Phase 0 of the westus2
+   region migration (see `docs/migration-westus2.md` Phase 0 step 6).
+   `dev.bicepparam` sets `existingDnsZoneRg = 'rg-jotjson-dns'`, which
+   makes the `dns` module conditional skip; the `dnsNameServers`
+   deployment output therefore returns `[]`. To read the live
+   nameservers, use the Azure portal -> DNS zones -> `jotjson.com` ->
+   Overview, or `az network dns zone show -g rg-jotjson-dns -n jotjson.com --query nameServers`.
 2. Log into GoDaddy -> **Domains -> jotjson.com -> Nameservers -> Change**.
    Replace GoDaddy's defaults with the 4 Azure nameservers. Save.
 3. Wait for propagation (usually 15-60 min, up to 48h). Verify with

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -10,6 +10,14 @@ param staticWebAppSku = 'Standard'
 param customDomain = ''
 param dnsZoneName = 'jotjson.com'
 
+// Azure DNS zone for jotjson.com lives in rg-jotjson-dns (relocated in
+// Phase 0 of the westus2 migration -- see docs/migration-westus2.md
+// Phase 0 step 6). Removing this line or changing its value without
+// first moving the zone back will cause the next infra.yml deploy to
+// create a phantom authoritative zone for jotjson.com here, silently
+// split-braining DNS.
+param existingDnsZoneRg = 'rg-jotjson-dns'
+
 // Entra External ID - populate via `-p` overrides or env-specific param file.
 // Keep these empty in the committed dev params; JWT validation is disabled
 // until values are provided.

--- a/infra/parameters/dev.bicepparam
+++ b/infra/parameters/dev.bicepparam
@@ -10,12 +10,15 @@ param staticWebAppSku = 'Standard'
 param customDomain = ''
 param dnsZoneName = 'jotjson.com'
 
-// Azure DNS zone for jotjson.com lives in rg-jotjson-dns (relocated in
-// Phase 0 of the westus2 migration -- see docs/migration-westus2.md
-// Phase 0 step 6). Removing this line or changing its value without
-// first moving the zone back will cause the next infra.yml deploy to
-// create a phantom authoritative zone for jotjson.com here, silently
-// split-braining DNS.
+// DNS zone jotjson.com is not managed by this template; the `dns`
+// module is suppressed while `existingDnsZoneRg` is non-empty. The
+// zone's current resource group and the operator-run relocation
+// sequence are documented in docs/migration-westus2.md Phase 0
+// step 6. Removing this line or clearing its value would re-enable
+// the `dns` module and have the next deploy attempt to manage
+// `jotjson.com` in rg-jotjson-dev, conflicting with the live zone
+// managed outside this template -- the textbook split-brain DNS
+// failure mode.
 param existingDnsZoneRg = 'rg-jotjson-dns'
 
 // Entra External ID - populate via `-p` overrides or env-specific param file.


### PR DESCRIPTION
## Summary

Phase 0 step 6 prep PR for the westus2 region migration. Sets
`existingDnsZoneRg = 'rg-jotjson-dns'` in `infra/parameters/dev.bicepparam`
so the `dns` module is skipped (i.e., the `jotjson.com` Azure DNS zone is
declared unmanaged by this template), ahead of the operator-run
`az resource move` that physically relocates the zone from
`rg-jotjson-dev` to a new `rg-jotjson-dns`.

This is the template-side half of step 6; the operator runs the
`az resource move` after this PR merges.

## Sequencing

The order is intentional and matters:

1. **(this PR)** flip `existingDnsZoneRg = 'rg-jotjson-dns'` in
   `dev.bicepparam` so Bicep stops trying to manage the zone.
2. **(operator, after merge)**
   ```
   az group create -n rg-jotjson-dns -l global
   az resource move --destination-group rg-jotjson-dns \
     --ids <id-of-jotjson.com-zone>
   ```
3. Apex resolution and SOA records unaffected (zone is moved, not
   recreated; nameservers preserved).

The inverse ordering -- move first, then this PR -- is unsafe. Between
the move and the param flip, any `infra.yml` run would observe a Bicep
template that still expects to manage `jotjson.com` in `rg-jotjson-dev`,
the zone is no longer there, and the deployment either (a) tries to
create a second authoritative `jotjson.com` zone in `rg-jotjson-dev`
(silent split-brain on subsequent A-record changes) or (b) fails-fast
on the subscription-scoped DNS zone singleton namespace. Either way,
PR-first is the only safe ordering.

The reverse direction (PR alone, no move) is benign: `infra.yml` runs
during the window see "Bicep declines to manage DNS"; live resolution
continues against the still-`rg-jotjson-dev`-resident zone.

## What-if expectation

CI's `Bicep what-if` step will show **exactly one delta**: the `dns`
module is removed from the deployment plan. The existing
`Microsoft.Network/dnsZones/jotjson.com` resource is shown as **Ignore**
(or absent), **not Delete or Modify**. This is correct: `infra.yml`
uses Incremental deployment mode (the default; no `--mode` flag is
set), and Incremental mode treats resources absent-from-template as
Ignore.

This is **not** a no-op in the deployment plan -- it is a transition
of the `jotjson.com` zone from "Managed by this template" to "Ignore by
this template," with no resource-side effect. Reviewer should assert
the what-if delta matches this description before merging.

## Definition of done

1. `az bicep build-params --file infra/parameters/dev.bicepparam --stdout`
   exits 0. (Verified locally; CI's Bicep build step will repeat.)
2. `npm run lint:all` passes. (Verified locally.)
3. CI `Bicep what-if` shows exactly the delta described above. (Reviewer
   verifies in the PR's CI artifacts before merge.)

## Rollback

If the move runs into trouble or this PR turns out to be premature, a
single-line revert (`existingDnsZoneRg = ''`) restores the prior
template behavior. No resource-side cleanup is needed -- the zone
itself is untouched by this PR. The next `infra.yml` run would then
either (a) re-include the dns module against the live `rg-jotjson-dev`
zone (no-op if zone still lives there), or (b) fail loud on
namespace-singleton collision (if the operator's already moved it).

## Alternatives explicitly ruled out

- **Bundle into PR-A (the main Bicep parameterization PR).** PR-A
  defaulted all migration params to off so it would be a no-op against
  every live stack on merge. Folding this flip into PR-A would have
  made PR-A's "live stacks unchanged" property dependent on PR-A
  merging in the same week the operator could schedule the
  `az resource move`. Keeping them separate preserves both PRs'
  reviewability.
- **Move first, then PR.** Unsafe; see Sequencing above.
- **`docs/migration-westus2.md` step 9 staleness fix.** Step 9 became
  partially stale after PR-A's iter-1 changed the dev default to
  no-op. Filed as a follow-up doc-only PR; causally independent
  (DNS vs Cosmos, different blast radii, different release cadences).

## Follow-up issues to be filed before merge

- Symmetric `existing` `Microsoft.Network/dnsZones` resource lookup in
  `main.bicep` for typo-safety on `existingDnsZoneRg` (currently a
  no-validate label string).
- SWA custom-domain binding verification across `az resource move` --
  Phase 0 step 6 runbook gap.
- Phase 0 step 6 rationale rewrite in `docs/migration-westus2.md`
  (lines 400-401 reference PR-A which is now merged).
- Phase 0 step 9 staleness post-PR-A iter-1.

## Session

AI-Local: d1db4668-c1d4-43a4-9c76-e86ec82bbb07
AI-Cloud: fa8e1735-48f9-47cc-9757-4eca1b12f784
