### PR TITLE
Enable knip unused-exports detection; rename gate to lint:unused (#425)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,7 @@ jobs:
         # mirrors the local `lint:all` flow and keeps install-vs-lint
         # failure attribution unambiguous in the Actions UI: an npm ci
         # failure here is clearly an "install" failure, not a "knip
-        # finding" failure misattributed to `lint-unused-deps`.
+        # finding" failure misattributed to `lint-unused`.
         run: npm --prefix api ci
       - name: Materialize environment.ts
         run: cp src/environments/environment.example.ts src/environments/environment.ts
@@ -144,18 +144,17 @@ jobs:
         id: lint-sw-shape
         if: ${{ !cancelled() && steps.lint-tsc.conclusion != 'skipped' }}
         run: npm run lint:sw-shape
-      - name: Lint - Unused dependencies
-        # knip-driven detection of orphan npm deps across the root SPA +
-        # api/ workspaces. Scoped to deps only via knip.jsonc rule
-        # severities (unused-exports and unused-files are configured at
-        # "off" and tracked as follow-ups #425 and #426). Allowlist
-        # entries in knip.jsonc require a rationale comment naming the
-        # specific mechanism by which the dep is used. The api/ workspace
-        # is `npm ci`d at the top of this job so knip can resolve
-        # cross-workspace binaries.
-        id: lint-unused-deps
+      - name: Lint - Unused code
+        # knip-driven detection of orphan npm deps and unused exports/types
+        # across the root SPA + api/ workspaces. Severity per rule set in
+        # knip.jsonc (deps/exports/types/ns* = error; files = off, tracked
+        # as follow-up #426). Allowlist entries in knip.jsonc require a
+        # rationale comment naming the specific mechanism by which the dep
+        # is used. The api/ workspace is `npm ci`d at the top of this job
+        # so knip can resolve cross-workspace binaries.
+        id: lint-unused
         if: ${{ !cancelled() && steps.lint-tsc.conclusion != 'skipped' }}
-        run: npm run lint:unused-deps
+        run: npm run lint:unused
       - name: Lint - Prettier formatting
         id: lint-format
         if: ${{ !cancelled() && steps.lint-tsc.conclusion != 'skipped' }}
@@ -205,7 +204,7 @@ jobs:
           OUTCOME_SWA_CONFIG: ${{ steps.lint-swa-config.outcome }}
           OUTCOME_FRESHNESS_CLI: ${{ steps.lint-deploy-freshness-cli.outcome }}
           OUTCOME_SW_SHAPE: ${{ steps.lint-sw-shape.outcome }}
-          OUTCOME_UNUSED_DEPS: ${{ steps.lint-unused-deps.outcome }}
+          OUTCOME_UNUSED: ${{ steps.lint-unused.outcome }}
           OUTCOME_FORMAT: ${{ steps.lint-format.outcome }}
           OUTCOME_TEST_SCRIPTS: ${{ steps.test-scripts.outcome }}
           OUTCOME_TEST_PERF_SCRIPTS: ${{ steps.test-perf-scripts.outcome }}
@@ -237,7 +236,7 @@ jobs:
             emit "SWA config"              "$OUTCOME_SWA_CONFIG"   "npm run lint:swa-config - fix the assertion failure printed above; see scripts/check-swa-config.mjs"
             emit "Deploy freshness CLI"    "$OUTCOME_FRESHNESS_CLI" "npm run lint:deploy-freshness-cli - workflow argv must match scripts/check-deploy-freshness.mjs CLI; see error printed above"
             emit "SW shape"                "$OUTCOME_SW_SHAPE"     "npm run lint:sw-shape - if src/sw.worker.ts changed intentionally, update EXPECTED_SW_SOURCE_SHA256 in scripts/check-sw-shape.mjs"
-            emit "Unused dependencies"     "$OUTCOME_UNUSED_DEPS"  "npm run lint:unused-deps - either remove the unused dep from package.json or add it to knip.jsonc ignoreDependencies with a rationale comment naming the specific (not generic) mechanism by which the dep is used"
+            emit "Unused code"             "$OUTCOME_UNUSED"       "npm run lint:unused - either remove the unused export/dep or add it to knip.jsonc ignoreDependencies with a rationale comment naming the specific (not generic) mechanism by which the dep is used"
             emit "Prettier formatting"     "$OUTCOME_FORMAT"       "npm run format"
             emit "Script tests"            "$OUTCOME_TEST_SCRIPTS" "npm run test:scripts - then fix the failing assertion in scripts/*.test.mjs"
             emit "Perf script tests"       "$OUTCOME_TEST_PERF_SCRIPTS" "npm run test:perf-scripts - then fix the failing assertion in perf/fixtures/*.test.mjs"

--- a/api/src/shared/auth.ts
+++ b/api/src/shared/auth.ts
@@ -364,7 +364,6 @@ export async function tryAuth(req: HttpRequest): Promise<AuthenticatedPrincipal 
   }
 }
 
