### PR TITLE
Set cosmosBackupPolicyType='Continuous' in nonprod.bicepparam (#404)

### DIFF
--- a/infra/parameters/nonprod.bicepparam
+++ b/infra/parameters/nonprod.bicepparam
@@ -33,3 +33,12 @@ param entraApiAudience = ''
 // Operational alerts receiver. Same address as prod -- the alerting
 // surface is unified across environments by design (see issue #94).
 param notificationEmail = 'jotjsonadmin@gmail.com'
+
+// Cosmos backup policy: 'Continuous' is required for Phase 0
+// step 11's rehearsal PITR-restore from cosmos-jotjson-nonprod
+// (docs/migration-westus2.md). PR-A iter-1 (#376) made the
+// Periodic branch of cosmosDb.bicep a true no-op via union(),
+// so this param is the only way to enable Continuous explicitly.
+// One-way per Azure -- see infra/modules/cosmosDb.bicep:6.
+// Tracking: #404.
+param cosmosBackupPolicyType = 'Continuous'


### PR DESCRIPTION
## Summary

Symmetric mirror of #399's dev fix. Sets
`param cosmosBackupPolicyType = 'Continuous'` on
`infra/parameters/nonprod.bicepparam` so the next deploy of the
nonprod stack converts `cosmos-jotjson-nonprod` from Periodic to
Continuous backup. Required to unblock Phase 0 step 11 of the
region migration (rehearsal against nonprod-west).

## Why now

The dev half of this fix (#399 / PR #405) merged at `bce9533` on
2026-05-26; `cosmos-jotjson-dev` was verified `Continuous7Days`
this turn. With dev confirmed, the symmetric nonprod hole is the
last priority:high item blocking Phase 0 progression.

The two halves were deliberately split (per #399's three-agent
panel) along the dev/nonprod deploy-semantic boundary: dev
auto-deploys on push to main (`infra.yml`), making Periodic ->
Continuous irreversible the moment merge lands; nonprod is
`workflow_dispatch`-only (`.github/workflows/infra-nonprod.yml:27`),
so the conversion only starts when the operator chooses to
trigger it. Bundling would have forced one of: (a) the operator
to dispatch nonprod immediately after merge (committing to a
half-considered second one-way conversion), or (b) the bundled
PR's intent to remain half-realized for an indeterminate window.
Split honors the reversibility/blast-radius asymmetry.

## Scope (one-line param + comment block)

`infra/parameters/nonprod.bicepparam`:

```bicep
// Cosmos backup policy: 'Continuous' is required for Phase 0
// step 11's rehearsal PITR-restore from cosmos-jotjson-nonprod
// (docs/migration-westus2.md). PR-A iter-1 (#376) made the
// Periodic branch of cosmosDb.bicep a true no-op via union(),
// so this param is the only way to enable Continuous explicitly.
// One-way per Azure -- see infra/modules/cosmosDb.bicep:6.
// Tracking: #404.
param cosmosBackupPolicyType = 'Continuous'
```

No doc edits in this PR. Phase 0 step 5 (paragraph) and Phase 0
step 11 (Prerequisite bullet) of `docs/migration-westus2.md`
already point at #404 and at the verification query — both
landed in #405's diff. The next-step-after-merge guidance below
restates the doc, not duplicates it.

## Post-merge sequencing (operator-driven)

1. **Merge this PR.** No auto-deploy fires; nonprod is
   `workflow_dispatch`-only.
2. **Operator manually dispatches `infra-nonprod.yml`** (the
   "Run workflow" button on the workflow's Actions page, or
   `gh workflow run infra-nonprod.yml`).
3. **ARM accepts the deployment.** The Bicep deploy step
   completes in minutes; the Periodic -> Continuous backup-policy
   conversion runs async on the Cosmos control plane over
   **several hours** after that.
4. **Operator polls until the conversion completes:**

   ```
   az cosmosdb show -g rg-jotjson-nonprod -n cosmos-jotjson-nonprod \
     --query backupPolicy.continuousModeProperties.tier
   ```

   Expected result: `"Continuous7Days"`. If the call returns
   nothing / `null` / a `Periodic` field set, the conversion is
   still in flight — wait and retry. (Per Azure docs: typically
   2-6 hours; can be longer for large accounts.) Verified
   working pattern on dev this past turn.
5. **Only after verification** can Phase 0 step 11 (rehearsal
   against nonprod-west) begin. PITR against a still-Periodic
   account is rejected by `az cosmosdb restore` with a
   subscription-quota-style error message, so the verification
   query is the gate, not the absence-of-error from earlier
   steps.

## Risk / blast radius

- **Deploy-time**: zero. ARM accepts the policy change against
  the existing Cosmos account; no resource recreation. Same as
  dev (#405) where this was already exercised live this turn.
- **Conversion window**: existing periodic backups remain
  restorable until the conversion completes; Continuous PITR
  becomes usable from the conversion-completion timestamp
  forward (the original "earliest restorable time" is the moment
  conversion finishes, not the original account creation time).
  Confirmed against Azure docs.
- **Cost**: ~$0.006/month at current nonprod data size (matches
  the locked decision in the migration plan).
- **Reversibility**: one-way per Azure. See `cosmosDb.bicep:6`.
  Same one-way property as dev's #405. Acknowledged by panel and
  locked into the migration plan.

## DoD

- `az bicep build-params --file infra/parameters/nonprod.bicepparam --stdout`
  exits 0; compiled JSON shows
  `"cosmosBackupPolicyType": { "value": "Continuous" }`. Verified
  locally this turn.
- `npm run lint:all` clean (628 ASCII files scanned, 144 spec
  files, 175 prod TS files, plus prettier-check and the api/
  tsc gate — all green).
- No SemVer bump: infra param change, no user-visible behavior.

## Follow-ups

None blocked by this PR. The remaining priority:high migration
items after this lands are operator-only (preflight name/SKU
checks, GZRS deployability rehearsal, nonprod-west rehearsal,
etc., per `docs/migration-westus2.md` Phase 0 steps 2-4 and
step 11).

Closes #404.
