### PR TITLE
Add vitest L2 perf config alongside Karma; fix latent #418 launch-args bug (#417)

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "perf:build": "node scripts/perf/build.mjs",
     "perf:l1": "node scripts/perf/run-bench.mjs",
     "perf:l2": "node scripts/perf/run-l2.mjs",
+    "perf:l2:vitest": "node scripts/perf/run-l2.mjs --vitest",
     "perf:l3": "node scripts/perf/run-l3.mjs",
     "perf:all": "node scripts/perf/run-all.mjs",
     "perf:baseline": "node scripts/perf/baseline.mjs",

--- a/scripts/perf/run-l2.mjs
+++ b/scripts/perf/run-l2.mjs
@@ -1,9 +1,16 @@
-// Runs `ng test --configuration perf`, captures `@@PERF_L2@@<json>@@END@@`
-// sentinels emitted by `*.perf.ts` specs from stdout, and writes a
+// Runs the L2 perf-bench harness (Karma by default, or Vitest with
+// `--vitest`), captures `@@PERF_L2@@<json>@@END@@` sentinels emitted
+// by `*.perf.ts` specs from stdout AND stderr, and writes a
 // `perf-results/<utc>/layer-2.jsonl`.
 //
 // Invoked as:
-//   npm run perf:l2
+//   npm run perf:l2          (Karma; `ng test --configuration perf`)
+//   npm run perf:l2:vitest   (Vitest; `vitest run --config vitest.perf.config.mts`)
+//
+// Both stdout and stderr are scanned for sentinels because Vitest
+// browser mode occasionally interleaves provider/dev-server output
+// across the two streams. The Karma path historically only emitted
+// to stdout, but scanning both is safe.
 
 import { execSync, spawn } from 'node:child_process';
 import { mkdirSync, writeFileSync } from 'node:fs';
@@ -47,7 +54,31 @@ export function extractRows(text) {
   return rows;
 }
 