-// Re-exports retained for any pre-existing imports. Both SWA's x-ms-client-
-// principal and Entra JWT models are now valid code paths; the SWA path is
-// legacy and should not be used for new routes.
-export type { JwtPayload };
+// (Previously re-exported `JwtPayload` here for any pre-existing
+// imports. Removed: the type is imported from 'jsonwebtoken' directly
+// where needed, and the re-export had no in-repo consumers.)

--- a/api/src/shared/blobs.ts
+++ b/api/src/shared/blobs.ts
@@ -71,15 +71,14 @@ export interface UpdateBlobPatch {
 export const MAX_BLOB_BYTES = 1_000_000; // 1 MB, per DESIGN_SPEC section Constraints
 export const MAX_HIGHLIGHTS = 100;
 export const MAX_HIGHLIGHT_PATH_LENGTH = 1024;
-export const MAX_HIGHLIGHTS_SERIALIZED_CHARS = 16_384;
+const MAX_HIGHLIGHTS_SERIALIZED_CHARS = 16_384;
 // Keeps the existing 1 MB raw-content allowance while bounding highlight overhead
 // to 16 KB plus a small JSON envelope.
-export const MAX_BLOB_DOCUMENT_SERIALIZED_CHARS =
-  MAX_BLOB_BYTES + MAX_HIGHLIGHTS_SERIALIZED_CHARS + 128;
+const MAX_BLOB_DOCUMENT_SERIALIZED_CHARS = MAX_BLOB_BYTES + MAX_HIGHLIGHTS_SERIALIZED_CHARS + 128;
 export const MAX_TITLE_LENGTH = 200;
 export const MAX_BLOBS_PER_USER = 100; // free-tier quota, DESIGN_SPEC section Constraints
-export const SLUG_LENGTH = 6;
-export const MAX_SLUG_ATTEMPTS = 5;
+const SLUG_LENGTH = 6;
+const MAX_SLUG_ATTEMPTS = 5;
 
 // Alphanumeric only - avoids URL-unfriendly or visually ambiguous characters.
 // This is effectively a tiny in-process NanoID implementation using
@@ -87,7 +86,7 @@ export const MAX_SLUG_ATTEMPTS = 5;
 // ships ESM-only and would drag in package.json "type": "module" changes).
 const SLUG_ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 
-export function generateSlug(length: number = SLUG_LENGTH): string {
+function generateSlug(length: number = SLUG_LENGTH): string {
   const mask = 63; // 6 bits, SLUG_ALPHABET.length === 62 < 64
   const step = Math.ceil((length * 1.6) | 0) || 1;
   let result = '';
@@ -119,7 +118,7 @@ export class SlugGenerationError extends Error {
 
 let cached: Container | undefined;
 
-export function getBlobsContainer(): Container {
+function getBlobsContainer(): Container {
   if (!cached) {
     // Container name is overridable via env var so the api-integration
     // test harness can point at a per-run isolated container in the
@@ -318,14 +317,14 @@ export function assertHighlightPath(value: unknown): string {
   return value;
 }
 
-export function assertHighlightColor(value: unknown): string {
+function assertHighlightColor(value: unknown): string {
   if (typeof value !== 'string' || !HEX_COLOR.test(value)) {
     throw new BlobValidationError('highlight color must be a #RRGGBB hex color');
   }
   return value;
 }
 
-export function assertHighlight(value: unknown): BlobHighlight {
+function assertHighlight(value: unknown): BlobHighlight {
   if (!isRecord(value)) {
     throw new BlobValidationError('highlight must be an object');
   }

--- a/api/src/shared/history.ts
+++ b/api/src/shared/history.ts
@@ -28,9 +28,7 @@ import type { Container } from '@azure/cosmos';
 import { randomUUID } from 'crypto';
 import { getCosmos } from './cosmos';
 
-export type HistoryAction = 'viewed';
-
-export const HISTORY_ACTIONS: ReadonlySet<HistoryAction> = new Set<HistoryAction>(['viewed']);
+type HistoryAction = 'viewed';
 
 export interface HistoryDocument {
   id: string;
@@ -75,12 +73,12 @@ export interface ListEntriesResult {
 
 export const HISTORY_RETENTION_PER_USER = 1000;
 export const VIEW_DEBOUNCE_SECONDS = 300;
-export const DEFAULT_PAGE_SIZE = 50;
-export const MAX_PAGE_SIZE = 200;
+const DEFAULT_PAGE_SIZE = 50;
+const MAX_PAGE_SIZE = 200;
 
 let cached: Container | undefined;
 
-export function getHistoryContainer(): Container {
+function getHistoryContainer(): Container {
   if (!cached) {
     cached = getCosmos().database.container('history');
   }

--- a/api/src/shared/preferences.ts
+++ b/api/src/shared/preferences.ts
@@ -8,7 +8,7 @@
  * `DESIGN_SPEC.md`.
  */
 
-export interface ThemeColorSet {
+interface ThemeColorSet {
   selectionColor: string;
   matchingValueColor: string;
   ancestorColor: string;
@@ -21,14 +21,14 @@ export interface ThemeColorSet {
  * `SearchMatchMode` in `src/app/core/api/models.ts` (cannot import
  * across workspaces). Tokens must stay in lockstep with that file.
  */
-export type SearchMatchMode = 'exact' | 'contains' | 'starts_with' | 'ends_with' | 'regex';
+type SearchMatchMode = 'exact' | 'contains' | 'starts_with' | 'ends_with' | 'regex';
 
-export interface TreeHighlightColors {
+interface TreeHighlightColors {
   dark: ThemeColorSet;
   light: ThemeColorSet;
 }
 
-export interface TreeDateAnnotationUnits {
+interface TreeDateAnnotationUnits {
   year: boolean;
   month: boolean;
   day: boolean;

--- a/api/src/shared/ruleSets.ts
+++ b/api/src/shared/ruleSets.ts
@@ -43,17 +43,14 @@ import {
 
 // -------- Document types --------
 
-export type RuleTarget = 'key' | 'value' | 'key_and_value';
+type RuleTarget = 'key' | 'value' | 'key_and_value';
 
 /**
  * Match-type union for v1. The `regex` option is deferred to v1.1
  * pending a safe-evaluation strategy (see DESIGN_SPEC.md §Features 7,
  * "Regex policy"). Add `'regex'` back here when the engine ships it.
  */
-export type FormattingRuleMatchType = 'exact' | 'contains' | 'starts_with' | 'ends_with';
-
-// Backwards-compatible alias for older API workspace callers.
-export type RuleMatchType = FormattingRuleMatchType;
+type FormattingRuleMatchType = 'exact' | 'contains' | 'starts_with' | 'ends_with';
 
 export type ValuePredicate =
   | 'is_null'
@@ -81,7 +78,7 @@ export type ValuePredicate =
  * because new icons require a spec amendment, not a user-supplied
  * free-form string.
  */
-export type FormattingIcon = 'warning' | 'check' | 'star' | 'info' | 'error' | 'flag' | 'bookmark';
+type FormattingIcon = 'warning' | 'check' | 'star' | 'info' | 'error' | 'flag' | 'bookmark';
 
 const FORMATTING_ICONS: readonly FormattingIcon[] = [
   'warning',
@@ -141,13 +138,13 @@ export interface FormattingStyle {
   icon?: FormattingIcon;
 }
 
-export interface KeyMatch {
+interface KeyMatch {
   matchType: FormattingRuleMatchType;
   matchValue: string;
   caseSensitive: boolean;
 }
 
-export type ValueMatch =
+type ValueMatch =
   | {
       kind: 'text';
       matchType: FormattingRuleMatchType;
@@ -349,7 +346,7 @@ function assertSimpleRule(raw: unknown, field: string): FormattingRuleSimple {
   return { id, kind, target, matchType, matchValue, caseSensitive, style };
 }
 
-export function assertKeyMatch(value: unknown, field = 'keyMatch'): KeyMatch {
+function assertKeyMatch(value: unknown, field = 'keyMatch'): KeyMatch {
   if (!isRecord(value)) {
     throw new RuleSetValidationError(`${field} must be an object`);
   }
@@ -361,7 +358,7 @@ export function assertKeyMatch(value: unknown, field = 'keyMatch'): KeyMatch {
   };
 }
 
-export function assertTextMatch(
+function assertTextMatch(
   value: unknown,
   field = 'valueMatch',
 ): Extract<ValueMatch, { kind: 'text' }> {
@@ -377,7 +374,7 @@ export function assertTextMatch(
   };
 }
 
-export function assertPredicateMatch(
+function assertPredicateMatch(
   value: unknown,
   field = 'valueMatch',
 ): Extract<ValueMatch, { kind: 'predicate' }> {
@@ -391,7 +388,7 @@ export function assertPredicateMatch(
   };
 }
 
-export function assertValueMatch(value: unknown, field = 'valueMatch'): ValueMatch {
+function assertValueMatch(value: unknown, field = 'valueMatch'): ValueMatch {
   if (!isRecord(value)) {
     throw new RuleSetValidationError(`${field} must be an object`);
   }
@@ -399,7 +396,7 @@ export function assertValueMatch(value: unknown, field = 'valueMatch'): ValueMat
   return kind === 'text' ? assertTextMatch(value, field) : assertPredicateMatch(value, field);
 }
 
-export function assertPairRule(raw: unknown, field = 'rule'): FormattingRulePair {
+function assertPairRule(raw: unknown, field = 'rule'): FormattingRulePair {
   if (!isRecord(raw)) {
     throw new RuleSetValidationError(`${field} must be an object`);
   }
@@ -479,7 +476,7 @@ export function assertRuleSetPayload(payload: unknown): UpdateRuleSetPayload {
 
 let cached: Container | undefined;
 
-export function getRuleSetsContainer(): Container {
+function getRuleSetsContainer(): Container {
   if (!cached) {
     cached = getCosmos().database.container('rule-sets');
   }
@@ -621,10 +618,10 @@ export async function deleteRuleSetById(id: string, userId: string): Promise<boo
   }
 }
 
-// Re-export limits so callers can `import { MAX_RULE_SETS_PER_USER } from './ruleSets'`.
-export {
-  MAX_RULES_PER_SET,
-  MAX_RULE_MATCH_VALUE_LENGTH,
-  MAX_RULE_SETS_PER_USER,
-  MAX_RULE_SET_NAME_LENGTH,
-};
+// (Re-export of MAX_RULES_PER_SET / MAX_RULE_MATCH_VALUE_LENGTH /
+// MAX_RULE_SET_NAME_LENGTH removed: callers reference these constants
+// inside `jest.mock('../shared/ruleSets', () => ({ ... }))` factories
+// as literal values, not via import, so the re-export was unused.
+// MAX_RULE_SETS_PER_USER stays because tests import it directly via
+// `from '../shared/ruleSets'`.)
+export { MAX_RULE_SETS_PER_USER };

--- a/api/src/shared/users.ts
+++ b/api/src/shared/users.ts
@@ -49,7 +49,7 @@ export class UserAlreadyExistsError extends Error {
 
 let cached: Container | undefined;
 
-export function getUsersContainer(): Container {
+function getUsersContainer(): Container {
   if (!cached) {
     cached = getCosmos().database.container('users');
   }

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -1,13 +1,14 @@
 // knip configuration. See https://knip.dev/reference/configuration.
 //
-// This config enables ONLY unused-dependency detection (rules.dependencies
-// + .devDependencies + .optionalPeerDependencies + .unlisted + .binaries
-// + .unresolved). The unused-exports, unused-files, and unused-types
-// checks are disabled in this PR because their false-positive surfaces
-// are different and need their own allowlist-tuning passes; follow-up
-// issues track enabling each.
+// This config enables knip's full unused-detection surface for both
+// dependencies (rules.dependencies + .devDependencies +
+// .optionalPeerDependencies + .unlisted + .binaries + .unresolved) and
+// exports (rules.exports + .types + .nsExports + .nsTypes). The
+// unused-files check is still disabled in this PR because its
+// false-positive surface is different and needs its own allowlist-tuning
+// pass; follow-up issue #426 tracks enabling it.
 //
-// Run via `npm run lint:unused-deps` (also runs as part of the compound
+// Run via `npm run lint:unused` (also runs as part of the compound
 // `npm run lint`).
 //
 // To add a new entry to `ignoreDependencies` or `ignoreBinaries`, include
@@ -25,10 +26,10 @@
     "unlisted": "error",
     "binaries": "error",
     "unresolved": "error",
-    "exports": "off",
-    "types": "off",
-    "nsExports": "off",
-    "nsTypes": "off",
+    "exports": "error",
+    "types": "error",
+    "nsExports": "error",
+    "nsTypes": "error",
     "enumMembers": "off",
     "duplicates": "off",
     "files": "off",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "lint:sw-shape": "node scripts/check-sw-shape.mjs",
     "lint:deprecated-telemetry": "node scripts/check-deprecated-telemetry.mjs",
     "lint:lockfile": "node scripts/check-lockfile.mjs",
-    "lint:unused-deps": "knip",
+    "lint:unused": "knip",
     "lint:no-sentinel-ceilings": "node scripts/perf/check-no-sentinel-ceilings.mjs",
     "lint:format": "node scripts/check-format.mjs",
     "lint:all": "npm run lint && npm run lint:reduced-motion && npm --prefix api run lint",

--- a/src/app/core/api/models.ts
+++ b/src/app/core/api/models.ts
@@ -192,7 +192,7 @@ export interface UserPreferences {
   treeHighlightColors: TreeHighlightColors;
 }
 
-export type HistoryAction = 'viewed';
+type HistoryAction = 'viewed';
 
 export interface HistoryEntry {
   id: string;

--- a/src/app/core/json/json-extractor.core.ts
+++ b/src/app/core/json/json-extractor.core.ts
@@ -30,14 +30,14 @@ export interface ExtractedJson {
   hasComments: boolean;
 }
 
-export interface JsonExtractorParseResult {
+interface JsonExtractorParseResult {
   value: unknown;
   errors: readonly unknown[];
 }
 
 export type ParseJsonCandidate = (candidateText: string) => JsonExtractorParseResult;
 
-export interface JsonExtractorCandidate {
+interface JsonExtractorCandidate {
   startIndex: number;
   endIndex: number;
   slice: string;
@@ -45,7 +45,7 @@ export interface JsonExtractorCandidate {
   hasComments: boolean;
 }
 
-export interface CloseScan {
+interface CloseScan {
   closeIndex: number;
   hasComments: boolean;
 }
@@ -292,10 +292,7 @@ function jsonStringifyValue(value: unknown): string {
   return JSON.stringify(value) ?? 'null';
 }
 
-export function scan(
-  text: string,
-  parseJsonCandidate: ParseJsonCandidate,
-): JsonExtractorCandidate[] {
+function scan(text: string, parseJsonCandidate: ParseJsonCandidate): JsonExtractorCandidate[] {
   const candidates: JsonExtractorCandidate[] = [];
   const textLength = text.length;
   let index = 0;
@@ -331,7 +328,7 @@ export function scan(
   return candidates;
 }
 
-export function formatExtractedJson(slice: string, tabSize: IndentSize): string {
+function formatExtractedJson(slice: string, tabSize: IndentSize): string {
   const edits = formatJsonc(slice, undefined, {
     tabSize,
     insertSpaces: true,
@@ -339,7 +336,7 @@ export function formatExtractedJson(slice: string, tabSize: IndentSize): string 
   return applyEdits(slice, edits);
 }
 
-export function findCloseIndex(text: string, startIndex: number): CloseScan {
+function findCloseIndex(text: string, startIndex: number): CloseScan {
   const textLength = text.length;
   let depth = 1;
   let inString = false;

--- a/src/app/core/telemetry/msal-bridge.ts
+++ b/src/app/core/telemetry/msal-bridge.ts
@@ -17,7 +17,7 @@ import { TelemetryProps } from './telemetry.service';
 const BUFFER_CAP = 50;
 const MAX_MSG = 500;
 
-export interface MsalBridgeEntry {
+interface MsalBridgeEntry {
   props: TelemetryProps;
 }
 

--- a/src/app/core/telemetry/noise-filter.ts
+++ b/src/app/core/telemetry/noise-filter.ts
@@ -1,5 +1,3 @@
-import { TelemetryMessageId } from './telemetry-message-ids';
-
 /**
  * Single seam where the global `TelemetryErrorHandler` decides whether
  * an escaped error is real signal worth forwarding to App Insights or
@@ -15,9 +13,9 @@ import { TelemetryMessageId } from './telemetry-message-ids';
  * the handler.
  */
 
-export type NoiseClassification = 'forward' | 'suppress';
+type NoiseClassification = 'forward' | 'suppress';
 
-export type SuppressReason = 'monacoCanceled';
+type SuppressReason = 'monacoCanceled';
 
 export interface NoiseClassificationResult {
   readonly kind: NoiseClassification;
@@ -67,10 +65,3 @@ function isMonacoCancellation(error: unknown): boolean {
   const candidate = error as { name?: unknown; message?: unknown };
   return candidate.name === 'Canceled' && candidate.message === 'Canceled';
 }
-
-/**
- * Convenience: the messageId used by the suppress-path counter event.
- * Re-exported as a typed `TelemetryMessageId` so call sites get the
- * literal-union safety check.
- */
-export const SUPPRESSED_EVENT_ID: TelemetryMessageId = 'errorHandler.suppressed';

--- a/src/app/core/telemetry/sw-registration.ts
+++ b/src/app/core/telemetry/sw-registration.ts
@@ -35,7 +35,7 @@
 
 import { BUILD_INFO } from '../../../generated/build-info';
 
-export interface BuildIdentity {
+interface BuildIdentity {
   readonly version: string;
   readonly sha: string;
   readonly branch: string;
@@ -69,8 +69,6 @@ export type SwEvent =
       props: BuildIdentity & BrowserBucket;
       timestamp: number;
     };
-
-export type SwEventName = SwEvent['name'];
 
 export const SW_EVENTS_KEY = 'jotjson.sw.events';
 

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -48,7 +48,7 @@
  * kind, call site, props, and (for events) measurements (see
  * `AGENTS.md` -> Logging).
  */
-export const TELEMETRY_MESSAGE_IDS = [
+const TELEMETRY_MESSAGE_IDS = [
   // Generic
 
   /**

--- a/src/app/core/title-suggester/types.ts
+++ b/src/app/core/title-suggester/types.ts
@@ -16,7 +16,7 @@
  * `toolbar.titleSuggestionAccepted` telemetry event, so total
  * cardinality is bounded by this list.
  */
-export type SuggestionSource =
+type SuggestionSource =
   | 'filename'
   | 'packageJson'
   | 'kubernetes'

--- a/src/app/shared/components/json-tree/build-tree.ts
+++ b/src/app/shared/components/json-tree/build-tree.ts
@@ -21,7 +21,7 @@
 import { pathToString } from '../../../core/json/json-path';
 import { jsonTypeOf, type JsonValueType } from '../../../core/json/json-value-type';
 
-export { pathToString as formatPath, jsonTypeOf, type JsonValueType };
+export { pathToString as formatPath, jsonTypeOf };
 
 export interface TreeNode {
   segment: string | number | undefined;

--- a/src/app/shared/components/json-tree/flatten.ts
+++ b/src/app/shared/components/json-tree/flatten.ts
@@ -21,7 +21,7 @@
 
 import type { TreeNode } from './build-tree';
 
-export type FlatItemKind = 'leaf' | 'open' | 'close';
+type FlatItemKind = 'leaf' | 'open' | 'close';
 
 export interface FlatItem {
   /** `'leaf'` for primitives and empty containers; `'open'`/`'close'` bracket expanded non-empty containers; collapsed non-empty containers emit a lone `'open'` (no `'close'`). */

--- a/src/app/shared/components/json-tree/formatting-rules-engine.ts
+++ b/src/app/shared/components/json-tree/formatting-rules-engine.ts
@@ -46,7 +46,7 @@ import type {
  * different concerns), but a single row can only have one text
  * color or one boldness state.
  */
-export interface RuleStyleProjection {
+interface RuleStyleProjection {
   color?: string;
   bold?: boolean;
   italic?: boolean;
@@ -58,7 +58,7 @@ export interface RuleStyleProjection {
  * Row-level style. Renders against the tree row container, not the
  * inline key/value tokens.
  */
-export interface RuleRowStyle {
+interface RuleRowStyle {
   backgroundColor?: string;
   borderColor?: string;
 }
@@ -68,7 +68,7 @@ export interface RuleRowStyle {
  * surfaced in tooltips and the editor's matched-rule list. `label` is
  * the auto-generated, human-readable description from `describeRule`.
  */
-export interface MatchedRuleRef {
+interface MatchedRuleRef {
   setId: string;
   ruleId: string;
   label: string;

--- a/src/app/shared/utils/contrast.ts
+++ b/src/app/shared/utils/contrast.ts
@@ -20,8 +20,6 @@ export const THEME_DEFAULTS = {
   dark: { bg: '#1e1e1e', fg: '#e4e4e4' },
 } as const;
 
-export type Theme = keyof typeof THEME_DEFAULTS;
-
 /**
  * WCAG AA contrast threshold for normal-size body text. Large text
  * (18pt regular / 14pt bold) is allowed at 3.0, but tree rows are

--- a/src/testing/a11y.ts
+++ b/src/testing/a11y.ts
@@ -98,15 +98,13 @@ interface RunAxeOptions {
    * snackbars), pass `target: document.body` so the CDK
    * `cdk-overlay-container` (which renders as a sibling of the fixture
    * wrapper) is included. Overlay specs typically also pass an `exclude`
-   * list to filter out Karma/Jasmine UI -- see the `OVERLAY_EXCLUDES`
-   * convenience export.
+   * list to filter out third-party reporter chrome from the scan.
    */
   target?: Element;
   /**
    * Selectors to exclude from the scan. Useful for third-party widgets
    * whose internal a11y is tracked upstream (e.g., the Monaco editor's
-   * `.monaco-editor` subtree) and for the Karma/Jasmine reporter chrome
-   * that lives in `document.body` alongside the fixture wrapper.
+   * `.monaco-editor` subtree).
    */
   exclude?: string[];
   /**
@@ -121,25 +119,6 @@ interface RunAxeOptions {
    */
   skipWhenStable?: boolean;
 }
-
-/**
- * Selectors that filter Karma + Jasmine + Angular debug UI out of an
- * overlay-state scan. Intended for callers that pass `target:
- * document.body` to capture the CDK overlay container.
- */
-export const OVERLAY_EXCLUDES: ReadonlyArray<string> = [
-  '.jasmine_html-reporter',
-  '.jasmine-overall-result',
-  '.jasmine-banner',
-  '.jasmine-runner',
-  '.jasmine-symbol-summary',
-  '.jasmine-alert',
-  '.jasmine-results',
-  '.jasmine-suite',
-  '.jasmine-spec',
-  '#karma-context',
-  'div[id^="karma"]',
-];
 
 export function getOverlayContainerElement(): HTMLElement {
   const overlayContainer = document.querySelector<HTMLElement>('.cdk-overlay-container');
@@ -158,7 +137,7 @@ export function getOverlayContainerElement(): HTMLElement {
  * filters to `critical` + `serious` impact and asserts the resulting list
  * is empty with a readable failure message.
  */
-export async function runA11yScan(
+async function runA11yScan(
   fixture: ComponentFixture<unknown>,
   options: RunAxeOptions = {},
 ): Promise<AxeResults> {
@@ -219,7 +198,7 @@ function formatNodeTarget(node: NodeResult): string {
  * Always registers a Jasmine expectation, even on the success path, so
  * specs are never flagged as expectation-less.
  */
-export function assertNoStrictA11yViolations(results: AxeResults): void {
+function assertNoStrictA11yViolations(results: AxeResults): void {
   const strict = results.violations.filter(
     (violation) => violation.impact !== undefined && STRICT_IMPACTS.includes(violation.impact),
   );


### PR DESCRIPTION
## Summary

Closes #425. Enables knip's unused-exports / unused-types / unused-ns-exports
/ unused-ns-types detection (flipping `rules.exports`, `rules.types`,
`rules.nsExports`, `rules.nsTypes` from `off` -> `error` in
`knip.jsonc`) and renames the script from `lint:unused-deps` ->
`lint:unused` to match the broader behavior.

Empirical pre-flight showed 30 unused exports + 28 unused exported
types + 0 ns* findings concentrated in ~12 files. All 58 findings
fit DELETE / INLINE without needing `@public` tagging (so the
follow-up `@public` convention work flagged in the plan is NOT
required for this PR).

## What this adds

- **4 rule severities flipped** in `knip.jsonc`. Header comment updated.
- **Script + CI rename**: `lint:unused-deps` -> `lint:unused`;
  CI step "Lint - Unused dependencies" -> "Lint - Unused code";
  outcome env var, summary emit label, fix-hint string all updated.

## What this removes

- 8 DELETEs (genuinely dead code).
- 50 INLINEs across 16 files (drops the unnecessary `export` keyword
  from declarations whose only consumers live in the same file).

## What this deliberately does NOT change

- **AGENTS.md** is not touched (per architect-3 from PR #431; #428
  tracks the broader §7 reframe).
- **No new CI step or summary row** -- flipping rule severity
  doesn't change the existing knip step's exit code.
- **No `@public` JSDoc convention introduced**. Rubber-duck panel
  surfaced this as a one-shot taxonomy decision deserving its own
  design discussion (architect-1 + skeptic-3). Pre-flight
  confirmed all 58 findings fit DELETE/INLINE without TAG.

## Per-file dispositions (58 findings)

| File | Exports | Types | Disposition |
|---|---|---|---|
| `api/src/shared/blobs.ts` | 8 | 0 | All INLINE |
| `api/src/shared/ruleSets.ts` | 9 | 8 | INLINE; bottom re-export block partially DELETE (3 names had 0 importers); `RuleMatchType` alias DELETE'd as unused-internally too |
| `api/src/shared/history.ts` | 4 | 1 | INLINE; `HISTORY_ACTIONS` DELETE'd |
| `api/src/shared/users.ts` | 1 | 0 | INLINE |
| `api/src/shared/preferences.ts` | 0 | 4 | All INLINE |
| `api/src/shared/auth.ts` | 0 | 1 | `JwtPayload` re-export DELETE'd |
| `src/app/core/api/models.ts` | 0 | 1 | INLINE (verified no feature-module consumer) |
| `src/app/core/json/json-extractor.core.ts` | 3 | 3 | All INLINE |
| `src/app/core/telemetry/noise-filter.ts` | 1 | 2 | INLINE + DELETE `SUPPRESSED_EVENT_ID` |
| `src/app/core/telemetry/telemetry-message-ids.ts` | 1 | 0 | INLINE (public surface is the derived type, per skeptic-2) |
| `src/app/core/telemetry/msal-bridge.ts` | 0 | 1 | INLINE |
| `src/app/core/telemetry/sw-registration.ts` | 0 | 2 | INLINE + DELETE `SwEventName` |
| `src/app/core/title-suggester/types.ts` | 0 | 1 | INLINE |
| `src/app/shared/components/json-tree/**` | 0 | 3 | All INLINE |
| `src/app/shared/utils/contrast.ts` | 0 | 1 | DELETE |
| `src/testing/a11y.ts` | 3 | 0 | DELETE `OVERLAY_EXCLUDES`; INLINE 2 helpers (used at L254/L255) |

Final tally: **8 DELETEs, 50 INLINEs, 0 ENTRY-GRAPH-FIX, 0
TEST-COUPLING-ACCEPTED, 0 TAG**.

## Verification

| Check | Result |
|---|---|
| `npm run lint:all` | exit 0 in ~60s (all 13 gates green) |
| `npx vitest run` | 3206/3208 pass (2 skipped, baseline) |
| `npm --prefix api test` | 474/474 pass |
| `npm run build` | clean; all expected chunks emit |

## Coordination

No file-overlap with in-flight PRs. #417 + #435 + #438 (perf-bench
Vitest migration tail) all landed during plan iteration; pre-flight
finding count is identical pre/post.

## SemVer

**No bump.** Tooling/CI + internal-code-cleanup only. Touches
`api/src/shared/**` utility exports, not `api/src/functions/**`
route handlers.

## New CI gate message (observability)

After this PR, the lint-summary row contributors see for knip
findings is **"Unused code"** (was "Unused dependencies"). Fix-hint:

> npm run lint:unused - either remove the unused export/dep or add
> it to knip.jsonc ignoreDependencies with a rationale comment
> naming the specific (not generic) mechanism by which the dep is
> used

## Rubber-duck

Three-agent panel (skeptic + advocate + architect, parallel,
2026-05-31). 12 distinct findings: **9 adopted, 3 set aside**.

Set-aside findings:
- skeptic-1 (entry-graph blocker) -- empirically refuted
- skeptic-5 (split by risk profile) -- cross-file-overlap evidence
- architect-4 (#417 timing) -- perf-bench disjoint from findings

Adoptions caused 4 structural plan revisions:
- TAG / `@public` category removed entirely
- Script + CI rename added to scope
- TELEMETRY_MESSAGE_IDS pre-classified as INLINE with a new rubric
  sub-rule
- Per-file test runs after each workspace's edits

Full transcripts in the session folder
(`plan.critic-skeptic.md`, `plan.critic-advocate.md`,
`plan.critic-architect.md`).

## Follow-ups

After this PR lands, #425 closes. Remaining open follow-ups from
#431's panel:
- #426 - Enable knip unused-files detection
- #427 - Positive-use assertions for ignoreDependencies
- #428 - Reframe AGENTS.md §7 #1 lint enumeration
- #429 - Replace hand-bumped gate counter
- #430 - Lint-chain regrouping

---
**Session**
- AI-Local: `bb6ac642-dd57-4c49-aded-df3395b91e3e`
- AI-Cloud: `76f32c00-92fd-4ecf-9232-0fc432d1e119`
