### PR TITLE
docs: fix three verbatim command bugs in migration-westus2.md Phase 0 steps 3, 4, 6 (#421)

### DIFF
--- a/docs/migration-westus2.md
+++ b/docs/migration-westus2.md
@@ -384,27 +384,34 @@ migration.
      PR-C script.
 3. **Pre-flight SKU availability**:
    ```
-   az storage account list-skus -l westus2 \
-     --query "[?name=='Standard_GZRS']"
+   az rest --method GET \
+     --url "https://management.azure.com/subscriptions/<sub-id>/providers/Microsoft.Storage/skus?api-version=2023-01-01" \
+     --query "value[?name=='Standard_GZRS' && resourceType=='storageAccounts'].locations" \
+     -o json
    ```
-   Confirm non-empty result. GZRS is supported in westus2 today;
-   this is a defensive guard against future SKU rotation.
+   Confirm `westus2` appears in the returned locations array. GZRS
+   is supported in westus2 today; this is a defensive guard against
+   future SKU rotation. (Use the providers SKUs REST API rather than
+   the obvious-looking `az storage account list-skus` -- the latter
+   is not a real subcommand.)
 4. **End-to-end GZRS deployability check** (critic v5 finding:
    "listed" != "deployable"; subscription enrollment in zone-
    redundant offers may differ):
    ```
-   $rnd = (New-Guid).Guid -replace '-','' | Select-Object -First 1
-   $sa = "stjjskucheck$($rnd.Substring(0,16))"
+   $rnd = ((New-Guid).Guid -replace '-','').Substring(0,12).ToLower()
+   $sa = "stjjskucheck$rnd"
    az group create -n rg-jotjson-skucheck -l westus2
    az storage account create -n $sa -g rg-jotjson-skucheck \
      -l westus2 --sku Standard_GZRS
    az storage account delete -n $sa -g rg-jotjson-skucheck --yes
    az group delete -n rg-jotjson-skucheck --yes --no-wait
    ```
-   Validates the GZRS path end-to-end. The 16-char random
-   suffix (critic v7 finding: 4-digit was weak entropy / squat
-   risk) makes collision and squat essentially impossible.
-   Discard the test account immediately.
+   Validates the GZRS path end-to-end. The 12-char random suffix
+   (critic v7 finding: 4-digit was weak entropy / squat risk; 16
+   would overflow the 24-char storage-account-name cap with the
+   `stjjskucheck` prefix) gives 2^48 entropy -- still squat-proof.
+   The `.ToLower()` is defensive: storage account names must be
+   lowercase alphanumeric. Discard the test account immediately.
 5. **Land PR-A in nonprod first**. Verify Bicep changes deploy
    cleanly with all new params unset (nonprod behavior unchanged).
    Side-effect-via-default note (post-#376 iter-1): with all new
@@ -432,10 +439,13 @@ migration.
      regardless of which RG currently hosts it.
    - **Operator-run move (remaining work for this step)**:
      ```
-     az group create -n rg-jotjson-dns -l global
+     az group create -n rg-jotjson-dns -l westus2
      az resource move --destination-group rg-jotjson-dns \
        --ids <zone-id>
      ```
+     (DNS zones are global resources, but the RG itself requires
+     a real region in its metadata; `-l global` is rejected.
+     `westus2` chosen to align metadata with the migration target.)
    - Apex resolution and SOA records unaffected.
 7. **AI/LAW move is DEFERRED to Phase 4** (critic v4 finding).
    Moving them in Phase 0 strands the existing alerts in


### PR DESCRIPTION
## Summary

Surgical fix to `docs/migration-westus2.md` Phase 0 steps 3, 4,
and 6 to replace three verbatim command bugs discovered while
executing the steps live on 2026-05-30 against the prod
subscription. All three corrected commands were validated by
running them and observing the expected outcomes.

## The three bugs (full detail in issue #421)

### Step 3 -- `az storage account list-skus` is not a real subcommand

The doc invokes `az storage account list-skus -l westus2`; az
rejects with `'list-skus' is misspelled or not recognized by the
system`. Likely a conflation with `az vm list-skus` (which does
exist). Replaced with the providers SKUs REST API, which is the
authoritative source for SKU-by-region availability and works
on the same subscription identity.

### Step 4 -- generated storage-account name overflows the 24-char cap

`stjjskucheck` (12 chars) + `$rnd.Substring(0,16)` (16 chars)
= 28 chars; the 24-char cap rejects the `az storage account
create` call. Truncated the random suffix to 12 hex chars
(prefix(12) + suffix(12) = 24). 12 hex chars is still 2^48
entropy -- well past the critic v7 squat-proof threshold (4
digits = 14 bits was the original concern). The updated text
explains the 12-char choice.

Also added `.ToLower()` defensively: storage-account names are
strictly lowercase alphanumeric, and `New-Guid` behavior is not
formally guaranteed across PowerShell versions.

### Step 6 -- `-l global` is rejected as an RG location

The doc's `az group create -n rg-jotjson-dns -l global` errors
with `LocationNotAvailableForResourceGroup`. DNS zones are
global resources, but the *RG* itself requires a real region in
its metadata. Replaced with `-l westus2` to align the RG's
metadata region with the migration target. (Any real region
would work functionally; `westus2` matches where everything else
is moving.)

## Verification (live runs from 2026-05-30 this turn)

All three corrected commands were executed live against prod
sub `db5e75e4-b980-486d-a11e-fe9327a52031`:

- Step 3 corrected: 26 GZRS-StorageV2 entries returned;
  `westus2` present.
- Step 4 corrected: created `stjjskucheck89e3d8080d54` (24
  chars), `sku: Standard_GZRS`, `provisioningState: Succeeded`;
  cleanup ran.
- Step 6 corrected: created `rg-jotjson-dns` in westus2;
  `az resource move` moved `jotjson.com` in 98.7s; NS records
  unchanged; Google (8.8.8.8) and Cloudflare (1.1.1.1) returned
  unchanged NS/A answers post-move. Zero external DNS impact.

## Out of scope (intentional)

Step 6 second half is now *actually* DONE (executed this turn).
This PR does **not** mark it `[DONE 2026-05-30]` in the doc --
status updates are a separate concern from verbatim-bug fixes,
and bundling them here would muddy the review surface. A small
follow-up PR (or a routine doc-cleanup pass at the next
checkpoint) can update step 6's status when convenient.

## DoD

- `npx prettier --check docs/migration-westus2.md`: pass.
- `npm run lint:all`: pass (628 ASCII files, 144 spec, 175 prod
  TS, prettier-check, api/ tsc).
- No SemVer bump: doc-only.

## Risk / blast radius

None. Documentation-only change.

Closes #421.