+/**
+ * Resolve the spawn command + args for the requested harness.
+ *
+ * @param {{ vitest: boolean }} opts
+ * @returns {{ runnerLabel: string, cmd: string, args: string[] }}
+ */
+export function resolveRunner(opts) {
+  const isWin = process.platform === 'win32';
+  const cmd = isWin ? 'npx.cmd' : 'npx';
+  if (opts.vitest) {
+    return {
+      runnerLabel: 'vitest',
+      cmd,
+      args: ['vitest', 'run', '--config', 'vitest.perf.config.mts'],
+    };
+  }
+  return {
+    runnerLabel: 'ng test',
+    cmd,
+    args: ['ng', 'test', '--configuration', 'perf'],
+  };
+}
+
 async function main() {
+  const useVitest = process.argv.includes('--vitest');
   const machineLabel = process.env['PERF_MACHINE'] ?? suggestMachineLabel();
   const sha = codeSha();
   const capturedAtUtc = new Date().toISOString();
@@ -58,27 +89,32 @@ async function main() {
   mkdirSync(outDir, { recursive: true });
   const outFile = join(outDir, 'layer-2.jsonl');
 
+  const { runnerLabel, cmd, args } = resolveRunner({ vitest: useVitest });
   const isWin = process.platform === 'win32';
-  const cmd = isWin ? 'npx.cmd' : 'npx';
-  const args = ['ng', 'test', '--configuration', 'perf'];
 
   const child = spawn(cmd, args, { cwd: REPO_ROOT, shell: isWin });
-  let buffered = '';
+  let bufferedStdout = '';
+  let bufferedStderr = '';
 
   child.stdout.on('data', (chunk) => {
     const text = chunk.toString();
-    buffered += text;
+    bufferedStdout += text;
     process.stdout.write(text);
   });
   child.stderr.on('data', (chunk) => {
-    process.stderr.write(chunk);
+    const text = chunk.toString();
+    bufferedStderr += text;
+    process.stderr.write(text);
   });
 
   const exitCode = await /** @type {Promise<number>} */ (
     new Promise((resolve) => child.on('close', (code) => resolve(code ?? 1)))
   );
 
-  const rows = extractRows(buffered);
+  // Scan stdout and stderr independently to avoid splicing sentinels
+  // across stream boundaries (a sentinel split between streams was
+  // already broken in the source spec; we cannot recover from that).
+  const rows = [...extractRows(bufferedStdout), ...extractRows(bufferedStderr)];
   const lines = rows.map((row) =>
     JSON.stringify({ machineLabel, codeSha: sha, capturedAtUtc, ...row }),
   );
@@ -86,7 +122,7 @@ async function main() {
   process.stdout.write(`perf:l2  wrote ${lines.length} rows to ${outFile}\n`);
 
   if (exitCode !== 0) {
-    process.stderr.write(`perf:l2  ng test exited ${exitCode}\n`);
+    process.stderr.write(`perf:l2  ${runnerLabel} exited ${exitCode}\n`);
     process.exit(exitCode);
   }
   if (rows.length === 0) {

--- a/scripts/perf/run-l2.test.mjs
+++ b/scripts/perf/run-l2.test.mjs
@@ -1,6 +1,6 @@
 import { strict as assert } from 'node:assert';
 import { test } from 'node:test';
-import { extractRows } from './run-l2.mjs';
+import { extractRows, resolveRunner } from './run-l2.mjs';
 
 test('extractRows returns [] for text containing no sentinels', () => {
   assert.deepEqual(extractRows('no sentinels here'), []);
@@ -31,7 +31,7 @@ test('extractRows parses multiple sentinels embedded in surrounding log noise', 
   const rowA = { layer: 2, scenario: 'initial-render', size: '10k' };
   const rowB = { layer: 2, scenario: 'scroll-after-expand', size: '10k' };
   const text = [
-    'Karma chunk 1 begins...',
+    'Vitest chunk 1 begins...',
     `@@PERF_L2@@${JSON.stringify(rowA)}@@END@@`,
     'some interleaved stdout',
     `@@PERF_L2@@${JSON.stringify(rowB)}@@END@@`,
@@ -56,4 +56,34 @@ test('extractRows preserves valid rows even when a malformed sentinel is interle
   const rows = extractRows(text);
   assert.equal(rows.length, 1);
   assert.deepEqual(rows[0], valid);
+});
+
+test('extractRows recovers sentinels split across stdout and stderr', () => {
+  // Vitest browser mode occasionally splits provider output between
+  // stdout and stderr. The wrapper independently scans each stream
+  // (rather than concatenating, which could splice a sentinel
+  // across the boundary). Verify each stream still yields its
+  // sentinel when looked at in isolation.
+  const stdoutRow = { layer: 2, scenario: 'initial-render', size: '10k' };
+  const stderrRow = { layer: 2, scenario: 'scroll-after-expand', size: '10k' };
+  const stdoutStream = `noise\n@@PERF_L2@@${JSON.stringify(stdoutRow)}@@END@@\nmore noise\n`;
+  const stderrStream = `warn\n@@PERF_L2@@${JSON.stringify(stderrRow)}@@END@@\ntrailing warn\n`;
+  const combined = [...extractRows(stdoutStream), ...extractRows(stderrStream)];
+  assert.equal(combined.length, 2);
+  assert.deepEqual(combined[0], stdoutRow);
+  assert.deepEqual(combined[1], stderrRow);
+});
+
+test('resolveRunner returns the Karma harness by default', () => {
+  const resolved = resolveRunner({ vitest: false });
+  assert.equal(resolved.runnerLabel, 'ng test');
+  assert.deepEqual(resolved.args, ['ng', 'test', '--configuration', 'perf']);
+  assert.ok(resolved.cmd === 'npx' || resolved.cmd === 'npx.cmd');
+});
+
+test('resolveRunner returns the Vitest harness when --vitest is set', () => {
+  const resolved = resolveRunner({ vitest: true });
+  assert.equal(resolved.runnerLabel, 'vitest');
+  assert.deepEqual(resolved.args, ['vitest', 'run', '--config', 'vitest.perf.config.mts']);
+  assert.ok(resolved.cmd === 'npx' || resolved.cmd === 'npx.cmd');
 });

--- a/src/app/shared/components/json-tree/json-tree.component.perf.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.perf.ts
@@ -1,7 +1,8 @@
-// Layer-2 perf bench: in-browser, in-Karma render benches for
-// `JsonTreeComponent`. NOT a `.spec.ts` -- excluded from `verify:fast`
-// via `tsconfig.spec.json`. Picked up by `tsconfig.perf-l2.json` and
-// `karma.perf.conf.js`.
+// Layer-2 perf bench: in-browser render benches for
+// `JsonTreeComponent`. NOT a `.test.ts` -- excluded from
+// `verify:fast` / `npm test` via `tsconfig.spec.json` and
+// `vitest.config.mts`. Picked up by `vitest.perf.config.mts` and
+// driven by `scripts/perf/run-l2.mjs`.
 //
 // Invoked as:
 //   npm run perf:l2
@@ -57,8 +58,8 @@ const TIMED_ITERS = 5;
 function defaultFixtures(): FixtureSpec[] {
   // Size gating (post-Phase 2 virtualization; issue #95):
   //   - 10K + 100K are enabled by default. Virtualization made 100K
-  //     viable inside Karma; each iter is now bounded by the viewport
-  //     window, not the full node count.
+  //     viable; each iter is now bounded by the viewport window, not
+  //     the full node count.
   //   - 1M is opt-in via `window.__perfL2Force1M = true` or `?force1m=1`.
   //     Each iter is many minutes (build/expand traversal dominates);
   //     reserve for deliberate diagnostic runs.
@@ -66,10 +67,11 @@ function defaultFixtures(): FixtureSpec[] {
   //     is opt-in via `window.__perfL2Force5MB = true` or
   //     `?force5mb=1`. Per skeptic #4: at default settings a 380K-
   //     node fixture extrapolated linearly from 100K's ~50 s/iter
-  //     risks Karma's browserNoActivityTimeout watchdog. The flag
-  //     mirrors the existing `?force1m=1` pattern.
+  //     risks the per-test timeout. The flag mirrors the existing
+  //     `?force1m=1` pattern.
   // Defaults intentionally cap so unattended `npm run perf:l2`
-  // stays well under the Karma browserNoActivityTimeout watchdog.
+  // stays well under the per-test timeout (15 min in
+  // `vitest.perf.config.mts`).
   type ForceWindow = Window & {
     __perfL2Force1M?: boolean;
     __perfL2Force5MB?: boolean;
@@ -107,7 +109,8 @@ function ensureGc(): () => void {
   const gc = (window as unknown as { gc?: () => void }).gc;
   if (typeof gc !== 'function') {
     throw new Error(
-      'L2 perf spec: window.gc is undefined. Karma launcher must pass --js-flags=--expose-gc.',
+      'L2 perf spec: window.gc is undefined. Vitest must launch Chromium with --js-flags=--expose-gc ' +
+        '(see `vitest.perf.config.mts` -> `makeBrowserConfig`).',
     );
   }
   return gc;
@@ -228,7 +231,7 @@ describe('JsonTreeComponent perf (L2)', () => {
   //
   // wide-aoo @ 10K previously needed a force-flag because `expandAll`
   // materialized all siblings synchronously on the non-virtualized
-  // mat-tree and tripped Karma's Jasmine timeout (#219).
+  // mat-tree and tripped the per-test timeout (#219).
   // Virtualization replaced the DOM-materialization cost with a single
   // `setExpandedBulk` Set write, so the gate is no longer needed.
   //

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -1,15 +1,13 @@
 /// <reference types="vitest" />
 //
-// Vitest configuration for JotJSON (issue #47: Karma -> Vitest migration).
+// Vitest configuration for JotJSON unit tests (issue #47: Karma ->
+// Vitest migration). Plugins, browser launch args, polyfills, and
+// optimizeDeps are factored into `vitest.shared.mts` and reused by
+// `vitest.perf.config.mts` (issue #417). Edit shared substrate
+// there, not here.
 
-import angular from '@analogjs/vite-plugin-angular';
-import { playwright } from '@vitest/browser-playwright';
-import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
 import { defineConfig } from 'vitest/config';
-import { staticMount } from './scripts/static-mount.mjs';
-
-const projectRoot = fileURLToPath(new URL('.', import.meta.url));
+import { makeBrowserConfig, sharedPlugins, sharedTestBase } from './vitest.shared.mts';
 
 const rawSeed = process.env['JASMINE_SEED'];
 const trimmedSeed = typeof rawSeed === 'string' ? rawSeed.trim() : '';
@@ -38,14 +36,9 @@ class SeedReporter {
 }
 
 export default defineConfig(() => ({
-  plugins: [
-    angular(),
-    staticMount('/fixtures', join(projectRoot, 'src/testing/fixtures')),
-    staticMount('/vs', join(projectRoot, 'node_modules/monaco-editor/min/vs')),
-  ],
+  plugins: sharedPlugins,
   test: {
-    globals: true,
-    setupFiles: ['src/test-setup.ts'],
+    ...sharedTestBase,
     include: ['src/**/*.test.ts'],
     exclude: ['src/**/*.perf.ts', 'node_modules/**', 'dist/**'],
     reporters: ['default', ['junit', { suiteName: 'web' }], new SeedReporter()],
@@ -78,32 +71,6 @@ export default defineConfig(() => ({
     restoreMocks: true,
     unstubGlobals: true,
     unstubEnvs: true,
-    browser: {
-      enabled: true,
-      headless: true,
-      provider: playwright(),
-      instances: [
-        {
-          browser: 'chromium',
-          launch: {
-            args: ['--no-sandbox', '--disable-gpu', '--disable-dev-shm-usage'],
-          },
-        },
-      ],
-    },
-    server: {
-      deps: {
-        inline: ['monaco-editor'],
-      },
-    },
-    optimizeDeps: {
-      include: [
-        '@angular/localize/init',
-        'zone.js',
-        'zone.js/testing',
-        'zone.js/plugins/proxy',
-        'zone.js/plugins/sync-test',
-      ],
-    },
+    browser: makeBrowserConfig(),
   },
 }));

--- a/vitest.perf.config.mts
+++ b/vitest.perf.config.mts
@@ -1,0 +1,62 @@
+/// <reference types="vitest" />
+//
+// Vitest configuration for JotJSON L2 perf benches (issue #417:
+// retire `karma.perf.conf.js`). Picks up `src/**/*.perf.ts`, runs
+// under Chromium with `--js-flags=--expose-gc`, and writes
+// `@@PERF_L2@@<json>@@END@@` sentinel rows to stdout for
+// `scripts/perf/run-l2.mjs` to parse.
+//
+// Deltas vs `vitest.config.mts`:
+//   - include perf files, exclude unit files
+//   - testTimeout: 15 minutes (matches the previous Karma perf
+//     `timeoutInterval` for 1M-node initial-render and opt-in 100K
+//     iterations)
+//   - browser launch args add `--js-flags=--expose-gc` so the spec's
+//     `ensureGc()` precondition holds
+//   - browser `fileParallelism: false` so benches are not racing
+//     each other for CPU (the only perf file today is JsonTree, but
+//     this is the explicit invariant for the future)
+//   - browser `onConsoleLog` forwards `[reporter.stdout]`-flavored
+//     payloads as raw bytes on stdout so the wrapper's sentinel
+//     regex sees them unmodified by Vitest reporter formatting
+//   - no coverage (perf runs are measurement, not coverage)
+//   - no shuffle (perf runs should be deterministic across reruns)
+//   - no restoreMocks/unstubGlobals/unstubEnvs (perf specs neither
+//     spy nor stub; the unit-config hardening is dead weight here
+//     and may interfere with cross-iteration state)
+//   - reporters: just `default` (no junit, no SeedReporter -- perf
+//     output is the sentinel stream and the human spec summary)
+
+import { defineConfig } from 'vitest/config';
+import { makeBrowserConfig, sharedPlugins, sharedTestBase } from './vitest.shared.mts';
+
+const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+
+export default defineConfig(() => ({
+  plugins: sharedPlugins,
+  test: {
+    ...sharedTestBase,
+    include: ['src/**/*.perf.ts'],
+    exclude: ['src/**/*.test.ts', 'node_modules/**', 'dist/**'],
+    reporters: ['default'],
+    coverage: { enabled: false },
+    sequence: { shuffle: false },
+    testTimeout: FIFTEEN_MINUTES_MS,
+    hookTimeout: FIFTEEN_MINUTES_MS,
+    restoreMocks: false,
+    unstubGlobals: false,
+    unstubEnvs: false,
+    browser: makeBrowserConfig(['--js-flags=--expose-gc'], {
+      fileParallelism: false,
+      // Forward browser-side `console.log` lines as raw stdout bytes
+      // so `scripts/perf/run-l2.mjs`'s `@@PERF_L2@@...@@END@@`
+      // sentinel regex sees them verbatim. Returning `false`
+      // suppresses Vitest's own `stdout | <file>` reporter wrapping.
+      onConsoleLog: (log: string) => {
+        process.stdout.write(log);
+        if (!log.endsWith('\n')) process.stdout.write('\n');
+        return false;
+      },
+    }),
+  },
+}));

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -1,0 +1,102 @@
+/// <reference types="vitest" />
+//
+// Shared Vitest configuration substrate for JotJSON. Consumed by both
+// the unit-test config (`vitest.config.mts`) and the L2 perf-bench
+// config (`vitest.perf.config.mts`) so the two stay in sync on the
+// asset/polyfill surface they both need (Angular plugin, fixtures
+// mount, Monaco mount, zone.js polyfills, monaco inline).
+//
+// Architectural note (issue #417): we factor out *named exports*
+// rather than a single mergeable config object. Vitest's
+// `mergeConfig` performs deep-merge with array concatenation, which
+// silently breaks for singleton fields like `browser.provider` (the
+// second config's value replaces the first's, but the user has to
+// know that). Explicit named exports let each consumer compose
+// deliberately.
+
+import angular from '@analogjs/vite-plugin-angular';
+import { playwright } from '@vitest/browser-playwright';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { PluginOption } from 'vite';
+import type { BrowserConfigOptions } from 'vitest/node';
+import { staticMount } from './scripts/static-mount.mjs';
+
+const projectRoot = fileURLToPath(new URL('.', import.meta.url));
+
+/**
+ * Chromium launch flags shared by every Vitest harness in this repo.
+ *
+ * Historical note: PR #418 attempted to pass these via
+ * `instances[].launch.args`, but `@vitest/browser-playwright`
+ * silently ignores that field. The launch options are only read
+ * from the `playwright({ launchOptions: { args: [...] } })` factory
+ * argument (verified in
+ * `node_modules/@vitest/browser-playwright/dist/index.js` lines
+ * 867-872). All callers must funnel launch args through the
+ * `makeBrowserConfig()` helper below.
+ */
+export const COMMON_LAUNCH_ARGS: readonly string[] = [
+  '--no-sandbox',
+  '--disable-gpu',
+  '--disable-dev-shm-usage',
+];
+
+export const sharedPlugins: PluginOption[] = [
+  angular(),
+  staticMount('/fixtures', join(projectRoot, 'src/testing/fixtures')),
+  staticMount('/vs', join(projectRoot, 'node_modules/monaco-editor/min/vs')),
+];
+
+/**
+ * Common `test` block fields shared by unit + perf configs. Caller
+ * spreads this and adds its own `include`, `exclude`, `reporters`,
+ * `coverage`, `browser`, etc.
+ */
+export const sharedTestBase = {
+  globals: true,
+  setupFiles: ['src/test-setup.ts'],
+  server: {
+    deps: {
+      inline: ['monaco-editor'],
+    },
+  },
+  optimizeDeps: {
+    include: [
+      '@angular/localize/init',
+      'zone.js',
+      'zone.js/testing',
+      'zone.js/plugins/proxy',
+      'zone.js/plugins/sync-test',
+    ],
+  },
+} as const;
+
+/**
+ * Build a `browser` config block for Vitest. Funneling all
+ * provider creation through this helper guarantees launch args
+ * actually reach Chromium (see `COMMON_LAUNCH_ARGS` comment).
+ *
+ * @param extraArgs Additional Chromium launch flags appended to
+ *   `COMMON_LAUNCH_ARGS`. The L2 perf bench adds
+ *   `--js-flags=--expose-gc`; the unit suite passes `[]`.
+ * @param overrides Optional extra browser-block fields (e.g.,
+ *   `fileParallelism: false`, `onConsoleLog`). Merged shallow on
+ *   top of the returned object.
+ */
+export function makeBrowserConfig(
+  extraArgs: readonly string[] = [],
+  overrides: Partial<BrowserConfigOptions> = {},
+): BrowserConfigOptions {
+  return {
+    enabled: true,
+    headless: true,
+    provider: playwright({
+      launchOptions: {
+        args: [...COMMON_LAUNCH_ARGS, ...extraArgs],
+      },
+    }),
+    instances: [{ browser: 'chromium' }],
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary

This is **PR-A** of a two-PR cadence for #417 (migrate the L2 perf-suite off Karma+Jasmine onto Vitest browser mode).

PR-A is **additive**: a new `vitest.perf.config.mts` is introduced alongside `karma.perf.conf.js`; both runners coexist; `npm run perf:l2` remains the Karma path (default); `npm run perf:l2:vitest` is the new opt-in path. **PR-B** (a follow-up) will delete the Karma surface and flip the default once we've run the Vitest path in CI for a stretch.

## What changed

### New shared substrate

- **`vitest.shared.mts`** -- exports `sharedPlugins`, `sharedTestBase`, `COMMON_LAUNCH_ARGS`, and `makeBrowserConfig(extraArgs, overrides)` so the unit and perf configs share one source of truth for the Angular plugin, per-suite asset mounts, and Chromium launch args.

### New perf config

- **`vitest.perf.config.mts`** -- composes from the shared base; adds `--js-flags=--expose-gc` (the perf spec hard-throws when `window.gc` is undefined); keeps `restoreMocks`/`unstubGlobals`/`unstubEnvs` off (perf has no spies/stubs); sets `fileParallelism: false` and `sequence.shuffle: false` for determinism; sets a 15-minute `testTimeout` for the larger opt-in fixtures; and uses an `onConsoleLog` hook that writes log output raw to `process.stdout` (returning `false` to suppress Vitest's `stdout | <file>` reporter wrapping) so the `@@PERF_L2@@...@@END@@` sentinel format passes through byte-identical.

### Latent #418 bug fix (folded in)

The cutover in #418 set Chromium launch args via `instances: [{ launch: { args: [...] } }]`, but `@vitest/browser-playwright` only reads from the `playwright({ launchOptions })` factory argument and never references `instances[].launch.*`. Verified at `node_modules/@vitest/browser-playwright/dist/index.js:867-872`:

```js
// Launch options come ONLY from this.options.launchOptions
// (the factory arg passed to playwright({...})).
// instances[].launch.* is never referenced.
```

So the unit suite has been silently running with default Chromium flags since the cutover -- `--no-sandbox` and friends were a no-op. The new `makeBrowserConfig()` puts the args where the provider actually reads them (the factory arg). This is folded into PR-A rather than split out separately because the refactor touches the same lines and the fix and the migration share the same shared-substrate scaffold.

### Wrapper script changes

- **`scripts/perf/run-l2.mjs`** -- gains a `--vitest` flag (via a new exported `resolveRunner({ vitest })` helper). The wrapper now buffers both stdout AND stderr and scans each independently via `[...extractRows(stdout), ...extractRows(stderr)]` because vitest browser mode occasionally interleaves provider output across the two streams; scanning the streams separately avoids splicing a sentinel across the boundary.
- **`scripts/perf/run-l2.test.mjs`** -- adds two new tests: one covering the dual-stream split-recovery path and one covering `resolveRunner`'s Karma/Vitest dispatch. The "Karma chunk 1" log noise in an existing test is renamed to "Vitest chunk 1".

### Other

- **`package.json`** adds `perf:l2:vitest`. `perf:l2` (default) stays on Karma until PR-B.
- **`src/app/shared/components/json-tree/json-tree.component.perf.ts`** docblock, `defaultFixtures()` comments, `ensureGc()` error message, and the `expandAll` historical note are degenericized off "Karma" so the same spec serves both runners without doc drift.

## What is NOT in this PR (deferred to PR-B)

- Deletion of `karma.perf.conf.js`, `tsconfig.perf-l2.json`, `scripts/perf/check-perf-ts-excluded.mjs`, the `architect.test` block in `angular.json`, and the `*.perf.ts` exclude from `tsconfig.spec.json`.
- Removing the Karma + Jasmine perf-only devDependencies (`karma`, `karma-jasmine`, `karma-chrome-launcher`, `karma-jasmine-html-reporter`, `karma-spec-reporter`, `jasmine-core`, `@types/jasmine`).
- Flipping `perf:l2` to the Vitest path and dropping `perf:l2:vitest`.
- Removing the `preperf:l2` script (its target `check-perf-ts-excluded.mjs` is gone in PR-B).
- Pruning frozen Karma entries from `.github/dependabot.yml`.
- Doc sweep of `docs/perf.md` Layer 2 section.

## Note on #417's deliverables list

The issue mentions `@angular-devkit/build-angular` in the "Files we'll be deleting" list. That package is still required by `angular.json`'s `architect.build/serve` blocks (Angular CLI itself) and must stay. Only the Karma-specific portions are removed in PR-B.

## Verification

| Check | Result |
| --- | --- |
| `npm test` (unit suite regression) | 132 files, **3206 passed, 2 skipped** (matches post-#418 baseline; launch-args fix is transparent) |
| `npm run lint:all` | clean (frontend + api) |
| `npm run test:scripts` | **484 pass** (+3 new: `resolveRunner` Karma, `resolveRunner` Vitest, dual-stream split-recovery) |
| `npm run lint:tsc` / `lint:tsc-spec` | clean |
| `npx tsc --noEmit -p tsconfig.perf-l2.json` | clean (perf tsconfig still resolves) |
| `npm run perf:l2` (Karma path) | exit 0, 8 rows captured |
| `npm run perf:l2:vitest` (new path) | exit 0, 8 rows captured, `ensureGc()` did not throw, sentinel byte-identical |

Both paths produce identical JSONL row shape (`{machineLabel, codeSha, capturedAtUtc, layer, scenario, fixture, size, approxNodes, iters, wallNsMedian/IqrLow/IqrHigh/Stddev}`).

## Decisions on the record

- **SemVer**: no bump (internal test-infrastructure change; no public API, stored shape, or user-visible behavior impact).
- **Telemetry**: no event (internal tooling).

Closes part of #417 (PR-B closes the rest).

---
**Session**
- AI-Local: `5738cf62-c889-4eac-8122-cedec36842b0`
- AI-Cloud: `f37a626e-f09d-42b6-b349-79ff39cfd71d`
