### PR TITLE
Fix tree.extract.applyFailed raw error.message leak (#373)

### DIFF
--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -1457,10 +1457,45 @@ export const TELEMETRY_MESSAGE_IDS = [
    * Fired by: `HomeComponent.onExtractRequest`
    *           (`features/home/home.component.ts`) when a tree extract click
    *           cannot be spliced into the current editor text.
-   * Props: { reason: 'extract.patch.parse-failed' | 'extract.patch.path-not-found'
-   *   | 'unknown' }.
+   * Props: { reason: 'parseFailed' | 'pathNotFound' | 'editorUnavailable'
+   *   | 'applyEditFailed' }. Closed-enum normalized form of the patcher's
+   *   `extract.patch.*` throw discriminators, plus the two editor-side
+   *   gating cases. Off-contract throws route to
+   *   `tree.extract.unexpectedError` instead, so the raw exception
+   *   message never lands in `customDimensions` (AGENTS.md S4 Telemetry
+   *   / Privacy). Mirrors `tree.sortKeys.applyFailed`'s reason
+   *   vocabulary for cross-handler KQL consistency.
+   * Privacy: no path, no document contents.
    */
   'tree.extract.applyFailed',
+
+  /**
+   * Severity: error
+   * Fired by: `HomeComponent.onExtractRequest`
+   *           (`features/home/home.component.ts`) default branch of the
+   *           patcher-error switch, when the thrown error does not match
+   *           either of the two documented `extract.patch.*` discriminators.
+   * Props: { source: 'patcher' }. Single-value closed-enum today;
+   *   reserved for future non-patcher unexpected sources (e.g. Monaco
+   *   edit machinery if a future regression throws synchronously from
+   *   inside the try). No raw exception message leaks into
+   *   `customDimensions`. The original cause is captured in App
+   *   Insights `exceptions` via `logger.error`'s second argument.
+   * Exception: any value caught from `patchExtractedValue(...)` whose
+   *   `error.message` is not `'extract.patch.parse-failed'` or
+   *   `'extract.patch.path-not-found'`. Indicates either a patcher
+   *   contract regression (e.g. a new throw added without updating the
+   *   handler) or an unexpected runtime fault (e.g. an internal
+   *   jsonc-parser error, OOM). Distinct from `applyFailed` warnings
+   *   to keep the closed-enum `warn` channel clean of unknown-shape
+   *   signals. Issue #372 tracks the longer-term contract evolution
+   *   (typed error class or `Result<T, E>`); the seam exists to drive
+   *   this default branch in tests under either contract.
+   * Privacy: stack and message land in `exceptions` (not
+   *   `customDimensions`), where the privacy initializer in
+   *   `TelemetryService` continues to apply.
+   */
+  'tree.extract.unexpectedError',
 
   // Tree extract undo (M7v)
 

--- a/src/app/features/home/extract-json-patcher.ts
+++ b/src/app/features/home/extract-json-patcher.ts
@@ -13,7 +13,34 @@ export interface PatchResult {
   replacementText: string;
 }
 
+/**
+ * Splice the extracted JSON payload over the value at `path` in
+ * `text`. Single call site today: `HomeComponent.onExtractRequest`
+ * (`features/home/home.component.ts`).
+ *
+ * Throws:
+ *   - `'extract.patch.parse-failed'` if `text` has JSONC parse errors
+ *     or has no parse root.
+ *   - `'extract.patch.path-not-found'` if the path does not resolve.
+ *
+ * The handler at the single call site translates these two
+ * discriminators to closed-enum `tree.extract.applyFailed` warn
+ * reasons; any other throw routes to `tree.extract.unexpectedError`
+ * to keep raw exception messages out of `customDimensions` (see
+ * AGENTS.md S4 Telemetry / Privacy). Issue #372 tracks evolving
+ * this string-discriminator contract to a typed error or
+ * `Result<T, E>` shape; until then, the two literals above are the
+ * stable contract surface.
+ */
 export function patchExtractedValue(
+  text: string,
+  path: (string | number)[],
+  replacement: ExtractedJson,
+): PatchResult {
+  return patchExtractedValueImpl(text, path, replacement);
+}
+
+function realPatchExtractedValue(
   text: string,
   path: (string | number)[],
   replacement: ExtractedJson,
@@ -46,4 +73,32 @@ export function patchExtractedValue(
     targetLength: target.length,
     replacementText: indented,
   };
+}
+
+type PatchExtractedValueImpl = (
+  text: string,
+  path: (string | number)[],
+  replacement: ExtractedJson,
+) => PatchResult;
+
+let patchExtractedValueImpl: PatchExtractedValueImpl = realPatchExtractedValue;
+
+/**
+ * Test seam: replace the patcher implementation used by
+ * `patchExtractedValue`. Allows specs to force unexpected throws
+ * (errors outside the two documented `extract.patch.*` discriminators)
+ * to exercise the default branch in `HomeComponent.onExtractRequest`.
+ * Production code must never call this.
+ */
+export function __setPatchExtractedValueImplForTesting(impl: PatchExtractedValueImpl): void {
+  patchExtractedValueImpl = impl;
+}
+
+/**
+ * Test seam: restore the production patcher implementation. Pair every
+ * `__setPatchExtractedValueImplForTesting` call with this in a
+ * `finally` (or `afterEach`) to prevent cross-spec leakage.
+ */
+export function __resetPatchExtractedValueImplForTesting(): void {
+  patchExtractedValueImpl = realPatchExtractedValue;
 }

--- a/src/app/features/home/home.component.spec.ts
+++ b/src/app/features/home/home.component.spec.ts
@@ -49,6 +49,10 @@ import {
   type ColdBootClipboardChoice,
 } from './cold-boot-clipboard-banner/cold-boot-clipboard-banner.component';
 import { ExtractJsonBannerComponent } from './extract-json-banner/extract-json-banner.component';
+import {
+  __resetPatchExtractedValueImplForTesting,
+  __setPatchExtractedValueImplForTesting,
+} from './extract-json-patcher';
 import { DropOverlayComponent } from './file-upload/drop-overlay.component';
 import { EDITOR_COMMIT_DEBOUNCE_MS, HomeComponent } from './home.component';
 import {
@@ -6660,6 +6664,65 @@ describe('HomeComponent tree extract wiring (M7s)', () => {
 
     expect(warnSpy).toHaveBeenCalledWith('tree.extract.applyFailed', {
       reason: 'editorUnavailable',
+    });
+    expect(snack.open).not.toHaveBeenCalled();
+  });
+
+  it('onExtractRequest emits applyFailed reason=pathNotFound when the path is missing', () => {
+    const { component, treeExtractor, snack, warnSpy } = setup();
+    treeExtractor.setVersion(20);
+    component.onValueChange('{"payload":"INFO {\\"a\\":1}"}');
+
+    component.onExtractRequest(
+      extractRequest(extracted('{"a":1}'), {
+        sourceVersion: 20,
+        path: ['missing'],
+      }),
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith('tree.extract.applyFailed', {
+      reason: 'pathNotFound',
+    });
+    expect(snack.open).not.toHaveBeenCalled();
+  });
+
+  it('onExtractRequest emits applyFailed reason=parseFailed when the document fails to parse', () => {
+    const { component, treeExtractor, snack, warnSpy } = setup();
+    treeExtractor.setVersion(21);
+    component.onValueChange('{"a":}');
+
+    component.onExtractRequest(
+      extractRequest(extracted('{"a":1}'), {
+        sourceVersion: 21,
+      }),
+    );
+
+    expect(warnSpy).toHaveBeenCalledWith('tree.extract.applyFailed', {
+      reason: 'parseFailed',
+    });
+    expect(snack.open).not.toHaveBeenCalled();
+  });
+
+  it('onExtractRequest forwards unexpected patcher throws to logger.error', () => {
+    const { component, treeExtractor, snack, errorSpy } = setup();
+    treeExtractor.setVersion(22);
+    component.onValueChange('{"payload":"INFO {\\"a\\":1}"}');
+    const cause = new Error('synthetic patcher failure');
+    __setPatchExtractedValueImplForTesting(() => {
+      throw cause;
+    });
+    try {
+      component.onExtractRequest(
+        extractRequest(extracted('{"a":1}'), {
+          sourceVersion: 22,
+        }),
+      );
+    } finally {
+      __resetPatchExtractedValueImplForTesting();
+    }
+
+    expect(errorSpy).toHaveBeenCalledWith('tree.extract.unexpectedError', cause, {
+      source: 'patcher',
     });
     expect(snack.open).not.toHaveBeenCalled();
   });

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -2334,10 +2334,28 @@ export class HomeComponent implements OnInit, OnDestroy {
     try {
       result = patchExtractedValue(priorText, event.path, event.replacement);
     } catch (error) {
-      this.logger.warn('tree.extract.applyFailed', {
-        reason: error instanceof Error ? error.message : 'unknown',
-      });
-      return;
+      const reason = error instanceof Error ? error.message : null;
+      switch (reason) {
+        case 'extract.patch.parse-failed':
+          this.logger.warn('tree.extract.applyFailed', { reason: 'parseFailed' });
+          return;
+        case 'extract.patch.path-not-found':
+          this.logger.warn('tree.extract.applyFailed', { reason: 'pathNotFound' });
+          return;
+        default: {
+          // Patcher's documented contract is the two extract.patch.*
+          // cases above; if a third throw appears (patcher regression)
+          // or an unexpected runtime fault leaks through (e.g. an
+          // internal jsonc-parser error, OOM), log via `error` so the
+          // cause is preserved in App Insights `exceptions` without
+          // leaking the raw message into `customDimensions`. Closed-
+          // enum `source` prop keeps the warn channel's reason union
+          // clean. Mirrors `onSortKeysRequest`'s default branch.
+          const cause = error instanceof Error ? error : new Error(String(error));
+          this.logger.error('tree.extract.unexpectedError', cause, { source: 'patcher' });
+          return;
+        }
+      }
     }
 
     const editor = this.editor();


### PR DESCRIPTION
Closes #373.

Mirrors PR #367's Sort handler fix for the parallel Extract handler. HomeComponent.onExtractRequest was passing raw ^[rror.message into customDimensions.reason, violating AGENTS.md S4 (closed-enum-only telemetry property values). Discovered as a deep-review:skeptic CRITICAL finding during PR #367 review, set aside as out-of-scope at the time.

## Changes

- **home.component.ts**: catch block in `onExtractRequest` switches on the patcher's documented discriminators and routes the default branch through `logger.error('tree.extract.unexpectedError', cause, { source: 'patcher' })`. The original cause lands in App Insights `exceptions`, not in `customDimensions`.
- **^[xtract-json-patcher.ts**: `__setPatchExtractedValueImplForTesting` / `__resetPatchExtractedValueImplForTesting` test seam mirroring `sort-json-patcher.ts:671-697` for the unexpected-throw spec.
- **	elemetry-message-ids.ts**: tightens the `tree.extract.applyFailed` reason union to `'parseFailed' | 'pathNotFound' | 'editorUnavailable' | 'applyEditFailed'` (matching `tree.sortKeys.applyFailed`'s vocabulary); registers new `tree.extract.unexpectedError` entry with the two-discriminator exclusion enumerated verbatim.
- **home.component.spec.ts**: 3 new specs (`parseFailed`, `pathNotFound`, `unexpectedError`) mirroring the Sort spec at lines 6754-6806. Real inputs for the two discriminator specs (welds the patcher<->handler integration); test seam only for the unexpected-throw spec.

## Wire-format (telemetry consumers)

Three shifts on `tree.extract.applyFailed`:

1. **Reason rename**: `'extract.patch.parse-failed'` -> `'parseFailed'`, `'extract.patch.path-not-found'` -> `'pathNotFound'`.
2. **'unknown' sentinel removed** from the reason union.
3. **Cross-event migration**: off-contract throws now surface as `tree.extract.unexpectedError` in `exceptions` (not `customDimensions`). A KQL query like `customEvents | where name == 'tree.extract.applyFailed' and customDimensions.reason == 'unknown'` becomes `exceptions | where customDimensions.messageId == 'tree.extract.unexpectedError'`.

In-repo grep over `docs/`, `scripts/`, `e2e/`, `api/`, `infra/` shows no consumers of the old reason values; `docs/telemetry.md`'s example KQL queries target only `tree.extract.click` / `tree.extract.undo`. Out-of-repo workbooks, portal-pinned queries, saved alerts, and Power BI / Grafana feeds are not in the git tree and may need updates; this PR description is the notice.

Rollout is atomic per-tab (frontend telemetry is fire-and-forget; no queued events bridge the rename).

## SemVer

No bump. Telemetry plumbing / privacy hygiene; no user-visible behavior change. Per `DESIGN_SPEC.md` -> Versioning -> SemVer bump rules: "No bump: refactors, tests, docs, deps, build/CI infrastructure, **telemetry plumbing**, dev-only changes -- anything that doesn't alter user-visible behavior."

## Out of scope

- **#371** (BOM-shift consolidation) and **#372** (`Result<T, E>` patcher contract): independent refactors with their own design surface; landing them here would mix privacy hygiene with architectural refactor.
- **home.decodedApply.applyFailed** has the same anti-pattern (`default: reason = 'unknown'` with no `logger.error` escape) but lives on an in-progress feature branch, not on `main` -- folding it in would create a cross-branch dependency. The lossy-mangling PR should adopt the same closed-enum + `unexpectedError` pattern before merging.

## Definition of Done

- [x] `npm run lint:all` passes
- [x] `npm test` passes (3142/3145 web; 3 pre-existing skips)
- [x] `npm --prefix api test` passes (466/466)
- [x] `npm run build` succeeds
- [x] No new TypeScript errors / console warnings
- [x] Spec untouched (no `DESIGN_SPEC.md` change needed)
- [x] `why-jotjson.md` untouched (no user-visible change)
- [x] Telemetry decision recorded: 1 new error event registered with full JSDoc, `check-deprecated-telemetry` passes
- [x] SemVer: no bump

---
**Session**
- AI-Local: `9a752753-4e71-4b1b-8b94-2af77679fabe`
- AI-Cloud: `9a752753-4e71-4b1b-8b94-2af77679fabe`
