### PR TITLE
1.3.0: remove isPublic blob visibility flag

### DIFF
--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -620,7 +620,7 @@ Available to **registered users** (create/manage). **Anonymous users can view an
 - After submitting JSON, a registered user can click **"Save & Share"**.
 - Generates a short, unique URL: `jotjson.com/s/abc123` (using the blob's NanoID slug).
 - The link loads the saved JSON blob into the editor + tree view.
-- **Visibility**: every saved blob is **unlisted**. The link works for anyone who has it, but the blob is not listed on any public index. Three crawler-defense layers ship together in 1.1.0 to prevent search-engine indexing of `/s/:slug`: a `Disallow: /s/` rule in `public/robots.txt` (pre-fetch signal, honored by every conformant crawler), an `X-Robots-Tag: noindex` HTTP header from the SWA route config (post-fetch signal for crawlers that bypass robots.txt), and a client-side `<meta name="robots" content="noindex">` injected on every blob load (last-resort signal for JS-executing crawlers). v1 deliberately does not surface a visibility toggle - keeps the share model simple. The 1.0.x `isPublic` flag, which never gated access (any blob was readable by anyone with the slug), was removed in 1.1.0; legacy stored documents have the field stripped on read via `normalizeBlobDocument` per DESIGN_SPEC -> Versioning -> Schema evolution.
+- **Visibility**: every saved blob is **unlisted**. The link works for anyone who has it, but the blob is not listed on any public index. Three crawler-defense layers ship together in 1.3.0 to prevent search-engine indexing of `/s/:slug`: a `Disallow: /s/` rule in `public/robots.txt` (pre-fetch signal, honored by every conformant crawler), an `X-Robots-Tag: noindex` HTTP header from the SWA route config (post-fetch signal for crawlers that bypass robots.txt), and a client-side `<meta name="robots" content="noindex">` injected on every blob load (last-resort signal for JS-executing crawlers). v1 deliberately does not surface a visibility toggle - keeps the share model simple. The 1.0.x `isPublic` flag, which never gated access (any blob was readable by anyone with the slug), was removed in 1.3.0; legacy stored documents have the field stripped on read via `normalizeBlobDocument` per DESIGN_SPEC -> Versioning -> Schema evolution.
 - Owner can update or delete the blob.
 - **Fork-on-save**: a signed-in non-owner who saves edits to a shared blob
   creates a new blob owned by that user with its own slug. The original blob is
@@ -1198,7 +1198,7 @@ is not enforced by code is a *lying flag* and creates the structural risk
 of users acting on a guarantee the system does not provide. Motivating
 case study: the 1.0.x `isPublic` blob flag named a privacy boundary that
 the `GET /api/blobs/{idOrSlug}` handler never honored (any blob was
-readable by anyone with the slug); the flag was removed in 1.1.0 once it
+readable by anyone with the slug); the flag was removed in 1.3.0 once it
 became clear it controlled only client-side SEO meta tags and a UI label.
 Future visibility / sharing features must ship with the access-control
 enforcement and the field together in the same PR, or not at all.
@@ -1279,7 +1279,7 @@ enforcement and the field together in the same PR, or not at all.
   `provideAppInitializer(AuthService.initializeFromRedirect)`.
 - **Open Graph + Twitter defaults** on `src/index.html` cover the homepage
   and survive into the prerendered `index.html`. Per-blob OG/Twitter was
-  retired in 1.1.0 alongside the `isPublic` flag removal - every `/s/:slug`
+  retired in 1.3.0 alongside the `isPublic` flag removal - every `/s/:slug`
   page is unlisted, so emitting per-blob rich previews would only create
   social-share friction without indexing benefit. Crawler defense for
   `/s/:slug` uses three independent layers (see Visibility above): the
@@ -1305,7 +1305,7 @@ enforcement and the field together in the same PR, or not at all.
   (npm `check:prerender`) validates the dist layout, marker placement,
   brand text, OG defaults, noindex, and asset presence after every build.
 - **Out of scope for v1** (tracked as priority:low follow-up issues):
-  - ~~Server-visible OG / `noindex` for `/s/:slug`.~~ **Resolved in 1.1.0.**
+  - ~~Server-visible OG / `noindex` for `/s/:slug`.~~ **Resolved in 1.3.0.**
     The `noindex` half is delivered via the three-layer crawler defense
     documented above (robots.txt `Disallow`, X-Robots-Tag header, client-
     side meta). The OG half is retired - no per-blob OG is emitted by any

--- a/DESIGN_SPEC.md
+++ b/DESIGN_SPEC.md
@@ -64,7 +64,6 @@ Browser (Angular SPA)
   createdAt: DateTime,
   updatedAt: DateTime,
   ownerId: string (every server-persisted blob has an owner; anonymous users keep their JSON only in localStorage),
-  isPublic: boolean,
   highlights?: BlobHighlight[] (optional sidecar manual highlights; absent on legacy blobs; max 100 entries; paths unique),
   version: number (monotonic concurrency token; surfaced as the strong ETag and required via If-Match on PUT)
 }
@@ -550,7 +549,7 @@ The primary page. Available to **all users** (anonymous + registered).
       BlobHighlight[]`, a sidecar on the blob. They are edited in
       memory until save; `POST /api/blobs` and `PUT /api/blobs/:id`
       carry them with the other blob fields. Read-only viewers
-      (anonymous public/unlisted readers and signed-in non-owners) see
+      (anonymous readers and signed-in non-owners) see
       existing highlights but cannot add, change, or remove them.
       Fork-on-save copies the source blob's highlights into the new
       owner-owned blob.
@@ -616,12 +615,12 @@ The primary page. Available to **all users** (anonymous + registered).
 
 ### 2. Persistent Link / Share  (`/s/:id`)
 
-Available to **registered users** (create/manage). **Anonymous users can view any shared link** they have the slug for (both unlisted and public blobs).
+Available to **registered users** (create/manage). **Anonymous users can view any shared link** they have the slug for.
 
 - After submitting JSON, a registered user can click **"Save & Share"**.
 - Generates a short, unique URL: `jotjson.com/s/abc123` (using the blob's NanoID slug).
 - The link loads the saved JSON blob into the editor + tree view.
-- **Visibility**: every saved blob is **private (unlisted) by default** - the link works for anyone who has it, but the blob is not listed on any public index, has a `noindex` meta tag, and does not emit rich Open Graph previews. The owner can toggle the blob to **public**, which enables Open Graph previews on `/s/:id` and allows indexing.
+- **Visibility**: every saved blob is **unlisted**. The link works for anyone who has it, but the blob is not listed on any public index. Three crawler-defense layers ship together in 1.1.0 to prevent search-engine indexing of `/s/:slug`: a `Disallow: /s/` rule in `public/robots.txt` (pre-fetch signal, honored by every conformant crawler), an `X-Robots-Tag: noindex` HTTP header from the SWA route config (post-fetch signal for crawlers that bypass robots.txt), and a client-side `<meta name="robots" content="noindex">` injected on every blob load (last-resort signal for JS-executing crawlers). v1 deliberately does not surface a visibility toggle - keeps the share model simple. The 1.0.x `isPublic` flag, which never gated access (any blob was readable by anyone with the slug), was removed in 1.1.0; legacy stored documents have the field stripped on read via `normalizeBlobDocument` per DESIGN_SPEC -> Versioning -> Schema evolution.
 - Owner can update or delete the blob.
 - **Fork-on-save**: a signed-in non-owner who saves edits to a shared blob
   creates a new blob owned by that user with its own slug. The original blob is
@@ -640,7 +639,7 @@ the event timeline (3b) took over that URL. The component and its
 per-row behavior are unchanged.
 
 - Lists the signed-in user's saved blobs, sorted by `updatedAt` DESC.
-- Each row shows: title (or "Untitled" when the blob has no title) linking to `/s/:slug` to open it, the slug, a relative updated-at time (e.g., "3 hours ago"), and a `public` badge when `isPublic` is true.
+- Each row shows: title (or "Untitled" when the blob has no title) linking to `/s/:slug` to open it, the slug, and a relative updated-at time (e.g., "3 hours ago").
 - Per-row actions: **Copy link** (writes `https://jotjson.com/s/:slug` to the clipboard) and **Delete** (confirms via dialog, then removes the blob server-side and from the list).
 - Loading state renders a three-row pulsing skeleton; empty state reads "You haven't saved any JSON blobs yet." with an "Open the editor" CTA.
 - No pagination needed in v1 - the 100-blob quota keeps the list small.
@@ -648,7 +647,6 @@ per-row behavior are unchanged.
   - Fallback title: show the first ~80 characters of the JSON body when `title` is absent, instead of "Untitled".
   - Additional metadata per row: save date (absolute) and byte size.
   - Search and filter by date range or keyword.
-  - Inline public/private toggle on the list row (today this lives in the toolbar overflow menu on `/s/:slug`).
   - Infinite scroll if/when quotas increase.
 
 #### 3b. Recently viewed page (`/history`, M5b - narrowed in v1)
@@ -1127,8 +1125,8 @@ for setup. The bypass cannot engage in any Azure-hosted environment.
 | GET | `/api/health` | None | Liveness probe |
 | POST | `/api/blobs` | Required | Create a new JSON blob |
 | GET | `/api/blobs` | Required | List caller's blobs (newest first) |
-| GET | `/api/blobs/:id` | Optional | Get a blob by UUID or slug. Public / unlisted blobs do not require auth; owner-only blobs (post-v1) will. |
-| PUT | `/api/blobs/:id` | Required (owner) | Update a blob's content, title, `isPublic` flag, or manual highlights |
+| GET | `/api/blobs/:id` | Optional | Get a blob by UUID or slug. Unlisted blobs do not require auth; owner-only blobs (post-v1) will. |
+| PUT | `/api/blobs/:id` | Required (owner) | Update a blob's content, title, or manual highlights |
 | DELETE | `/api/blobs/:id` | Required (owner) | Delete a blob |
 | GET | `/api/me` | Required | Read the current user document. Returns 404 if not yet seeded. Response carries `ETag: "<version>"`. |
 | POST | `/api/me` | Required | First-time seed: create the user document from the request body (typically the anon user's local preferences). Idempotent; 409 if already seeded. Response carries `ETag: "<version>"`. |
@@ -1192,6 +1190,18 @@ tripwires together make IfMatch protection the default for every
 - Must be valid JSON or JSONC (server re-validates using JSONC-aware parser).
 - Rate limiting: 60 requests/min per IP (anonymous), 120/min (authenticated).
 - **Blob quota (free tier: 100 blobs per user)** - when a user saves their 101st blob, the server automatically deletes the **oldest** blob (by `updatedAt`, then `createdAt` as tiebreaker) to make room. The user is notified via a toast: "Deleted oldest blob '[title]' to stay within your 100-blob limit." The first time this happens per user, a one-time modal explains the auto-delete behavior and offers "OK, got it" or "Let me manage manually" (which instead aborts the save with a prompt to delete blobs from `/blobs`). This choice is remembered as a user preference (`blobQuotaStrategy`: `"auto_fifo"` default or `"manual"`).
+- **Access-control semantics must be enforced at the access-control layer.**
+API fields that imply an access-control semantic (visibility, ownership,
+permissions, sharing scope) MUST be enforced at the access-control layer
+at the time of the field's introduction. A field whose declared meaning
+is not enforced by code is a *lying flag* and creates the structural risk
+of users acting on a guarantee the system does not provide. Motivating
+case study: the 1.0.x `isPublic` blob flag named a privacy boundary that
+the `GET /api/blobs/{idOrSlug}` handler never honored (any blob was
+readable by anyone with the slug); the flag was removed in 1.1.0 once it
+became clear it controlled only client-side SEO meta tags and a UI label.
+Future visibility / sharing features must ship with the access-control
+enforcement and the field together in the same PR, or not at all.
 
 ---
 
@@ -1268,19 +1278,25 @@ tripwires together make IfMatch protection the default for every
   provides MSAL no-op stubs and skips `provideServiceWorker` /
   `provideAppInitializer(AuthService.initializeFromRedirect)`.
 - **Open Graph + Twitter defaults** on `src/index.html` cover the homepage
-  and survive into the prerendered `index.html`. Per-blob OG/Twitter and
-  `noindex` for unlisted blobs are still set client-side by `SeoService`
-  (M4c). `home.component.ts`'s constructor effect that wipes OG tags when
-  no blob is loaded is gated on `isBrowser` so the static defaults are not
-  stripped during prerender.
+  and survive into the prerendered `index.html`. Per-blob OG/Twitter was
+  retired in 1.1.0 alongside the `isPublic` flag removal - every `/s/:slug`
+  page is unlisted, so emitting per-blob rich previews would only create
+  social-share friction without indexing benefit. Crawler defense for
+  `/s/:slug` uses three independent layers (see Visibility above): the
+  pre-fetch `Disallow: /s/` rule in `public/robots.txt`, the
+  `X-Robots-Tag: noindex` HTTP header from `staticwebapp.config.json`
+  (asserted by `scripts/check-swa-config.mjs`), and the always-on
+  client-side `<meta name="robots" content="noindex">` injected by
+  `HomeComponent` for every blob load (covers JS-executing crawlers that
+  bypass the first two).
 - **`og.png`** at `public/og.png` (1200x630, `summary_large_image`).
 - **`robots.txt` + `sitemap.xml`** at `public/robots.txt` and
   `public/sitemap.xml`, listing `https://jotjson.com/` (homepage only;
   /404 is excluded from sitemaps).
 - **404 noindex.** `NotFoundComponent.ngOnInit()` calls
-  `seo.setNoindex(true)` and `seo.clearBlobTags()`, both of which fire
-  during the `/404` prerender so the emitted HTML carries
-  `<meta name="robots" content="noindex">` for crawlers.
+  `seo.setNoindex(true)`, which fires during the `/404` prerender so
+  the emitted HTML carries `<meta name="robots" content="noindex">`
+  for crawlers.
 - **Navigation fallback.** SWA's `navigationFallback.rewrite` points at
   `/shell.html` so unknown navigation URLs land on the SPA shell.
   Prerendered `/index.html` and `/404/index.html`, plus `og.png`,
@@ -1289,9 +1305,11 @@ tripwires together make IfMatch protection the default for every
   (npm `check:prerender`) validates the dist layout, marker placement,
   brand text, OG defaults, noindex, and asset presence after every build.
 - **Out of scope for v1** (tracked as priority:low follow-up issues):
-  - Server-visible OG / `noindex` for `/s/:slug`. Slug space is unbounded
-    and per-blob visibility is dynamic, so static prerender cannot
-    satisfy this. Issue: `followup-share-og`.
+  - ~~Server-visible OG / `noindex` for `/s/:slug`.~~ **Resolved in 1.1.0.**
+    The `noindex` half is delivered via the three-layer crawler defense
+    documented above (robots.txt `Disallow`, X-Robots-Tag header, client-
+    side meta). The OG half is retired - no per-blob OG is emitted by any
+    code path now that all blobs are unlisted.
   - True HTTP 404 status for unknown paths. SWA's `navigationFallback`
     returns 200 and would need `responseOverrides` config. Issue:
     `followup-true-404`.
@@ -3334,6 +3352,39 @@ Out of scope (for v1):
   effect across the four `system`+OS / `dark` / `light` permutations,
   the `color-scheme` rules via stylesheet introspection, and the
   boot-theme helper.
+- **1.3.0**: Remove the `isPublic` blob visibility flag. Investigation
+  found the 1.x flag was a *lying flag* - its declared "private vs
+  public" semantic was not enforced at the access-control layer (any
+  blob was readable by anyone with the slug; `GET /api/blobs/{idOrSlug}`
+  has no `isPublic` check). The flag controlled only client-side SEO
+  meta tags and an overflow-menu UI label. Removed end-to-end: dropped
+  from `JsonBlob`, `BlobDocument`, `CreateBlobInput`, `UpdateBlobPatch`,
+  POST/PUT wire payloads; removed the toolbar overflow item, the
+  `/blobs` "public" badge, the 3-way merge branch + snapshot field +
+  dirty-flag term + `onTogglePublic` chain in `HomeComponent`, the
+  `share.visibility.changed` / `.failed` telemetry tokens, the
+  `share.created` event's `visibility` dimension, and seven i18n
+  strings. `SeoService` shrinks to a single `setNoindex(boolean)`
+  method (per-blob OG/Twitter retired alongside the flag).
+  Schema-evolution Removal (DESIGN_SPEC §2102): `normalizeBlobDocument`
+  strips any legacy `isPublic` key on read with a typed in-only field
+  guard preserving the existing reference-equality optimization, and
+  emits a deduplicated `blob.legacy.isPublic.stripped` event once per
+  blob id per process so the cleanup follow-up
+  (`followup-blob-ispublic-strip`) has a measurable exit signal. The
+  `updateBlob` handler gains an empty-patch early-out so a stale-client
+  `{ isPublic: true }`-only PUT no longer bumps version / `updatedAt`.
+  All `/s/:slug` URLs are now layered-defended from search-engine
+  indexing: `Disallow: /s/` in `public/robots.txt`,
+  `X-Robots-Tag: noindex` header from `staticwebapp.config.json` for
+  `/s/*` (asserted by extended `scripts/check-swa-config.mjs`), and
+  always-on client-side `<meta name="robots" content="noindex">` on
+  every blob load. Verified empirically before merge that no `/s/*`
+  URLs were indexed by any major search engine, eliminating the
+  orphan-index failure mode for the single-deploy rollout. New spec
+  rule §Security: API fields with access-control semantics must be
+  enforced at the access-control layer at the time of the field's
+  introduction. Resolves `followup-share-og`.
 - **Pre-V1**: stays at the current pre-v1 version for non-feature work;
   minor bumps applied for new user-visible features per the rules above. The
   build counter + SHA in the status-bar badge remain the per-build

--- a/api/integration/blobs.create-read.integration.test.ts
+++ b/api/integration/blobs.create-read.integration.test.ts
@@ -43,7 +43,6 @@ describe('api-integration: blob create -> read round-trip', () => {
     const created = await createBlob(ownerId, {
       content,
       title,
-      isPublic: false,
     });
 
     expect(created.id).toMatch(/^[0-9a-f-]{36}$/);
@@ -51,7 +50,6 @@ describe('api-integration: blob create -> read round-trip', () => {
     expect(created.ownerId).toBe(ownerId);
     expect(created.content).toBe(content);
     expect(created.title).toBe(title);
-    expect(created.isPublic).toBe(false);
     expect(created.version).toBe(1);
     expect(created.createdAt).toBe(created.updatedAt);
     expect(new Date(created.createdAt).toString()).not.toBe('Invalid Date');
@@ -63,7 +61,6 @@ describe('api-integration: blob create -> read round-trip', () => {
     expect(byId?.ownerId).toBe(ownerId);
     expect(byId?.content).toBe(content);
     expect(byId?.title).toBe(title);
-    expect(byId?.isPublic).toBe(false);
     expect(byId?.version).toBe(1);
 
     const bySlug = await findBlobByIdOrSlug(created.slug);

--- a/api/src/functions/blobs.test.ts
+++ b/api/src/functions/blobs.test.ts
@@ -129,7 +129,6 @@ const sampleBlob = {
   slug: 'abc123',
   content: '{"hello":"world"}',
   ownerId: 'u-1',
-  isPublic: false,
   version: 1,
   createdAt: '2026-01-01T00:00:00Z',
   updatedAt: '2026-01-01T00:00:00Z',
@@ -157,24 +156,31 @@ describe('POST /api/blobs', () => {
 
   it('creates a blob for the authenticated caller', async () => {
     createBlob.mockResolvedValueOnce(sampleBlob);
-    const res = await postBlob(
-      makeRequest({ body: { content: '{}', title: 'hi', isPublic: false } }),
-      ctx,
-    );
+    const res = await postBlob(makeRequest({ body: { content: '{}', title: 'hi' } }), ctx);
     expect(res.status).toBe(201);
     expect(res.headers).toEqual({ ETag: '"1"' });
     expect(res.jsonBody).toEqual(sampleBlob);
     expect(createBlob).toHaveBeenCalledWith('u-1', {
       content: '{}',
       title: 'hi',
-      isPublic: false,
     });
   });
 
-  it('omits title/isPublic when missing from the payload', async () => {
+  it('omits title when missing from the payload', async () => {
     createBlob.mockResolvedValueOnce(sampleBlob);
     await postBlob(makeRequest({ body: { content: '{}' } }), ctx);
     expect(createBlob).toHaveBeenCalledWith('u-1', { content: '{}' });
+  });
+
+  it('silently drops unknown payload fields like the legacy isPublic flag', async () => {
+    // Pre-1.1.0 SPA bundles cached in tabs still send `isPublic` on save;
+    // the handler must accept-and-drop rather than 400. See plan.md.
+    createBlob.mockResolvedValueOnce(sampleBlob);
+    await postBlob(makeRequest({ body: { content: '{}', title: 'hi', isPublic: true } }), ctx);
+    expect(createBlob).toHaveBeenCalledWith('u-1', {
+      content: '{}',
+      title: 'hi',
+    });
   });
 
   it('passes highlights through when supplied', async () => {
@@ -222,7 +228,6 @@ describe('POST /api/blobs - quota enforcement', () => {
       slug: `slug-${i}`,
       ownerId: 'u-1',
       content: '{}',
-      isPublic: false,
       // Older indices are older (smaller updatedAt).
       createdAt: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
       updatedAt: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
@@ -434,7 +439,7 @@ describe('PUT /api/blobs/:id', () => {
 
   it.each([
     ['title-only', { title: 'renamed' }],
-    ['isPublic-only', { isPublic: true }],
+    ['highlights-only', { highlights: [{ path: '$.x', color: '#abcdef', cascade: false }] }],
   ])('returns 412 for stale %s updates', async (_name, body) => {
     findBlob.mockResolvedValueOnce({ ...sampleBlob, version: 2 });
     const response = await putBlob(
@@ -803,7 +808,6 @@ describe('quota.exceeded telemetry emission from blob handlers', () => {
         slug: `slug-${i}`,
         ownerId: 'u-1',
         content: '{}',
-        isPublic: false,
         createdAt: timestamp,
         updatedAt: timestamp,
         title: i === 0 ? 'oldest title' : undefined,
@@ -888,7 +892,6 @@ describe('blob.autoDeleted telemetry emission from postBlob', () => {
         slug: `slug-${i}`,
         ownerId: 'u-1',
         content: '{}',
-        isPublic: false,
         createdAt: timestamp,
         updatedAt: timestamp,
         title: i === 0 ? 'oldest title' : undefined,

--- a/api/src/functions/blobs.test.ts
+++ b/api/src/functions/blobs.test.ts
@@ -173,7 +173,7 @@ describe('POST /api/blobs', () => {
   });
 
   it('silently drops unknown payload fields like the legacy isPublic flag', async () => {
-    // Pre-1.1.0 SPA bundles cached in tabs still send `isPublic` on save;
+    // Pre-1.3.0 SPA bundles cached in tabs still send `isPublic` on save;
     // the handler must accept-and-drop rather than 400. See plan.md.
     createBlob.mockResolvedValueOnce(sampleBlob);
     await postBlob(makeRequest({ body: { content: '{}', title: 'hi', isPublic: true } }), ctx);

--- a/api/src/functions/blobs.ts
+++ b/api/src/functions/blobs.ts
@@ -4,8 +4,8 @@
  * POST   /api/blobs                -> create a new blob owned by the caller
  * GET    /api/blobs                -> list the caller's blobs (auth required)
  * GET    /api/blobs/{idOrSlug}     -> read any blob by UUID id or NanoID slug
- *                                     (auth optional - private/unlisted blobs
- *                                     are viewable by anyone with the link)
+ *                                     (auth optional - blobs are unlisted but
+ *                                     viewable by anyone with the link)
  * PUT    /api/blobs/{id}           -> update an owned blob in place
  * DELETE /api/blobs/{id}           -> delete an owned blob
  *
@@ -183,7 +183,6 @@ export async function postBlob(
   const payload = body as {
     content?: unknown;
     title?: unknown;
-    isPublic?: unknown;
     highlights?: unknown;
   };
 
@@ -233,7 +232,6 @@ export async function postBlob(
     const saved = await createBlob(principal.id, {
       content: payload.content,
       ...(payload.title !== undefined ? { title: payload.title } : {}),
-      ...(payload.isPublic !== undefined ? { isPublic: payload.isPublic } : {}),
       ...(payload.highlights !== undefined ? { highlights: payload.highlights } : {}),
     });
     const response = withEtag(201, saved);
@@ -390,7 +388,6 @@ export async function putBlob(
   const patch = body as {
     content?: unknown;
     title?: unknown;
-    isPublic?: unknown;
     highlights?: unknown;
   };
 
@@ -419,7 +416,6 @@ export async function putBlob(
       {
         ...(patch.content !== undefined ? { content: patch.content } : {}),
         ...(patch.title !== undefined ? { title: patch.title } : {}),
-        ...(patch.isPublic !== undefined ? { isPublic: patch.isPublic } : {}),
         ...(patch.highlights !== undefined ? { highlights: patch.highlights } : {}),
       },
       expectedVersion,

--- a/api/src/shared/blobs.test.ts
+++ b/api/src/shared/blobs.test.ts
@@ -580,4 +580,33 @@ describe('normalizeBlobDocument legacy isPublic strip (1.3.0)', () => {
     // After the write, the stored doc no longer has isPublic.
     expect((fake.items[0] as unknown as Record<string, unknown>).isPublic).toBeUndefined();
   });
+
+  it('uses an own-property check so a hypothetical prototype-polluted `Object.prototype.isPublic` cannot trigger a false-positive strip + telemetry', async () => {
+    // Defense against an upstream prototype-pollution gadget (a defective
+    // dep that sets Object.prototype.isPublic via __proto__-injection).
+    // `'isPublic' in doc` would walk the prototype chain and trigger a
+    // strip + telemetry emit on every read. The own-property guard
+    // sidesteps that. Test reproduces the failure mode by setting the
+    // pollution explicitly. Restore Object.prototype in a finally so
+    // sibling tests don't see it.
+    const a = await createBlob('owner-1', { content: '{"a":1}' });
+    trackEventSpy.mockClear();
+    Object.defineProperty(Object.prototype, 'isPublic', {
+      value: true,
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
+    try {
+      const found = await findBlobByIdOrSlug(a.id);
+      expect(found).not.toBeNull();
+      // Importantly: no strip telemetry, because the field is NOT on the
+      // doc itself even though `in` would have reported it as present.
+      expect(trackEventSpy).not.toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'blob.legacy.isPublic.stripped' }),
+      );
+    } finally {
+      delete (Object.prototype as Record<string, unknown>)['isPublic'];
+    }
+  });
 });

--- a/api/src/shared/blobs.test.ts
+++ b/api/src/shared/blobs.test.ts
@@ -2,6 +2,7 @@ import type { TelemetryClient } from 'applicationinsights';
 import { HIGHLIGHT_PATH_FIXTURES } from '../../../src/testing/fixtures/highlight-paths.fixture';
 import {
   __resetBlobsContainerForTesting,
+  __resetIsPublicStripLoggedIdsForTesting,
   assertHighlightPath,
   assertHighlights,
   BlobValidationError,
@@ -124,6 +125,7 @@ let trackEventSpy: jest.Mock;
 beforeEach(() => {
   fake = makeFakeContainer();
   __resetBlobsContainerForTesting();
+  __resetIsPublicStripLoggedIdsForTesting();
   // Issue #71 B3: createBlob now emits `slug.collisions.exhausted` on
   // the SlugGenerationError throw path. Install the telemetry seam for
   // every test in this file so the new trackEvent call routes through
@@ -207,7 +209,6 @@ describe('createBlob', () => {
     expect(doc.slug).toMatch(/^[A-Za-z0-9]{6}$/);
     expect(doc.content).toBe('{"a":1}');
     expect(doc.ownerId).toBe('owner-1');
-    expect(doc.isPublic).toBe(false);
     expect(doc.title).toBeUndefined();
     expect(doc.version).toBe(1);
     expect(doc.createdAt).toBe(doc.updatedAt);
@@ -222,13 +223,6 @@ describe('createBlob', () => {
   it('drops empty-string titles to undefined', async () => {
     const doc = await createBlob('owner-1', { content: '[]', title: '   ' });
     expect(doc.title).toBeUndefined();
-  });
-
-  it('honors isPublic when supplied, defaulting to false', async () => {
-    const a = await createBlob('owner-1', { content: '[]' });
-    const b = await createBlob('owner-1', { content: '[]', isPublic: true });
-    expect(a.isPublic).toBe(false);
-    expect(b.isPublic).toBe(true);
   });
 
   it('stores highlights supplied on create', async () => {
@@ -366,11 +360,10 @@ describe('updateBlob', () => {
     );
   });
 
-  it('updates title and isPublic independently', async () => {
+  it('updates title independently of content', async () => {
     const orig = await seed();
-    const updated = await updateBlob(orig, { title: 'new', isPublic: true }, orig.version);
+    const updated = await updateBlob(orig, { title: 'new' }, orig.version);
     expect(updated.title).toBe('new');
-    expect(updated.isPublic).toBe(true);
     expect(updated.content).toBe(orig.content);
   });
 
@@ -411,10 +404,18 @@ describe('updateBlob', () => {
 
   it('ignores undefined patch fields', async () => {
     const orig = await seed();
-    const updated = await updateBlob(orig, {}, orig.version);
+    const updated = await updateBlob(orig, { content: orig.content }, orig.version);
     expect(updated.content).toBe(orig.content);
     expect(updated.title).toBe(orig.title);
-    expect(updated.isPublic).toBe(orig.isPublic);
+  });
+
+  it('empty patch is a no-op: returns existing doc without bumping version', async () => {
+    const orig = await seed();
+    const updated = await updateBlob(orig, {}, orig.version);
+    expect(updated.version).toBe(orig.version);
+    expect(updated.updatedAt).toBe(orig.updatedAt);
+    expect(updated.content).toBe(orig.content);
+    expect(updated.title).toBe(orig.title);
   });
 
   it('rejects stale expected versions before replacing', async () => {
@@ -504,5 +505,79 @@ describe('listBlobsByOwner', () => {
   it('returns an empty list when given an empty ownerId', async () => {
     const list = await listBlobsByOwner('');
     expect(list).toEqual([]);
+  });
+});
+
+describe('normalizeBlobDocument legacy isPublic strip (1.1.0)', () => {
+  // Stored docs from the v1.0.x era may still carry an `isPublic: boolean`
+  // field that v1.1.0 deliberately removed. `normalizeBlobDocument` (the
+  // single funnel for every read path) drops it on the way out so it never
+  // reaches the wire, and emits one `blob.legacy.isPublic.stripped`
+  // telemetry event per blob id per process to give the
+  // `followup-blob-ispublic-strip` cleanup a measurable exit signal.
+  // See DESIGN_SPEC.md §Schema evolution and plan.md.
+
+  it('strips isPublic from the response of findBlobByIdOrSlug', async () => {
+    const legacy = await createBlob('owner-1', { content: '{"x":1}' });
+    fake.items[0] = { ...legacy, isPublic: true } as unknown as BlobDocument;
+
+    const found = await findBlobByIdOrSlug(legacy.id);
+    expect(found).not.toBeNull();
+    expect((found as unknown as Record<string, unknown>).isPublic).toBeUndefined();
+  });
+
+  it('strips isPublic from every entry returned by listBlobsByOwner', async () => {
+    const a = await createBlob('owner-1', { content: '{"a":1}' });
+    const b = await createBlob('owner-1', { content: '{"b":2}' });
+    fake.items[0] = { ...a, isPublic: true } as unknown as BlobDocument;
+    fake.items[1] = { ...b, isPublic: false } as unknown as BlobDocument;
+
+    const list = await listBlobsByOwner('owner-1');
+    expect(list).toHaveLength(2);
+    for (const item of list) {
+      expect((item as unknown as Record<string, unknown>).isPublic).toBeUndefined();
+    }
+  });
+
+  it('emits blob.legacy.isPublic.stripped exactly once per blob id per process', async () => {
+    const a = await createBlob('owner-1', { content: '{"a":1}' });
+    fake.items[0] = { ...a, isPublic: true } as unknown as BlobDocument;
+
+    trackEventSpy.mockClear();
+    await findBlobByIdOrSlug(a.id);
+    await findBlobByIdOrSlug(a.id);
+    await findBlobByIdOrSlug(a.id);
+
+    const stripEvents = trackEventSpy.mock.calls.filter(
+      ([call]) => (call as { name?: string }).name === 'blob.legacy.isPublic.stripped',
+    );
+    expect(stripEvents).toHaveLength(1);
+    expect(stripEvents[0]?.[0]).toEqual({
+      name: 'blob.legacy.isPublic.stripped',
+      properties: undefined,
+      measurements: undefined,
+    });
+  });
+
+  it('does NOT emit the signal for docs that never had isPublic', async () => {
+    const a = await createBlob('owner-1', { content: '{"a":1}' });
+
+    trackEventSpy.mockClear();
+    await findBlobByIdOrSlug(a.id);
+
+    expect(trackEventSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'blob.legacy.isPublic.stripped' }),
+    );
+  });
+
+  it('writes back the stripped doc on next update (self-healing)', async () => {
+    const created = await createBlob('owner-1', { content: '{"x":1}' });
+    fake.items[0] = { ...created, isPublic: true } as unknown as BlobDocument;
+
+    const found = await findBlobByIdOrSlug(created.id);
+    await updateBlob(found!, { title: 'updated' }, 1);
+
+    // After the write, the stored doc no longer has isPublic.
+    expect((fake.items[0] as unknown as Record<string, unknown>).isPublic).toBeUndefined();
   });
 });

--- a/api/src/shared/blobs.test.ts
+++ b/api/src/shared/blobs.test.ts
@@ -508,9 +508,9 @@ describe('listBlobsByOwner', () => {
   });
 });
 
-describe('normalizeBlobDocument legacy isPublic strip (1.1.0)', () => {
+describe('normalizeBlobDocument legacy isPublic strip (1.3.0)', () => {
   // Stored docs from the v1.0.x era may still carry an `isPublic: boolean`
-  // field that v1.1.0 deliberately removed. `normalizeBlobDocument` (the
+  // field that v1.3.0 deliberately removed. `normalizeBlobDocument` (the
   // single funnel for every read path) drops it on the way out so it never
   // reaches the wire, and emits one `blob.legacy.isPublic.stripped`
   // telemetry event per blob id per process to give the

--- a/api/src/shared/blobs.ts
+++ b/api/src/shared/blobs.ts
@@ -175,13 +175,25 @@ function normalizeVersion(value: unknown): number {
  * Insights across enough deploys"). The id itself is held in memory only
  * and never crosses the wire - backend telemetry has no PII redaction
  * (AGENTS.md §4 Telemetry), so the emitted event carries no properties.
+ *
+ * The Set is capped at `MAX_STRIP_LOGGED_IDS` entries so a long-lived
+ * Functions instance cannot accumulate unbounded memory if the legacy
+ * population is large or slow to drain. Once the cap is reached, further
+ * strips no longer log -- but at that point the cap itself proves we
+ * still have a non-zero legacy population (10k unique ids is way more
+ * than enough signal for the cleanup decision), so the dropped emissions
+ * lose no useful information.
  */
+const MAX_STRIP_LOGGED_IDS = 10_000;
 const stripLoggedIds = new Set<string>();
 
 function normalizeBlobDocument(doc: BlobDocument & { isPublic?: unknown }): BlobDocument {
   const version = normalizeVersion(doc.version);
-  if ('isPublic' in doc) {
-    if (doc.id && !stripLoggedIds.has(doc.id)) {
+  // `Object.prototype.hasOwnProperty.call(...)` over `'isPublic' in doc`
+  // so a hypothetical prototype-polluted `Object.prototype.isPublic`
+  // cannot trigger false-positive strips + telemetry on every read.
+  if (Object.prototype.hasOwnProperty.call(doc, 'isPublic')) {
+    if (doc.id && stripLoggedIds.size < MAX_STRIP_LOGGED_IDS && !stripLoggedIds.has(doc.id)) {
       stripLoggedIds.add(doc.id);
       trackEvent('blob.legacy.isPublic.stripped');
     }

--- a/api/src/shared/blobs.ts
+++ b/api/src/shared/blobs.ts
@@ -11,13 +11,17 @@
  *   content: string,      // raw JSON/JSONC text
  *   title?: string,
  *   ownerId: string,      // Entra oid of the owner; partition key
- *   isPublic: boolean,
  *   highlights?: BlobHighlight[],
  *   version: number,      // monotonic client-facing revision
  *   createdAt: string,    // ISO
  *   updatedAt: string     // ISO
  * }
  * ```
+ *
+ * Legacy stored docs may still carry an `isPublic: boolean` field from the
+ * v1.0.x era. `normalizeBlobDocument` strips it on read so it never reaches
+ * the wire; see DESIGN_SPEC.md -> Versioning -> Schema evolution and the
+ * `followup-blob-ispublic-strip` cleanup issue.
  *
  * GET lookups can accept either `id` or `slug`. Neither is the partition key
  * alone, so lookups are cross-partition queries. The `blobs` container is
@@ -47,7 +51,6 @@ export interface BlobDocument extends VersionedDocument {
   content: string;
   title?: string;
   ownerId: string;
-  isPublic: boolean;
   highlights?: BlobHighlight[];
   version: number;
   createdAt: string;
@@ -57,14 +60,12 @@ export interface BlobDocument extends VersionedDocument {
 export interface CreateBlobInput {
   content: unknown;
   title?: unknown;
-  isPublic?: unknown;
   highlights?: unknown;
 }
 
 export interface UpdateBlobPatch {
   content?: unknown;
   title?: unknown;
-  isPublic?: unknown;
   highlights?: unknown;
 }
 
@@ -137,6 +138,16 @@ export function __resetBlobsContainerForTesting(): void {
   cached = undefined;
 }
 
+/**
+ * Reset the per-process dedupe Set used by `normalizeBlobDocument`'s
+ * legacy-`isPublic`-strip telemetry. Test-only seam - production code never
+ * calls this. See AGENTS.md §4 "Test-only seams use the `__<verb>ForTesting`
+ * prefix".
+ */
+export function __resetIsPublicStripLoggedIdsForTesting(): void {
+  stripLoggedIds.clear();
+}
+
 const HEX_COLOR = /^#[0-9a-fA-F]{6}$/;
 const IDENTIFIER_START = /^[A-Za-z_$]$/;
 const IDENTIFIER_PART = /^[A-Za-z0-9_$]$/;
@@ -154,8 +165,31 @@ function normalizeVersion(value: unknown): number {
   return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : 1;
 }
 
-function normalizeBlobDocument(doc: BlobDocument): BlobDocument {
+/**
+ * Per-process dedupe of legacy-`isPublic`-strip telemetry emissions. The
+ * stored field carries no semantics post-1.1.0 but lingers on documents
+ * written under v1.0.x. `normalizeBlobDocument` strips it on read; we emit
+ * a `blob.legacy.isPublic.stripped` event once per unique blob id per
+ * function-instance lifetime so the `followup-blob-ispublic-strip` cleanup
+ * has a measurable exit criterion ("event count goes to zero in App
+ * Insights across enough deploys"). The id itself is held in memory only
+ * and never crosses the wire - backend telemetry has no PII redaction
+ * (AGENTS.md §4 Telemetry), so the emitted event carries no properties.
+ */
+const stripLoggedIds = new Set<string>();
+
+function normalizeBlobDocument(doc: BlobDocument & { isPublic?: unknown }): BlobDocument {
   const version = normalizeVersion(doc.version);
+  if ('isPublic' in doc) {
+    if (doc.id && !stripLoggedIds.has(doc.id)) {
+      stripLoggedIds.add(doc.id);
+      trackEvent('blob.legacy.isPublic.stripped');
+    }
+    const { isPublic: _stripped, ...rest } = doc;
+    void _stripped;
+    const stripped = rest as BlobDocument;
+    return stripped.version === version ? stripped : { ...stripped, version };
+  }
   return doc.version === version ? doc : { ...doc, version };
 }
 
@@ -410,14 +444,6 @@ function validateTitle(title: unknown): string | undefined {
   return trimmed;
 }
 
-function validateIsPublic(isPublic: unknown): boolean {
-  if (isPublic === undefined) return false;
-  if (typeof isPublic !== 'boolean') {
-    throw new BlobValidationError('isPublic must be a boolean');
-  }
-  return isPublic;
-}
-
 /**
  * Look up a blob by either its UUID `id` or its NanoID `slug`. Cross-partition
  * query - returns null if not found.
@@ -454,7 +480,6 @@ export async function createBlob(ownerId: string, input: CreateBlobInput): Promi
   }
   const content = validateContent(input.content);
   const title = validateTitle(input.title);
-  const isPublic = validateIsPublic(input.isPublic);
   const highlights =
     input.highlights !== undefined ? assertHighlights(input.highlights) : undefined;
   validateBlobDocumentSize(content, highlights);
@@ -486,7 +511,6 @@ export async function createBlob(ownerId: string, input: CreateBlobInput): Promi
     content,
     ...(title !== undefined ? { title } : {}),
     ownerId,
-    isPublic,
     ...(highlights !== undefined ? { highlights } : {}),
     version: 1,
     createdAt: now,
@@ -515,6 +539,14 @@ export async function updateBlob(
     );
   }
 
+  // Empty-patch early-out: a patch that touches no recognized field is a
+  // no-op (e.g. a stale-client PUT carrying only the dropped `isPublic`).
+  // Returning unchanged avoids spurious version + `updatedAt` bumps and
+  // wasted Cosmos RUs. See plan §10 (skeptic finding #11).
+  if (patch.content === undefined && patch.title === undefined && patch.highlights === undefined) {
+    return current;
+  }
+
   const result = await replaceWithIfMatch<BlobDocument>(
     getBlobsContainer(),
     current.ownerId,
@@ -530,9 +562,6 @@ export async function updateBlob(
         } else {
           draft.title = title;
         }
-      }
-      if (patch.isPublic !== undefined) {
-        draft.isPublic = validateIsPublic(patch.isPublic);
       }
       if (patch.highlights !== undefined) {
         draft.highlights = assertHighlights(patch.highlights);

--- a/api/src/shared/blobs.ts
+++ b/api/src/shared/blobs.ts
@@ -167,7 +167,7 @@ function normalizeVersion(value: unknown): number {
 
 /**
  * Per-process dedupe of legacy-`isPublic`-strip telemetry emissions. The
- * stored field carries no semantics post-1.1.0 but lingers on documents
+ * stored field carries no semantics post-1.3.0 but lingers on documents
  * written under v1.0.x. `normalizeBlobDocument` strips it on read; we emit
  * a `blob.legacy.isPublic.stripped` event once per unique blob id per
  * function-instance lifetime so the `followup-blob-ispublic-strip` cleanup

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jotjson",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jotjson",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "dependencies": {
         "@angular/animations": "^21.2.14",
         "@angular/cdk": "^21.2.11",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jotjson",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "JotJSON - input, store, and display JSON (Angular SPA).",
   "private": true,
   "repository": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -2,5 +2,6 @@ User-agent: *
 Allow: /
 Disallow: /api/
 Disallow: /404
+Disallow: /s/
 
 Sitemap: https://jotjson.com/sitemap.xml

--- a/scripts/check-prerender.mjs
+++ b/scripts/check-prerender.mjs
@@ -131,6 +131,14 @@ check(
   'robots.txt missing sitemap reference',
   /Sitemap:\s*https:\/\/jotjson\.com\/sitemap\.xml/i.test(robotsTxt),
 );
+// 1.1.0: all blob share URLs are unlisted. `Disallow: /s/` is the
+// pre-fetch crawler signal; pair with the `/s/*` X-Robots-Tag header
+// route in staticwebapp.config.json (asserted by check-swa-config.mjs)
+// and the client-side always-on `<meta name="robots" content="noindex">`
+// in HomeComponent for full layered defense. Asserting this here so a
+// future robots.txt edit can't silently regress the strongest
+// forward-looking crawler signal.
+check('robots.txt missing Disallow: /s/ rule', /Disallow:\s*\/s\//i.test(robotsTxt));
 check('sitemap.xml missing root URL', sitemapXml.includes('https://jotjson.com/'));
 check('og.png not deployed to dist', existsSync(ogPng));
 

--- a/scripts/check-prerender.mjs
+++ b/scripts/check-prerender.mjs
@@ -131,7 +131,7 @@ check(
   'robots.txt missing sitemap reference',
   /Sitemap:\s*https:\/\/jotjson\.com\/sitemap\.xml/i.test(robotsTxt),
 );
-// 1.1.0: all blob share URLs are unlisted. `Disallow: /s/` is the
+// 1.3.0: all blob share URLs are unlisted. `Disallow: /s/` is the
 // pre-fetch crawler signal; pair with the `/s/*` X-Robots-Tag header
 // route in staticwebapp.config.json (asserted by check-swa-config.mjs)
 // and the client-side always-on `<meta name="robots" content="noindex">`

--- a/scripts/check-swa-config.mjs
+++ b/scripts/check-swa-config.mjs
@@ -131,6 +131,19 @@ export const SHELL_CACHE_CONTROL = 'no-cache, must-revalidate';
 // Allowlist (not a regex floor) because SWA's supported Functions runtime
 // set is small and explicit. A regex like `^node:\d+$` would silently
 // accept `node:14` or `node:16` (both EOL on Azure).
+export const SHARE_ROUTE_PATTERN = '/s/*';
+export const SHARE_ROUTE_X_ROBOTS_TAG = 'noindex';
+
+// 1.1.0: per-blob crawler-defense layer B. The X-Robots-Tag header
+// ships on every `/s/*` response (which then falls through the SPA
+// navigation rewrite to `shell.html`); together with `Disallow: /s/`
+// in `public/robots.txt` (layer C, asserted by check-prerender.mjs)
+// and the always-on `<meta name="robots" content="noindex">` injected
+// by HomeComponent (layer A), this prevents `/s/:slug` URLs from
+// being indexed by any major crawler regardless of JS-execution
+// behavior. Asserting structurally here so a future SWA-config edit
+// can't silently regress the deindex defense.
+
 export const SUPPORTED_API_RUNTIMES = Object.freeze(['node:20', 'node:22']);
 
 // PWA install requires this exact MIME for `.webmanifest` files.
@@ -465,6 +478,44 @@ export function checkRoutes(config) {
   return errors;
 }
 
+export function checkShareRouteNoindex(config) {
+  const errors = [];
+  const routes = Array.isArray(config?.routes) ? config.routes : [];
+  if (routes.length === 0) {
+    // checkRoutes already reports the missing-routes case.
+    return errors;
+  }
+  const route = routes.find((entry) => entry?.route === SHARE_ROUTE_PATTERN);
+  if (!route) {
+    errors.push(
+      `routes is missing the '${SHARE_ROUTE_PATTERN}' entry. The 1.1.0 ` +
+        `crawler-defense layer relies on an 'X-Robots-Tag: ${SHARE_ROUTE_X_ROBOTS_TAG}' ` +
+        `header on every /s/:slug response. See DESIGN_SPEC.md ` +
+        `§Visibility and scripts/check-prerender.mjs (asserts the paired ` +
+        `robots.txt rule).`,
+    );
+    return errors;
+  }
+  const xRobotsTag = route?.headers?.['X-Robots-Tag'];
+  if (xRobotsTag !== SHARE_ROUTE_X_ROBOTS_TAG) {
+    errors.push(
+      `routes['${SHARE_ROUTE_PATTERN}'].headers['X-Robots-Tag'] must be ` +
+        `'${SHARE_ROUTE_X_ROBOTS_TAG}' (got: ${JSON.stringify(xRobotsTag)}). ` +
+        `Drift re-opens the JS-less-crawler indexing gap that motivated the ` +
+        `1.1.0 isPublic-removal change.`,
+    );
+  }
+  if (route.rewrite !== undefined) {
+    errors.push(
+      `routes['${SHARE_ROUTE_PATTERN}'] must NOT specify a 'rewrite'. ` +
+        `Omitting rewrite lets navigationFallback take effect (which serves ` +
+        `/shell.html) while still attaching the header to the original /s/* ` +
+        `URL. An explicit rewrite here would short-circuit SPA routing.`,
+    );
+  }
+  return errors;
+}
+
 export function checkPlatform(config) {
   const errors = [];
   const apiRuntime = config?.platform?.apiRuntime;
@@ -536,6 +587,7 @@ export function checkConfig(config) {
     ...checkGlobalHeaders(config),
     ...checkNavigationFallback(config),
     ...checkRoutes(config),
+    ...checkShareRouteNoindex(config),
     ...checkImmutableAssets(config),
     ...checkPlatform(config),
     ...checkMimeTypes(config),

--- a/scripts/check-swa-config.mjs
+++ b/scripts/check-swa-config.mjs
@@ -134,7 +134,7 @@ export const SHELL_CACHE_CONTROL = 'no-cache, must-revalidate';
 export const SHARE_ROUTE_PATTERN = '/s/*';
 export const SHARE_ROUTE_X_ROBOTS_TAG = 'noindex';
 
-// 1.1.0: per-blob crawler-defense layer B. The X-Robots-Tag header
+// 1.3.0: per-blob crawler-defense layer B. The X-Robots-Tag header
 // ships on every `/s/*` response (which then falls through the SPA
 // navigation rewrite to `shell.html`); together with `Disallow: /s/`
 // in `public/robots.txt` (layer C, asserted by check-prerender.mjs)
@@ -488,7 +488,7 @@ export function checkShareRouteNoindex(config) {
   const route = routes.find((entry) => entry?.route === SHARE_ROUTE_PATTERN);
   if (!route) {
     errors.push(
-      `routes is missing the '${SHARE_ROUTE_PATTERN}' entry. The 1.1.0 ` +
+      `routes is missing the '${SHARE_ROUTE_PATTERN}' entry. The 1.3.0 ` +
         `crawler-defense layer relies on an 'X-Robots-Tag: ${SHARE_ROUTE_X_ROBOTS_TAG}' ` +
         `header on every /s/:slug response. See DESIGN_SPEC.md ` +
         `§Visibility and scripts/check-prerender.mjs (asserts the paired ` +
@@ -502,7 +502,7 @@ export function checkShareRouteNoindex(config) {
       `routes['${SHARE_ROUTE_PATTERN}'].headers['X-Robots-Tag'] must be ` +
         `'${SHARE_ROUTE_X_ROBOTS_TAG}' (got: ${JSON.stringify(xRobotsTag)}). ` +
         `Drift re-opens the JS-less-crawler indexing gap that motivated the ` +
-        `1.1.0 isPublic-removal change.`,
+        `1.3.0 isPublic-removal change.`,
     );
   }
   if (route.rewrite !== undefined) {

--- a/scripts/check-swa-config.test.mjs
+++ b/scripts/check-swa-config.test.mjs
@@ -436,12 +436,12 @@ test('mimeTypes key without leading dot fails (proves dot-prefix is intentional)
   assertHasErrorMatching(checkMimeTypes(config), /\.webmanifest/);
 });
 
-// --- Negative: /s/* X-Robots-Tag header (1.1.0 crawler-defense layer B) ---
+// --- Negative: /s/* X-Robots-Tag header (1.3.0 crawler-defense layer B) ---
 // The header pairs with `Disallow: /s/` in public/robots.txt (asserted
 // by scripts/check-prerender.mjs) and the always-on client-side
 // `<meta name="robots" content="noindex">` injected by HomeComponent.
 // Drift here re-opens the JS-less-crawler indexing gap that motivated
-// the 1.1.0 isPublic-removal change.
+// the 1.3.0 isPublic-removal change.
 
 test('checkShareRouteNoindex passes on the actual staticwebapp.config.json', () => {
   assert.deepEqual(checkShareRouteNoindex(readConfig()), []);

--- a/scripts/check-swa-config.test.mjs
+++ b/scripts/check-swa-config.test.mjs
@@ -23,10 +23,13 @@ import {
   checkNavigationFallback,
   checkPlatform,
   checkRoutes,
+  checkShareRouteNoindex,
   expandBraceGlob,
   getExcludedExtensions,
   readConfig,
   routeMatchesPath,
+  SHARE_ROUTE_PATTERN,
+  SHARE_ROUTE_X_ROBOTS_TAG,
   SHELL_CACHE_CONTROL,
   SHELL_PATHS,
   SUPPORTED_API_RUNTIMES,
@@ -431,6 +434,52 @@ test('mimeTypes key without leading dot fails (proves dot-prefix is intentional)
   config.mimeTypes['webmanifest'] = config.mimeTypes['.webmanifest'];
   delete config.mimeTypes['.webmanifest'];
   assertHasErrorMatching(checkMimeTypes(config), /\.webmanifest/);
+});
+
+// --- Negative: /s/* X-Robots-Tag header (1.1.0 crawler-defense layer B) ---
+// The header pairs with `Disallow: /s/` in public/robots.txt (asserted
+// by scripts/check-prerender.mjs) and the always-on client-side
+// `<meta name="robots" content="noindex">` injected by HomeComponent.
+// Drift here re-opens the JS-less-crawler indexing gap that motivated
+// the 1.1.0 isPublic-removal change.
+
+test('checkShareRouteNoindex passes on the actual staticwebapp.config.json', () => {
+  assert.deepEqual(checkShareRouteNoindex(readConfig()), []);
+});
+
+test('/s/* route removed fails', () => {
+  const config = cloneConfig();
+  config.routes = config.routes.filter((entry) => entry.route !== SHARE_ROUTE_PATTERN);
+  assertHasErrorMatching(
+    checkShareRouteNoindex(config),
+    new RegExp(SHARE_ROUTE_PATTERN.replace(/[*/]/g, '\\$&')),
+  );
+});
+
+test('/s/* X-Robots-Tag header value drift fails', () => {
+  const config = cloneConfig();
+  const route = config.routes.find((entry) => entry.route === SHARE_ROUTE_PATTERN);
+  assert.ok(route, `expected base config to contain a '${SHARE_ROUTE_PATTERN}' route`);
+  route.headers['X-Robots-Tag'] = 'all';
+  assertHasErrorMatching(checkShareRouteNoindex(config), /X-Robots-Tag/);
+});
+
+test('/s/* X-Robots-Tag header removed fails', () => {
+  const config = cloneConfig();
+  const route = config.routes.find((entry) => entry.route === SHARE_ROUTE_PATTERN);
+  delete route.headers['X-Robots-Tag'];
+  assertHasErrorMatching(checkShareRouteNoindex(config), /X-Robots-Tag/);
+});
+
+test('/s/* route with explicit rewrite fails (breaks SPA navigation fallback)', () => {
+  const config = cloneConfig();
+  const route = config.routes.find((entry) => entry.route === SHARE_ROUTE_PATTERN);
+  route.rewrite = '/shell.html';
+  assertHasErrorMatching(checkShareRouteNoindex(config), /rewrite/);
+});
+
+test('SHARE_ROUTE_X_ROBOTS_TAG export is the canonical noindex value', () => {
+  assert.equal(SHARE_ROUTE_X_ROBOTS_TAG, 'noindex');
 });
 
 // --- checkConfig aggregator -----------------------------------------------

--- a/scripts/check-swa-config.test.mjs
+++ b/scripts/check-swa-config.test.mjs
@@ -450,10 +450,11 @@ test('checkShareRouteNoindex passes on the actual staticwebapp.config.json', () 
 test('/s/* route removed fails', () => {
   const config = cloneConfig();
   config.routes = config.routes.filter((entry) => entry.route !== SHARE_ROUTE_PATTERN);
-  assertHasErrorMatching(
-    checkShareRouteNoindex(config),
-    new RegExp(SHARE_ROUTE_PATTERN.replace(/[*/]/g, '\\$&')),
-  );
+  // Pass the literal pattern string directly so assertHasErrorMatching
+  // does a substring search; avoids the manual regex-escape utility
+  // CodeQL flagged for incomplete escape coverage on the prior
+  // `new RegExp(...replace(/[*/]/g, ...))` form.
+  assertHasErrorMatching(checkShareRouteNoindex(config), SHARE_ROUTE_PATTERN);
 });
 
 test('/s/* X-Robots-Tag header value drift fails', () => {

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -15,7 +15,7 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
  * client with the actual auth state.
  *
  * `/s/:slug` is parameterized over an unbounded slug space and is
- * not prerendered. Crawler defense for `/s/:slug` lands in v1.1.0 via
+ * not prerendered. Crawler defense for `/s/:slug` lands in v1.3.0 via
  * three layers (client-side `<meta name="robots" content="noindex">`,
  * `X-Robots-Tag: noindex` HTTP header from `staticwebapp.config.json`,
  * and `Disallow: /s/` in `robots.txt`); per-blob Open Graph is

--- a/src/app/app.routes.server.ts
+++ b/src/app/app.routes.server.ts
@@ -15,8 +15,11 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
  * client with the actual auth state.
  *
  * `/s/:slug` is parameterized over an unbounded slug space and is
- * not prerendered. Its OG/noindex story is tracked as a post-v1
- * follow-up (see DESIGN_SPEC.md SEO section).
+ * not prerendered. Crawler defense for `/s/:slug` lands in v1.1.0 via
+ * three layers (client-side `<meta name="robots" content="noindex">`,
+ * `X-Robots-Tag: noindex` HTTP header from `staticwebapp.config.json`,
+ * and `Disallow: /s/` in `robots.txt`); per-blob Open Graph is
+ * intentionally not emitted (DESIGN_SPEC.md SEO section).
  */
 export const serverRoutes: ServerRoute[] = [
   { path: '', renderMode: RenderMode.Prerender },

--- a/src/app/core/api/blob.service.test.ts
+++ b/src/app/core/api/blob.service.test.ts
@@ -29,7 +29,6 @@ describe('BlobService', () => {
       createdAt: '2026-01-01T00:00:00.000Z',
       updatedAt: '2026-01-01T00:00:00.000Z',
       ownerId: 'owner-1',
-      isPublic: false,
       version: 1,
       ...overrides,
     };
@@ -62,37 +61,34 @@ describe('BlobService', () => {
   });
 
   it('POSTs the correct payload shape to /api/blobs on create', () => {
-    service.create('{"a":1}', 'My Blob', true).subscribe();
+    service.create('{"a":1}', 'My Blob').subscribe();
     const req = httpMock.expectOne(base);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({
       content: '{"a":1}',
       title: 'My Blob',
-      isPublic: true,
     });
-    req.flush(makeBlob({ isPublic: true }));
+    req.flush(makeBlob());
   });
 
-  it('defaults isPublic to false and omits title when not provided on create', () => {
+  it('omits title when not provided on create', () => {
     service.create('{}').subscribe();
     const req = httpMock.expectOne(base);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({
       content: '{}',
       title: undefined,
-      isPublic: false,
     });
     req.flush(makeBlob({ content: '{}' }));
   });
 
   it('POSTs highlights on create when provided', () => {
-    service.create('{}', undefined, false, [highlight]).subscribe();
+    service.create('{}', undefined, [highlight]).subscribe();
     const req = httpMock.expectOne(base);
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({
       content: '{}',
       title: undefined,
-      isPublic: false,
       highlights: [highlight],
     });
     req.flush(makeBlob({ content: '{}', highlights: [highlight] }));
@@ -133,11 +129,10 @@ describe('BlobService', () => {
   for (const testCase of [
     { name: 'content', patch: { content: '{"x":2}' } },
     { name: 'title', patch: { title: 'Renamed' } },
-    { name: 'isPublic', patch: { isPublic: true } },
     { name: 'highlights', patch: { highlights: [highlight] } },
   ] satisfies Array<{
     name: string;
-    patch: Partial<Pick<JsonBlob, 'content' | 'title' | 'isPublic' | 'highlights'>>;
+    patch: Partial<Pick<JsonBlob, 'content' | 'title' | 'highlights'>>;
   }>) {
     it(`includes If-Match for ${testCase.name} updates`, () => {
       service.get(id).subscribe();

--- a/src/app/core/api/blob.service.test.ts
+++ b/src/app/core/api/blob.service.test.ts
@@ -77,7 +77,6 @@ describe('BlobService', () => {
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({
       content: '{}',
-      title: undefined,
     });
     req.flush(makeBlob({ content: '{}' }));
   });
@@ -88,7 +87,6 @@ describe('BlobService', () => {
     expect(req.request.method).toBe('POST');
     expect(req.request.body).toEqual({
       content: '{}',
-      title: undefined,
       highlights: [highlight],
     });
     req.flush(makeBlob({ content: '{}', highlights: [highlight] }));

--- a/src/app/core/api/blob.service.ts
+++ b/src/app/core/api/blob.service.ts
@@ -200,13 +200,12 @@ export class BlobService {
   create(
     content: string,
     title?: string,
-    isPublic = false,
     highlights?: readonly BlobHighlight[],
   ): Observable<CreateBlobResponse> {
     const body =
       highlights === undefined
-        ? { content, title, isPublic }
-        : { content, title, isPublic, highlights: [...highlights] };
+        ? { content, title }
+        : { content, title, highlights: [...highlights] };
     return this.http.post<CreateBlobResponse>(this.base, body).pipe(
       tap((created) => {
         const { autoDeleted: _autoDeleted, ...blob } = created;
@@ -218,7 +217,7 @@ export class BlobService {
 
   update(
     id: string,
-    patch: Partial<Pick<JsonBlob, 'content' | 'title' | 'isPublic' | 'highlights'>>,
+    patch: Partial<Pick<JsonBlob, 'content' | 'title' | 'highlights'>>,
   ): Observable<JsonBlob> {
     const version = this.versionsByKey.get(id) ?? 1;
     const headers = new HttpHeaders({ 'If-Match': `"${version}"` });

--- a/src/app/core/api/blob.service.ts
+++ b/src/app/core/api/blob.service.ts
@@ -202,10 +202,11 @@ export class BlobService {
     title?: string,
     highlights?: readonly BlobHighlight[],
   ): Observable<CreateBlobResponse> {
-    const body =
-      highlights === undefined
-        ? { content, title }
-        : { content, title, highlights: [...highlights] };
+    const body = {
+      content,
+      ...(title !== undefined ? { title } : {}),
+      ...(highlights !== undefined ? { highlights: [...highlights] } : {}),
+    };
     return this.http.post<CreateBlobResponse>(this.base, body).pipe(
       tap((created) => {
         const { autoDeleted: _autoDeleted, ...blob } = created;

--- a/src/app/core/api/models.ts
+++ b/src/app/core/api/models.ts
@@ -12,7 +12,6 @@ export interface JsonBlob {
   createdAt: string;
   updatedAt: string;
   ownerId: string;
-  isPublic: boolean;
   highlights?: BlobHighlight[];
   version: number;
 }

--- a/src/app/core/seo/seo.service.test.ts
+++ b/src/app/core/seo/seo.service.test.ts
@@ -1,21 +1,6 @@
 import { TestBed } from '@angular/core/testing';
 import { Meta } from '@angular/platform-browser';
-import type { JsonBlob } from '../api/models';
 import { SeoService } from './seo.service';
-
-function blob(overrides: Partial<JsonBlob> = {}): JsonBlob {
-  return {
-    id: 'b1',
-    slug: 'abc123',
-    content: '{"a":1}',
-    ownerId: 'u1',
-    isPublic: true,
-    version: 1,
-    createdAt: '2024-01-01T00:00:00Z',
-    updatedAt: '2024-01-01T00:00:00Z',
-    ...overrides,
-  };
-}
 
 describe('SeoService', () => {
   let svc: SeoService;
@@ -28,51 +13,7 @@ describe('SeoService', () => {
   });
 
   afterEach(() => {
-    for (const sel of [
-      'property="og:title"',
-      'property="og:description"',
-      'property="og:type"',
-      'property="og:url"',
-      'property="og:site_name"',
-      'name="twitter:card"',
-      'name="robots"',
-    ]) {
-      meta.removeTag(sel);
-    }
-  });
-
-  describe('setOpenGraphForBlob', () => {
-    it('emits og:* and twitter:card tags with title', () => {
-      svc.setOpenGraphForBlob(blob({ title: 'My config' }));
-      expect(meta.getTag('property="og:title"')?.content).toBe('My config');
-      expect(meta.getTag('property="og:description"')?.content).toBe(
-        'My config - JSON shared on JotJSON',
-      );
-      expect(meta.getTag('property="og:type"')?.content).toBe('website');
-      expect(meta.getTag('property="og:site_name"')?.content).toBe('JotJSON');
-      expect(meta.getTag('property="og:url"')?.content).toContain('http');
-      expect(meta.getTag('name="twitter:card"')?.content).toBe('summary');
-    });
-
-    it('falls back to "Untitled JSON" when title is missing/blank', () => {
-      svc.setOpenGraphForBlob(blob({ title: '   ' }));
-      expect(meta.getTag('property="og:title"')?.content).toBe('Untitled JSON');
-      expect(meta.getTag('property="og:description"')?.content).toBe('JSON shared on JotJSON');
-    });
-
-    it('is idempotent - repeat calls update rather than duplicate', () => {
-      svc.setOpenGraphForBlob(blob({ title: 'One' }));
-      svc.setOpenGraphForBlob(blob({ title: 'Two' }));
-      const all = meta.getTags('property="og:title"');
-      expect(all.length).toBe(1);
-      expect(all[0].content).toBe('Two');
-    });
-
-    it('clears any prior noindex when switching to a public blob', () => {
-      svc.setNoindex(true);
-      svc.setOpenGraphForBlob(blob({ title: 'Public' }));
-      expect(meta.getTag('name="robots"')).toBeNull();
-    });
+    meta.removeTag('name="robots"');
   });
 
   describe('setNoindex', () => {
@@ -92,18 +33,19 @@ describe('SeoService', () => {
       svc.setNoindex(true);
       expect(meta.getTags('name="robots"').length).toBe(1);
     });
-  });
 
-  describe('clearBlobTags', () => {
-    it('removes every og:*, twitter:card, and robots tag', () => {
-      svc.setOpenGraphForBlob(blob({ title: 'Cleanup' }));
-      svc.setNoindex(true);
-      svc.clearBlobTags();
-      expect(meta.getTag('property="og:title"')).toBeNull();
-      expect(meta.getTag('property="og:description"')).toBeNull();
-      expect(meta.getTag('property="og:url"')).toBeNull();
-      expect(meta.getTag('name="twitter:card"')).toBeNull();
+    it('is idempotent on repeat off() calls', () => {
+      svc.setNoindex(false);
+      svc.setNoindex(false);
       expect(meta.getTag('name="robots"')).toBeNull();
+    });
+
+    it('toggles cleanly between on and off', () => {
+      svc.setNoindex(true);
+      svc.setNoindex(false);
+      svc.setNoindex(true);
+      expect(meta.getTag('name="robots"')?.content).toBe('noindex');
+      expect(meta.getTags('name="robots"').length).toBe(1);
     });
   });
 });

--- a/src/app/core/seo/seo.service.ts
+++ b/src/app/core/seo/seo.service.ts
@@ -1,78 +1,32 @@
 import { Injectable, inject } from '@angular/core';
 import { Meta } from '@angular/platform-browser';
-import type { JsonBlob } from '../api/models';
 
 /**
- * Centralizes `<meta>` tag management for per-route SEO / social concerns.
+ * Centralizes the `<meta name="robots">` noindex toggle.
  *
- * Note: JotJSON is a client-rendered SPA, so tags set here are only honored by
- * crawlers that execute JavaScript (e.g. LinkedIn, Slack unfurl partially).
- * Universal support requires pre-rendering, which is tracked as milestone M7h.
+ * Post-1.1.0 surface: only the robots noindex toggle. Per-blob Open Graph
+ * and Twitter tags were retired alongside the `isPublic` blob visibility
+ * flag - all blobs are unlisted and every `/s/:slug` page emits
+ * `<meta name="robots" content="noindex">` always-on. The static homepage
+ * OG defaults from `src/index.html` survive into the prerendered
+ * `index.html` without any client-side per-blob OG emission.
  */
 @Injectable({ providedIn: 'root' })
 export class SeoService {
   private readonly meta = inject(Meta);
 
-  private static readonly OG_TAGS = [
-    'og:title',
-    'og:description',
-    'og:type',
-    'og:url',
-    'og:site_name',
-  ] as const;
-
-  private static readonly TWITTER_TAGS = ['twitter:card'] as const;
-
-  /** Set Open Graph tags for a publicly-shared blob. Removes any prior noindex. */
-  setOpenGraphForBlob(blob: JsonBlob): void {
-    this.setNoindex(false);
-    const title = (blob.title ?? '').trim();
-    const displayTitle = title.length > 0 ? title : 'Untitled JSON';
-    const description =
-      title.length > 0 ? `${title} - JSON shared on JotJSON` : 'JSON shared on JotJSON';
-
-    this.upsert('og:title', displayTitle);
-    this.upsert('og:description', description);
-    this.upsert('og:type', 'website');
-    this.upsert('og:url', this.currentUrl());
-    this.upsert('og:site_name', 'JotJSON');
-    this.upsert('twitter:card', 'summary', { nameAttr: true });
-  }
-
-  /** Toggle the robots=noindex tag. */
+  /** Toggle the `robots=noindex` meta tag. */
   setNoindex(on: boolean): void {
     if (on) {
-      this.upsert('robots', 'noindex', { nameAttr: true });
+      const selector = 'name="robots"';
+      const definition = { name: 'robots', content: 'noindex' };
+      if (this.meta.getTag(selector)) {
+        this.meta.updateTag(definition, selector);
+      } else {
+        this.meta.addTag(definition);
+      }
     } else {
       this.meta.removeTag('name="robots"');
     }
-  }
-
-  /** Remove every per-blob tag we might have emitted. Safe to call repeatedly. */
-  clearBlobTags(): void {
-    for (const property of SeoService.OG_TAGS) {
-      this.meta.removeTag(`property="${property}"`);
-    }
-    for (const name of SeoService.TWITTER_TAGS) {
-      this.meta.removeTag(`name="${name}"`);
-    }
-    this.setNoindex(false);
-  }
-
-  private upsert(key: string, content: string, opts: { nameAttr?: boolean } = {}): void {
-    const selector = opts.nameAttr ? `name="${key}"` : `property="${key}"`;
-    const definition: Record<string, string> = opts.nameAttr
-      ? { name: key, content }
-      : { property: key, content };
-    if (this.meta.getTag(selector)) {
-      this.meta.updateTag(definition, selector);
-    } else {
-      this.meta.addTag(definition);
-    }
-  }
-
-  private currentUrl(): string {
-    if (typeof window === 'undefined') return 'https://jotjson.com/';
-    return window.location.href;
   }
 }

--- a/src/app/core/seo/seo.service.ts
+++ b/src/app/core/seo/seo.service.ts
@@ -4,7 +4,7 @@ import { Meta } from '@angular/platform-browser';
 /**
  * Centralizes the `<meta name="robots">` noindex toggle.
  *
- * Post-1.1.0 surface: only the robots noindex toggle. Per-blob Open Graph
+ * Post-1.3.0 surface: only the robots noindex toggle. Per-blob Open Graph
  * and Twitter tags were retired alongside the `isPublic` blob visibility
  * flag - all blobs are unlisted and every `/s/:slug` page emits
  * `<meta name="robots" content="noindex">` always-on. The static homepage

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -898,7 +898,7 @@ export const TELEMETRY_MESSAGE_IDS = [
    *           (`features/home/home.component.ts`) after a successful
    *           `BlobService.create` (create branch only -- the
    *           update branch has no creation semantic).
-   * Props: none. (Pre-1.1.0 carried `{ visibility: 'public' | 'private' }`
+   * Props: none. (Pre-1.3.0 carried `{ visibility: 'public' | 'private' }`
    *   which was a constant `'private'` after the `isPublic` flag was
    *   removed; dropped to avoid a dead dimension.)
    * Measurements: { sizeBytes: number }. UTF-8 byte count of the

--- a/src/app/core/telemetry/telemetry-message-ids.ts
+++ b/src/app/core/telemetry/telemetry-message-ids.ts
@@ -893,40 +893,18 @@ export const TELEMETRY_MESSAGE_IDS = [
   'home.clipboard.coldBoot.autoPaste.undo',
 
   /**
-   * Severity: warn
-   * Fired by: `HomeComponent.onToggleVisibility`
-   *           (`features/home/home.component.ts`)
-   * Props: none
-   */
-  'share.visibility.failed',
-
-  /**
    * Kind: event
    * Fired by: `HomeComponent.onSave`
    *           (`features/home/home.component.ts`) after a successful
    *           `BlobService.create` (create branch only -- the
    *           update branch has no creation semantic).
-   * Props: { visibility: 'public' | 'private' }. Today always
-   *   `'private'` (create passes `isPublic=false`); the dimension
-   *   shape is locked now so a future public-create flow can reuse
-   *   the token without renaming.
+   * Props: none. (Pre-1.1.0 carried `{ visibility: 'public' | 'private' }`
+   *   which was a constant `'private'` after the `isPublic` flag was
+   *   removed; dropped to avoid a dead dimension.)
    * Measurements: { sizeBytes: number }. UTF-8 byte count of the
    *   saved content.
    */
   'share.created',
-
-  /**
-   * Kind: event
-   * Fired by: `HomeComponent.onToggleVisibility`
-   *           (`features/home/home.component.ts`) after a successful
-   *           `BlobService.update({ isPublic })`. Failures keep the
-   *           existing `share.visibility.failed` warn token.
-   * Props: { newVisibility: 'public' | 'private' }. The new value;
-   *   `oldVisibility` is the opposite by definition of a toggle and
-   *   is not separately logged.
-   * Measurements: none.
-   */
-  'share.visibility.changed',
 
   /**
    * Severity: warn
@@ -1175,9 +1153,6 @@ export const TELEMETRY_MESSAGE_IDS = [
    *   `clear`         -- Clear button.
    *   `save`          -- Save button (or Enter on title field).
    *   `copyShareLink` -- overflow menu "Copy share link".
-   *   `togglePublic`  -- overflow menu "Make public/private".
-   *                      The resulting visibility flip is logged
-   *                      separately as `share.visibility.changed`.
    *   `deleteBlob`    -- overflow menu "Delete".
    *   `fileChange`    -- a file was actually selected from the
    *                      picker (post-`openFile`, gives funnel

--- a/src/app/features/blobs/blobs.component.a11y.test.ts
+++ b/src/app/features/blobs/blobs.component.a11y.test.ts
@@ -36,7 +36,6 @@ describe('BlobsComponent (a11y shell landmarks)', () => {
       slug: 'slug1',
       content: '{}',
       ownerId: 'u1',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',

--- a/src/app/features/blobs/blobs.component.html
+++ b/src/app/features/blobs/blobs.component.html
@@ -48,16 +48,6 @@
               <span class="blob-slug">/s/{{ blob.slug }}</span>
               <span class="blob-dot">&middot;</span>
               <span class="blob-time">{{ relativeTime(blob.updatedAt) }}</span>
-              @if (blob.isPublic) {
-                <span class="blob-dot">&middot;</span>
-                <span
-                  class="blob-badge"
-                  i18n="@@blobs.public"
-                  matTooltip="Anyone with the link and search engines can see this blob."
-                  i18n-matTooltip="@@blobs.public.tooltip"
-                  >public</span
-                >
-              }
             </div>
           </div>
           <button

--- a/src/app/features/blobs/blobs.component.scss
+++ b/src/app/features/blobs/blobs.component.scss
@@ -101,15 +101,6 @@
   font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
 }
 
-.blob-badge {
-  font-size: 0.72rem;
-  padding: 1px 6px;
-  border-radius: 10px;
-  background: rgba(127, 127, 127, 0.18);
-  text-transform: uppercase;
-  letter-spacing: 0.03em;
-}
-
 .blob-dot {
   opacity: 0.6;
 }

--- a/src/app/features/blobs/blobs.component.test.ts
+++ b/src/app/features/blobs/blobs.component.test.ts
@@ -16,7 +16,6 @@ function blob(overrides: Partial<JsonBlob> = {}): JsonBlob {
     slug: 'slug1',
     content: '{}',
     ownerId: 'u1',
-    isPublic: false,
     version: 1,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',

--- a/src/app/features/blobs/blobs.component.ts
+++ b/src/app/features/blobs/blobs.component.ts
@@ -56,7 +56,6 @@ export class BlobsComponent implements OnInit {
   readonly isEmpty = computed(() => this.state() === 'ready' && this.blobList().length === 0);
 
   ngOnInit(): void {
-    this.seo.clearBlobTags();
     this.seo.setNoindex(true);
     void this.reload();
   }

--- a/src/app/features/history/history.component.ts
+++ b/src/app/features/history/history.component.ts
@@ -151,7 +151,6 @@ export class HistoryComponent implements OnInit, AfterViewInit, OnDestroy {
   });
 
   ngOnInit(): void {
-    this.seo.clearBlobTags();
     this.seo.setNoindex(true);
     void this.reload();
   }

--- a/src/app/features/home/home.component.html
+++ b/src/app/features/home/home.component.html
@@ -10,7 +10,6 @@
       [isOwnedBlob]="isOwnedBlob()"
       [saveInFlight]="saveInFlight()"
       [isOwner]="isOwnedBlob()"
-      [isPublic]="isBlobPublic()"
       [clipboardState]="clipboardState()"
       [clipboardPreview]="clipboardPreview()"
       [paneLayout]="paneLayout()"
@@ -34,7 +33,6 @@
       (signInRequested)="onSignInRequested()"
       (titleChange)="onTitleChange($event)"
       (copyShareLink)="onCopyShareLink()"
-      (togglePublic)="onTogglePublic()"
       (deleteBlob)="onDeleteBlob()"
       (suggestRequested)="onSuggestRequested()"
     ></jj-toolbar>

--- a/src/app/features/home/home.component.test.ts
+++ b/src/app/features/home/home.component.test.ts
@@ -151,7 +151,6 @@ function makeIdentityBlob(overrides: Partial<JsonBlob> = {}): JsonBlob {
     content: '{"saved":true}',
     title: 'Saved title',
     ownerId: 'owner-me',
-    isPublic: false,
     version: 1,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
@@ -273,7 +272,6 @@ describe('HomeComponent (unit-level)', () => {
       content: '{"a":1}',
       title: 'hello',
       ownerId: 'me',
-      isPublic: false,
       highlights: [{ path: '$.a', color: '#ffff00', cascade: false }],
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
@@ -294,7 +292,6 @@ describe('HomeComponent (unit-level)', () => {
       content: '{"a":1}',
       title: 'hello',
       ownerId: 'me',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
@@ -327,7 +324,6 @@ describe('HomeComponent (unit-level)', () => {
       content: '{"a":1}',
       title: 'hello',
       ownerId: 'me',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
@@ -377,7 +373,6 @@ describe('HomeComponent (unit-level)', () => {
       content: '{"a":1}',
       title: 'hello',
       ownerId: 'me',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
@@ -388,7 +383,6 @@ describe('HomeComponent (unit-level)', () => {
       content: '{"b":2}',
       title: 'world',
       ownerId: 'me',
-      isPublic: false,
       version: 1,
       createdAt: '2024-02-01T00:00:00Z',
       updatedAt: '2024-02-01T00:00:00Z',
@@ -420,7 +414,6 @@ describe('HomeComponent (unit-level)', () => {
       content: '{"a":1}',
       title: 'hello',
       ownerId: 'me',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
@@ -3069,7 +3062,6 @@ describe('HomeComponent save() branching (M4a)', () => {
     content: '{"a":1}',
     title: 'Hello',
     ownerId: 'owner-me',
-    isPublic: false,
     version: 1,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
@@ -3176,14 +3168,12 @@ describe('HomeComponent save() branching (M4a)', () => {
     fixture.componentInstance.content.set(content);
     fixture.componentInstance.title.set('My title');
     await fixture.componentInstance.onSave();
-    expect(stub.create).toHaveBeenCalledWith(content, 'My title', false, []);
+    expect(stub.create).toHaveBeenCalledWith(content, 'My title', []);
     expect(fixture.componentInstance.loadedBlob()).toEqual(created);
     expect(navSpy).toHaveBeenCalledWith(['/s', 'newslug']);
-    expect(eventSpy).toHaveBeenCalledExactlyOnceWith(
-      'share.created',
-      { visibility: 'private' },
-      { sizeBytes: new Blob([content]).size },
-    );
+    expect(eventSpy).toHaveBeenCalledExactlyOnceWith('share.created', undefined, {
+      sizeBytes: new Blob([content]).size,
+    });
   });
 
   it('create path: forks when loaded blob belongs to someone else', async () => {
@@ -3213,7 +3203,7 @@ describe('HomeComponent save() branching (M4a)', () => {
 
     await fixture.componentInstance.onSave();
 
-    expect(stub.create).toHaveBeenCalledWith('{"a":1}', 'Hello', false, [sourceHighlight]);
+    expect(stub.create).toHaveBeenCalledWith('{"a":1}', 'Hello', [sourceHighlight]);
     expect(stub.update).not.toHaveBeenCalled();
     expect(fixture.componentInstance.highlights()).toEqual([sourceHighlight]);
     expect(fixture.componentInstance.canEditHighlights()).toBe(true);
@@ -3229,7 +3219,7 @@ describe('HomeComponent save() branching (M4a)', () => {
 
     await fixture.componentInstance.onSave();
 
-    expect(stub.create).toHaveBeenCalledWith('{"a":1}', 'Hello', false, []);
+    expect(stub.create).toHaveBeenCalledWith('{"a":1}', 'Hello', []);
     expect(stub.update).not.toHaveBeenCalled();
     expect(fixture.componentInstance.highlights()).toEqual([]);
   });
@@ -3255,7 +3245,7 @@ describe('HomeComponent save() branching (M4a)', () => {
 
     await fixture.componentInstance.onSave();
 
-    expect(stub.create).toHaveBeenCalledWith(content, 'Hello', false, sourceHighlights);
+    expect(stub.create).toHaveBeenCalledWith(content, 'Hello', sourceHighlights);
     expect(stub.update).not.toHaveBeenCalled();
     expect(fixture.componentInstance.highlights()).toEqual(sourceHighlights);
   });
@@ -3278,7 +3268,6 @@ describe('HomeComponent save() branching (M4a)', () => {
     expect(stub.update).toHaveBeenCalledWith('id-1', {
       content: '{"a":2}',
       title: 'New',
-      isPublic: false,
       highlights: [],
     });
     expect(stub.create).not.toHaveBeenCalled();
@@ -3292,7 +3281,7 @@ describe('HomeComponent save() branching (M4a)', () => {
     fixture.componentInstance.content.set('{"a":1}');
     fixture.componentInstance.title.set('   ');
     await fixture.componentInstance.onSave();
-    expect(stub.create).toHaveBeenCalledWith('{"a":1}', undefined, false, []);
+    expect(stub.create).toHaveBeenCalledWith('{"a":1}', undefined, []);
   });
 
   it('save sets saveInFlight during request and clears it after', async () => {
@@ -3366,7 +3355,6 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     content: '{"foo":1,"bar":2}',
     title: 'Saved title',
     ownerId: 'owner-me',
-    isPublic: false,
     version: 1,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
@@ -3563,7 +3551,6 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     return blob({
       content: '{"parent":{"child":{"leaf":1}}}',
       ownerId,
-      isPublic: true,
       highlights: [
         { path: '$.parent', color: '#7e6500', cascade: true },
         { path: '$.parent.child', color: '#fff59d', cascade: false },
@@ -3571,7 +3558,7 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     });
   }
 
-  it('passes canEditHighlights false and hides highlight menu actions for anonymous public viewers', async () => {
+  it('passes canEditHighlights false and hides highlight menu actions for anonymous viewers', async () => {
     const { fixture } = setup({ userId: null });
     const component = fixture.componentInstance;
     component.__loadBlobForTesting(highlightedReadOnlyBlob('owner-me'));
@@ -3637,7 +3624,6 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     expect(stub.update).toHaveBeenCalledWith('blob-1', {
       content: '{"foo":1,"bar":2}',
       title: 'Saved title',
-      isPublic: false,
       highlights: [highlightFoo],
     });
     expect(component.highlights()).toEqual([serverHighlight]);
@@ -3659,7 +3645,6 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     expect(stub.update.mock.lastCall![1]).toEqual({
       content: '{"bar":2}',
       title: 'Saved title',
-      isPublic: false,
       highlights: [],
     });
   });
@@ -3676,7 +3661,6 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     expect(stub.update.mock.lastCall![1]).toEqual({
       content: '{"foo":',
       title: 'Saved title',
-      isPublic: false,
       highlights: [highlightFoo],
     });
   });
@@ -3703,7 +3687,6 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     expect(stub.update.mock.lastCall![1]).toEqual({
       content: '{"a":1,"d":3}',
       title: 'Saved title',
-      isPublic: false,
       highlights: survivingHighlights,
     });
     expect(component.highlights()).toEqual(survivingHighlights);
@@ -3729,7 +3712,6 @@ describe('HomeComponent manual highlights save flow (Phase 4)', () => {
     expect(stub.update.mock.lastCall![1]).toEqual({
       content: '{"a":1,"d":',
       title: 'Saved title',
-      isPublic: false,
       highlights: allHighlights,
     });
     expect(component.highlights()).toEqual(allHighlights);
@@ -3934,7 +3916,6 @@ describe('HomeComponent browser-title effect (M4a)', () => {
       content: '{}',
       title: 'My Config',
       ownerId: 'o1',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
@@ -3953,7 +3934,6 @@ describe('HomeComponent browser-title effect (M4a)', () => {
       slug: 's1',
       content: '{}',
       ownerId: 'o1',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
@@ -4077,7 +4057,6 @@ describe('HomeComponent document-title dirty indicator (issue #84)', () => {
     expect(blobService.update).toHaveBeenCalledWith('identity-blob-1', {
       content: '{"saved":false}',
       title: 'Saved title',
-      isPublic: false,
       highlights: [],
     });
     expect(mostRecentTitle(titleSpy)).toBe('Saved title | JotJSON');
@@ -4117,7 +4096,6 @@ describe('HomeComponent browser-title env-label prefix', () => {
       content: '{}',
       title: 'My Config',
       ownerId: 'o1',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',
@@ -4159,7 +4137,6 @@ describe('HomeComponent blob actions (M4b)', () => {
     slug: 'abc123',
     content: '{"a":1}',
     ownerId: 'owner-me',
-    isPublic: false,
     version: 1,
     createdAt: '2024-01-01T00:00:00Z',
     updatedAt: '2024-01-01T00:00:00Z',
@@ -4280,67 +4257,6 @@ describe('HomeComponent blob actions (M4b)', () => {
     const { fixture, snack } = setup({ userId: 'owner-me' });
     fixture.componentInstance.onCopyShareLink();
     expect(snack.open).not.toHaveBeenCalled();
-  });
-
-  it('onTogglePublic emits public visibility telemetry after a private-to-public update', async () => {
-    const updated = blob({ isPublic: true });
-    const { fixture, stub, snack } = setup({
-      userId: 'owner-me',
-      loaded: blob({ isPublic: false }),
-      updateResult: updated,
-    });
-    const eventSpy = vi.spyOn(TestBed.inject(LoggerService), 'event');
-    await fixture.componentInstance.onTogglePublic();
-    expect(stub.update).toHaveBeenCalledWith('blob-1', { isPublic: true });
-    expect(fixture.componentInstance.loadedBlob()?.isPublic).toBe(true);
-    expect(snack.open).toHaveBeenCalled();
-    expect(eventSpy).toHaveBeenCalledExactlyOnceWith(
-      'share.visibility.changed',
-      { newVisibility: 'public' },
-      undefined,
-    );
-  });
-
-  it('onTogglePublic emits private visibility telemetry after a public-to-private update', async () => {
-    const updated = blob({ isPublic: false });
-    const { fixture, stub, snack } = setup({
-      userId: 'owner-me',
-      loaded: blob({ isPublic: true }),
-      updateResult: updated,
-    });
-    const eventSpy = vi.spyOn(TestBed.inject(LoggerService), 'event');
-    await fixture.componentInstance.onTogglePublic();
-    expect(stub.update).toHaveBeenCalledWith('blob-1', { isPublic: false });
-    expect(fixture.componentInstance.loadedBlob()?.isPublic).toBe(false);
-    expect(snack.open).toHaveBeenCalled();
-    expect(eventSpy).toHaveBeenCalledExactlyOnceWith(
-      'share.visibility.changed',
-      { newVisibility: 'private' },
-      undefined,
-    );
-  });
-
-  it('onTogglePublic toasts an error without visibility telemetry when the update fails', async () => {
-    const { fixture, snack } = setup({
-      userId: 'owner-me',
-      loaded: blob(),
-      updateResult: new Error('nope'),
-    });
-    const eventSpy = vi.spyOn(TestBed.inject(LoggerService), 'event');
-    const warnSpy = vi.spyOn(console, 'warn');
-    await fixture.componentInstance.onTogglePublic();
-    expect(snack.open).toHaveBeenCalled();
-    expect(warnSpy).toHaveBeenCalledWith('[share.visibility.failed]', {});
-    expect(eventSpy).not.toHaveBeenCalled();
-  });
-
-  it('onTogglePublic does nothing when the user does not own the blob', async () => {
-    const { fixture, stub } = setup({
-      userId: 'someone-else',
-      loaded: blob(),
-    });
-    await fixture.componentInstance.onTogglePublic();
-    expect(stub.update).not.toHaveBeenCalled();
   });
 
   it('onDeleteBlob confirms, deletes, clears state, and navigates home', async () => {

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -1115,7 +1115,7 @@ export class HomeComponent implements OnInit, OnDestroy {
       if (this.isBrowser) {
         // All blobs are unlisted (see DESIGN_SPEC.md §Visibility) and the
         // SPA never emits per-blob Open Graph tags. Three crawler-defense
-        // layers ship together in 1.1.0:
+        // layers ship together in 1.3.0:
         //   1. `Disallow: /s/` in public/robots.txt
         //   2. `X-Robots-Tag: noindex` header from staticwebapp.config.json
         //      for /s/* responses

--- a/src/app/features/home/home.component.ts
+++ b/src/app/features/home/home.component.ts
@@ -208,7 +208,6 @@ type SignInRestoreSnapshot = {
 type LoadedSnapshot = {
   content: string;
   title: string;
-  isPublic: boolean;
   highlights: readonly BlobHighlight[];
 };
 
@@ -690,7 +689,6 @@ export class HomeComponent implements OnInit, OnDestroy {
   /** The currently-loaded server blob, if any. Null when editing an anonymous draft. */
   readonly loadedBlob = signal<JsonBlob | null>(null);
   readonly title = signal<string>('');
-  readonly isPublic = signal<boolean>(false);
   readonly highlights = signal<readonly BlobHighlight[]>([]);
   readonly saveInFlight = signal<boolean>(false);
   readonly saveError = signal<string | null>(null);
@@ -863,7 +861,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     return (
       this.content() !== snapshot.content ||
       this.title() !== snapshot.title ||
-      this.isPublic() !== snapshot.isPublic ||
       !highlightsEqual(this.highlights(), snapshot.highlights)
     );
   });
@@ -895,8 +892,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       this.hasContent() &&
       (this.loadedBlob() === null || !this.isOwnedBlob() || this.dirty()),
   );
-
-  readonly isBlobPublic = computed(() => this.loadedBlob() !== null && this.isPublic());
 
   /**
    * Title-suggester wand-enable predicate (M7r). The wand is enabled
@@ -1110,7 +1105,7 @@ export class HomeComponent implements OnInit, OnDestroy {
         // homepage's og:title / og:description / og:type / og:url /
         // og:site_name / twitter:card without an Angular-side wipe.
         if (this.isBrowser) {
-          this.seo.clearBlobTags();
+          this.seo.setNoindex(false);
         }
         return;
       }
@@ -1118,12 +1113,15 @@ export class HomeComponent implements OnInit, OnDestroy {
         title.trim().length > 0 ? title.trim() : $localize`:@@app.title.untitled:Untitled`;
       this.titleService.setTitle(this.envLabel.withPrefix(`${dirtyPrefix}${label} | JotJSON`));
       if (this.isBrowser) {
-        if (blob.isPublic) {
-          this.seo.setOpenGraphForBlob(blob);
-        } else {
-          this.seo.clearBlobTags();
-          this.seo.setNoindex(true);
-        }
+        // All blobs are unlisted (see DESIGN_SPEC.md §Visibility) and the
+        // SPA never emits per-blob Open Graph tags. Three crawler-defense
+        // layers ship together in 1.1.0:
+        //   1. `Disallow: /s/` in public/robots.txt
+        //   2. `X-Robots-Tag: noindex` header from staticwebapp.config.json
+        //      for /s/* responses
+        //   3. This client-side `<meta name="robots" content="noindex">`
+        //      tag for JS-executing crawlers
+        this.seo.setNoindex(true);
       }
     });
 
@@ -1871,7 +1869,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     this.loadedBlob.set(blob);
     this.replaceDocument(snapshot.content);
     this.title.set(snapshot.title);
-    this.isPublic.set(snapshot.isPublic);
     this.highlights.set(snapshot.highlights);
     this.loadedSnapshot.set(snapshot);
     this.mutatedPaths.set(new Set<string>());
@@ -1886,9 +1883,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     if (this.title() === submitted.title) {
       this.title.set(snapshot.title);
     }
-    if (this.isPublic() === submitted.isPublic) {
-      this.isPublic.set(snapshot.isPublic);
-    }
     if (highlightsEqual(this.highlights(), submitted.highlights)) {
       this.highlights.set(snapshot.highlights);
     }
@@ -1900,7 +1894,6 @@ export class HomeComponent implements OnInit, OnDestroy {
     return {
       content: blob.content,
       title: blob.title ?? '',
-      isPublic: blob.isPublic,
       highlights: [...(blob.highlights ?? [])],
     };
   }
@@ -1909,14 +1902,12 @@ export class HomeComponent implements OnInit, OnDestroy {
     return {
       content: this.content(),
       title: this.title(),
-      isPublic: this.isPublic(),
       highlights: [...this.highlights()],
     };
   }
 
   private resetLoadedBlobState(): void {
     this.loadedBlob.set(null);
-    this.isPublic.set(false);
     this.highlights.set([]);
     this.loadedSnapshot.set(null);
     this.mutatedPaths.set(new Set<string>());
@@ -2034,14 +2025,8 @@ export class HomeComponent implements OnInit, OnDestroy {
       localSnapshot.title !== baseSnapshot.title &&
       remoteSnapshot.title !== baseSnapshot.title &&
       localSnapshot.title !== remoteSnapshot.title;
-    const publicConflicts =
-      localSnapshot.isPublic !== baseSnapshot.isPublic &&
-      remoteSnapshot.isPublic !== baseSnapshot.isPublic &&
-      localSnapshot.isPublic !== remoteSnapshot.isPublic;
     const replaceRemote =
-      contentConflicts || titleConflicts || publicConflicts
-        ? await this.promptConflictResolution()
-        : false;
+      contentConflicts || titleConflicts ? await this.promptConflictResolution() : false;
 
     const nextContent = this.rebaseCoarseField(
       baseSnapshot.content,
@@ -2057,13 +2042,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       titleConflicts,
       replaceRemote,
     );
-    const nextIsPublic = this.rebaseCoarseField(
-      baseSnapshot.isPublic,
-      localSnapshot.isPublic,
-      remoteSnapshot.isPublic,
-      publicConflicts,
-      replaceRemote,
-    );
     const nextHighlights = this.rebaseHighlights(
       remoteSnapshot.highlights,
       localSnapshot.highlights,
@@ -2076,7 +2054,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       this.replaceDocument(nextContent);
     }
     this.title.set(nextTitle);
-    this.isPublic.set(nextIsPublic);
     this.highlights.set(nextHighlights);
     this.mutatedPaths.set(new Set<string>());
   }
@@ -3230,7 +3207,6 @@ export class HomeComponent implements OnInit, OnDestroy {
             .update(existing.id, {
               content: submitted.content,
               title: titlePatch,
-              isPublic: submitted.isPublic,
               highlights: [...highlights],
             })
             .subscribe({ next: resolve, error: reject });
@@ -3239,14 +3215,12 @@ export class HomeComponent implements OnInit, OnDestroy {
       } else {
         const created = await new Promise<CreateBlobResponse>((resolve, reject) => {
           this.blobs
-            .create(submitted.content, titlePatch, false, [...highlights])
+            .create(submitted.content, titlePatch, [...highlights])
             .subscribe({ next: resolve, error: reject });
         });
-        this.logger.event(
-          'share.created',
-          { visibility: 'private' },
-          { sizeBytes: new Blob([submitted.content]).size },
-        );
+        this.logger.event('share.created', undefined, {
+          sizeBytes: new Blob([submitted.content]).size,
+        });
         // Strip the auxiliary quota marker before we treat it as a JsonBlob
         // so loadedBlob stays clean.
         const { autoDeleted, ...blob } = created;
@@ -3443,41 +3417,6 @@ export class HomeComponent implements OnInit, OnDestroy {
       failed: $localize`:@@share.copyLink.failed:Failed to copy share link.`,
       unsupported: $localize`:@@share.copyLink.unsupported:Copy is not supported in this browser.`,
     });
-  }
-
-  async onTogglePublic(): Promise<void> {
-    const blob = this.loadedBlob();
-    if (!blob) return;
-    const user = this.auth.user();
-    if (!user || user.id !== blob.ownerId) return;
-    const next = !this.isPublic();
-    try {
-      const updated = await firstValueFrom(this.blobs.update(blob.id, { isPublic: next }));
-      this.loadedBlob.set(updated);
-      this.isPublic.set(updated.isPublic);
-      this.loadedSnapshot.set(this.snapshotFromBlob(updated));
-      this.logger.event(
-        'share.visibility.changed',
-        { newVisibility: updated.isPublic ? 'public' : 'private' },
-        undefined,
-      );
-      const message = updated.isPublic
-        ? $localize`:@@share.visibility.public:Blob is now public.`
-        : $localize`:@@share.visibility.private:Blob is now private.`;
-      this.snack.open(message, $localize`:@@common.dismiss:Dismiss`, { duration: 3000 });
-    } catch (error) {
-      const httpError = error as { status?: number };
-      if (httpError.status === 412) {
-        return;
-      }
-      this.logger.warn('share.visibility.failed');
-      void error;
-      this.snack.open(
-        $localize`:@@share.visibility.failed:Failed to update visibility.`,
-        $localize`:@@common.dismiss:Dismiss`,
-        { duration: 4000 },
-      );
-    }
   }
 
   async onDeleteBlob(): Promise<void> {

--- a/src/app/features/not-found/not-found.component.ts
+++ b/src/app/features/not-found/not-found.component.ts
@@ -19,7 +19,6 @@ export class NotFoundComponent implements OnInit {
 
   ngOnInit(): void {
     // A 404 page should never be indexed, regardless of prior page state.
-    this.seo.clearBlobTags();
     this.seo.setNoindex(true);
   }
 

--- a/src/app/features/share/share-blob.resolver.test.ts
+++ b/src/app/features/share/share-blob.resolver.test.ts
@@ -32,7 +32,6 @@ describe('shareBlobResolver', () => {
       slug: 'abc123',
       content: '{"a":1}',
       ownerId: 'owner',
-      isPublic: false,
       version: 1,
       createdAt: '2024-01-01T00:00:00Z',
       updatedAt: '2024-01-01T00:00:00Z',

--- a/src/app/shared/components/toolbar/toolbar.component.html
+++ b/src/app/shared/components/toolbar/toolbar.component.html
@@ -202,10 +202,6 @@
             <jj-icon name="link" />
             <span i18n="@@toolbar.overflow.copyShareLink">Copy share link</span>
           </button>
-          <button mat-menu-item type="button" (click)="onTogglePublicClick()">
-            <jj-icon [name]="isPublic() ? 'lock' : 'globe'" />
-            <span>{{ visibilityMenuLabel() }}</span>
-          </button>
           <button mat-menu-item type="button" (click)="onDeleteBlobClick()">
             <jj-icon name="trash" />
             <span i18n="@@toolbar.overflow.delete">Delete this blob</span>

--- a/src/app/shared/components/toolbar/toolbar.component.test.ts
+++ b/src/app/shared/components/toolbar/toolbar.component.test.ts
@@ -23,7 +23,6 @@ type ToolbarAction =
   | 'clear'
   | 'save'
   | 'copyShareLink'
-  | 'togglePublic'
   | 'deleteBlob'
   | 'fileChange';
 
@@ -928,7 +927,6 @@ describe('ToolbarComponent', () => {
       'clear',
       'save',
       'copyShareLink',
-      'togglePublic',
       'deleteBlob',
     ];
 
@@ -937,7 +935,6 @@ describe('ToolbarComponent', () => {
       fixture.componentRef.setInput('canSave', true);
       fixture.componentRef.setInput('saveInFlight', false);
       fixture.componentRef.setInput('isOwner', true);
-      fixture.componentRef.setInput('isPublic', false);
       fixture.detectChanges();
     }
 
@@ -1094,10 +1091,6 @@ describe('ToolbarComponent', () => {
       triggerMenuItemClick(fixture, 'Copy share link');
     }
 
-    function triggerTogglePublicMenuClick(fixture: ComponentFixture<ToolbarComponent>): void {
-      triggerMenuItemClick(fixture, 'Make public');
-    }
-
     function triggerDeleteBlobMenuClick(fixture: ComponentFixture<ToolbarComponent>): void {
       triggerMenuItemClick(fixture, 'Delete this blob');
     }
@@ -1148,7 +1141,6 @@ describe('ToolbarComponent', () => {
         ['clear', () => triggerClearButtonClick(fixture)],
         ['save', () => triggerSaveButtonClick(fixture)],
         ['copyShareLink', () => triggerCopyShareLinkMenuClick(fixture)],
-        ['togglePublic', () => triggerTogglePublicMenuClick(fixture)],
         ['deleteBlob', () => triggerDeleteBlobMenuClick(fixture)],
       ];
     }
@@ -1215,9 +1207,6 @@ describe('ToolbarComponent', () => {
           break;
         case 'copyShareLink':
           component.copyShareLink.subscribe(() => outputSpy());
-          break;
-        case 'togglePublic':
-          component.togglePublic.subscribe(() => outputSpy());
           break;
         case 'deleteBlob':
           component.deleteBlob.subscribe(() => outputSpy());
@@ -1493,30 +1482,16 @@ describe('ToolbarComponent', () => {
       expect(fixture.componentInstance.showOverflowMenu()).toBe(true);
     });
 
-    it('visibilityMenuLabel flips based on isPublic', async () => {
-      const { fixture } = await create();
-      fixture.componentRef.setInput('isPublic', false);
-      fixture.detectChanges();
-      expect(fixture.componentInstance.visibilityMenuLabel()).toBe('Make public');
-      fixture.componentRef.setInput('isPublic', true);
-      fixture.detectChanges();
-      expect(fixture.componentInstance.visibilityMenuLabel()).toBe('Make private');
-    });
-
-    it('copyShareLink, togglePublic, deleteBlob outputs emit when invoked', async () => {
+    it('copyShareLink and deleteBlob outputs emit when invoked', async () => {
       const { fixture } = await create();
       const cmp = fixture.componentInstance;
       const copy = vi.fn();
-      const toggle = vi.fn();
       const del = vi.fn();
       cmp.copyShareLink.subscribe(copy);
-      cmp.togglePublic.subscribe(toggle);
       cmp.deleteBlob.subscribe(del);
       cmp.copyShareLink.emit();
-      cmp.togglePublic.emit();
       cmp.deleteBlob.emit();
       expect(copy).toHaveBeenCalledTimes(1);
-      expect(toggle).toHaveBeenCalledTimes(1);
       expect(del).toHaveBeenCalledTimes(1);
     });
   });

--- a/src/app/shared/components/toolbar/toolbar.component.ts
+++ b/src/app/shared/components/toolbar/toolbar.component.ts
@@ -33,7 +33,6 @@ type ToolbarAction =
   | 'clear'
   | 'save'
   | 'copyShareLink'
-  | 'togglePublic'
   | 'deleteBlob'
   | 'fileChange';
 
@@ -87,12 +86,9 @@ export class ToolbarComponent {
   readonly isOwnedBlob = input<boolean>(false);
   /**
    * Set to true when a blob is loaded AND the signed-in user owns it.
-   * Controls whether the 3-dot overflow menu (copy link / toggle visibility
-   * / delete) is shown.
+   * Controls whether the 3-dot overflow menu (copy link / delete) is shown.
    */
   readonly isOwner = input<boolean>(false);
-  /** Current isPublic flag of the loaded blob, drives the visibility toggle label. */
-  readonly isPublic = input<boolean>(false);
 
   /**
    * Title-suggester candidates (M7p). Lazily populated by the parent
@@ -158,7 +154,6 @@ export class ToolbarComponent {
   readonly titleChange = output<string>();
   readonly signInRequested = output<void>();
   readonly copyShareLink = output<void>();
-  readonly togglePublic = output<void>();
   readonly deleteBlob = output<void>();
 
   /**
@@ -265,12 +260,6 @@ export class ToolbarComponent {
    */
   readonly showOverflowMenu = computed(() => this.ownsLoadedBlob());
 
-  readonly visibilityMenuLabel = computed(() =>
-    this.isPublic()
-      ? $localize`:@@toolbar.overflow.makePrivate:Make private`
-      : $localize`:@@toolbar.overflow.makePublic:Make public`,
-  );
-
   readonly saveTooltip = computed(() => {
     if (!this.saveInFlight() && this.saveDisabled()) {
       return $localize`:@@toolbar.save.disabledTooltip:No changes to save`;
@@ -369,11 +358,6 @@ export class ToolbarComponent {
   onCopyShareLinkClick(): void {
     this.emitToolbarAction('copyShareLink');
     this.copyShareLink.emit();
-  }
-
-  onTogglePublicClick(): void {
-    this.emitToolbarAction('togglePublic');
-    this.togglePublic.emit();
   }
 
   onDeleteBlobClick(): void {

--- a/src/locale/messages.xlf
+++ b/src/locale/messages.xlf
@@ -18,11 +18,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">137</context>
+          <context context-type="linenumber">136</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">145</context>
+          <context context-type="linenumber">144</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/formatting-rules/formatting-rules.component.ts</context>
@@ -102,55 +102,47 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">235</context>
+          <context context-type="linenumber">234</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">348</context>
+          <context context-type="linenumber">347</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">356</context>
+          <context context-type="linenumber">355</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2017</context>
+          <context context-type="linenumber">2008</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2936</context>
+          <context context-type="linenumber">2915</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3067</context>
+          <context context-type="linenumber">3046</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3077</context>
+          <context context-type="linenumber">3056</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3085</context>
+          <context context-type="linenumber">3064</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3095</context>
+          <context context-type="linenumber">3074</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3467</context>
+          <context context-type="linenumber">3456</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3477</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3513</context>
-        </context-group>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3523</context>
+          <context context-type="linenumber">3466</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/rule-sets-toolbar/rule-sets-toolbar.component.ts</context>
@@ -459,130 +451,116 @@
           <context context-type="linenumber">34,36</context>
         </context-group>
       </trans-unit>
-      <trans-unit id="blobs.public.tooltip" datatype="html">
-        <source>Anyone with the link and search engines can see this blob.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/blobs/blobs.component.html</context>
-          <context context-type="linenumber">56,57</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="blobs.public" datatype="html">
-        <source>public</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/blobs/blobs.component.html</context>
-          <context context-type="linenumber">58,60</context>
-        </context-group>
-      </trans-unit>
       <trans-unit id="blobs.copyLink.tooltip" datatype="html">
         <source>Copy link</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.html</context>
-          <context context-type="linenumber">67,68</context>
+          <context context-type="linenumber">57,58</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.copyLink.aria" datatype="html">
         <source>Copy link to this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.html</context>
-          <context context-type="linenumber">69,70</context>
+          <context context-type="linenumber">59,60</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.delete.tooltip" datatype="html">
         <source>Delete this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.html</context>
-          <context context-type="linenumber">79,80</context>
+          <context context-type="linenumber">69,70</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.delete.aria" datatype="html">
         <source>Delete this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.html</context>
-          <context context-type="linenumber">81,82</context>
+          <context context-type="linenumber">71,72</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.load.failed" datatype="html">
         <source>Failed to load your saved blobs.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">75</context>
+          <context context-type="linenumber">74</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.untitled" datatype="html">
         <source>Untitled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">82</context>
+          <context context-type="linenumber">81</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.justNow" datatype="html">
         <source>just now</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">90</context>
+          <context context-type="linenumber">89</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.minutesAgo" datatype="html">
         <source><x id="count" equiv-text="minutes"/> min ago</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">91</context>
+          <context context-type="linenumber">90</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.hoursAgo" datatype="html">
         <source><x id="count" equiv-text="hours"/> h ago</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">93</context>
+          <context context-type="linenumber">92</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.daysAgo" datatype="html">
         <source><x id="count" equiv-text="days"/> d ago</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">95</context>
+          <context context-type="linenumber">94</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.copyLink.success" datatype="html">
         <source>Link copied to clipboard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">106</context>
+          <context context-type="linenumber">105</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.copyLink.failed" datatype="html">
         <source>Failed to copy link</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">107</context>
+          <context context-type="linenumber">106</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.copyLink.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">108</context>
+          <context context-type="linenumber">107</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.delete.title" datatype="html">
         <source>Delete this blob?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">118</context>
+          <context context-type="linenumber">117</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.delete.message" datatype="html">
         <source>&quot;<x id="name" equiv-text="label"/>&quot; will be permanently deleted. This cannot be undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">119</context>
+          <context context-type="linenumber">118</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.confirm" datatype="html">
         <source>Delete</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">120</context>
+          <context context-type="linenumber">119</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/formatting-rules/formatting-rules.component.ts</context>
@@ -590,14 +568,14 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3493</context>
+          <context context-type="linenumber">3436</context>
         </context-group>
       </trans-unit>
       <trans-unit id="common.cancel" datatype="html">
         <source>Cancel</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">121</context>
+          <context context-type="linenumber">120</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/formatting-rules/formatting-rules.component.ts</context>
@@ -605,11 +583,11 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">331</context>
+          <context context-type="linenumber">330</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3494</context>
+          <context context-type="linenumber">3437</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/rule-sets-toolbar/clone-preset-dialog.component.ts</context>
@@ -620,22 +598,22 @@
         <source>Blob deleted.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">136</context>
+          <context context-type="linenumber">135</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3512</context>
+          <context context-type="linenumber">3455</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.failed" datatype="html">
         <source>Failed to delete blob.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/blobs/blobs.component.ts</context>
-          <context context-type="linenumber">144</context>
+          <context context-type="linenumber">143</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3522</context>
+          <context context-type="linenumber">3465</context>
         </context-group>
       </trans-unit>
       <trans-unit id="formattingRules.title" datatype="html">
@@ -1895,63 +1873,63 @@
         <source>Failed to load your history.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">210</context>
+          <context context-type="linenumber">209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.loadMore.failed" datatype="html">
         <source>Failed to load more history.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">234</context>
+          <context context-type="linenumber">233</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.filter.date.invalid" datatype="html">
         <source>From date must be on or before To date.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">318</context>
+          <context context-type="linenumber">317</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.clear.title" datatype="html">
         <source>Clear all history?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">328</context>
+          <context context-type="linenumber">327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.clear.message" datatype="html">
         <source>Every entry in your activity history will be permanently removed. The blobs themselves are not affected.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">329</context>
+          <context context-type="linenumber">328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.clear.confirm" datatype="html">
         <source>Clear history</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">330</context>
+          <context context-type="linenumber">329</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.clear.success" datatype="html">
         <source>History cleared.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">347</context>
+          <context context-type="linenumber">346</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.clear.failed" datatype="html">
         <source>Failed to clear history.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">355</context>
+          <context context-type="linenumber">354</context>
         </context-group>
       </trans-unit>
       <trans-unit id="history.deletedBlob" datatype="html">
         <source>(deleted blob)</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/history/history.component.ts</context>
-          <context context-type="linenumber">397</context>
+          <context context-type="linenumber">396</context>
         </context-group>
       </trans-unit>
       <trans-unit id="clipboard.banner.body" datatype="html">
@@ -2056,337 +2034,316 @@
         <source>JSON editor</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">45,47</context>
+          <context context-type="linenumber">43,45</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.editorPane.aria" datatype="html">
         <source>JSON input</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">57,58</context>
+          <context context-type="linenumber">55,56</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.treePane.aria" datatype="html">
         <source>Tree view</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">102,103</context>
+          <context context-type="linenumber">100,101</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.server.brand" datatype="html">
         <source>JotJSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">124,125</context>
+          <context context-type="linenumber">122,123</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.server.tagline" datatype="html">
         <source>JSON viewer, formatter, and tree explorer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">125,126</context>
+          <context context-type="linenumber">123,124</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.server.description" datatype="html">
         <source> Paste, format, validate, and share JSON or JSONC. Browse large documents in a fast tree explorer with formatting rules, history, and shareable links. </source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.html</context>
-          <context context-type="linenumber">127,129</context>
+          <context context-type="linenumber">125,127</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.title.homepage" datatype="html">
         <source>JotJSON - JSON viewer, formatter, and tree explorer</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">928</context>
+          <context context-type="linenumber">923</context>
         </context-group>
       </trans-unit>
       <trans-unit id="app.title.untitled" datatype="html">
         <source>Untitled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1118</context>
+          <context context-type="linenumber">1113</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.coldBootClipboard.snackbar.pasted" datatype="html">
         <source>Pasted from clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1481</context>
+          <context context-type="linenumber">1479</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.coldBootClipboard.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">1482</context>
+          <context context-type="linenumber">1480</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.toast" datatype="html">
         <source>Reloaded - this blob was changed in another tab</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2016</context>
+          <context context-type="linenumber">2007</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.title" datatype="html">
         <source>Blob changed in another tab</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2099</context>
+          <context context-type="linenumber">2078</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.message" datatype="html">
         <source>Your local changes conflict with the latest version. Discard your changes or replace the remote version on your next save?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2100</context>
+          <context context-type="linenumber">2079</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.replaceRemote" datatype="html">
         <source>Replace remote</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2101</context>
+          <context context-type="linenumber">2080</context>
         </context-group>
       </trans-unit>
       <trans-unit id="blobs.conflict.discardMine" datatype="html">
         <source>Discard my changes</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2102</context>
+          <context context-type="linenumber">2081</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.extract.snackbar.applied" datatype="html">
         <source>Extracted embedded JSON into the document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2436</context>
+          <context context-type="linenumber">2415</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2877</context>
+          <context context-type="linenumber">2856</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.extract.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2437</context>
+          <context context-type="linenumber">2416</context>
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2878</context>
+          <context context-type="linenumber">2857</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sortKeys.snackbar.applied" datatype="html">
         <source>Sorted this object&apos;s keys.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2507</context>
+          <context context-type="linenumber">2486</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sortKeys.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2508</context>
+          <context context-type="linenumber">2487</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.decodedApply.snackbar.applied" datatype="html">
         <source>Replaced &quot;??&quot; markers with line breaks in the document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2593</context>
+          <context context-type="linenumber">2572</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.decodedApply.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2594</context>
+          <context context-type="linenumber">2573</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.osLaunch.error.unreadable" datatype="html">
         <source>Could not open the file.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">2935</context>
+          <context context-type="linenumber">2914</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.osLaunch.snackbar.opened" datatype="html">
         <source>Opened <x id="filename" equiv-text="this.formatFilenameForSnack(filename)"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3024</context>
+          <context context-type="linenumber">3003</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.snackbar.uploaded" datatype="html">
         <source>Uploaded <x id="filename" equiv-text="this.formatFilenameForSnack(filename)"/>.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3025</context>
+          <context context-type="linenumber">3004</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3026</context>
+          <context context-type="linenumber">3005</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.tooMany" datatype="html">
         <source>Please drop one file at a time.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3066</context>
+          <context context-type="linenumber">3045</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.tooLarge" datatype="html">
         <source>File too large - max 5 MB</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3076</context>
+          <context context-type="linenumber">3055</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.binary" datatype="html">
         <source>File does not appear to be a text file - upload was ignored.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3084</context>
+          <context context-type="linenumber">3063</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.upload.error.readFailed" datatype="html">
         <source>Could not read file</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3094</context>
+          <context context-type="linenumber">3073</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.quotaExceeded" datatype="html">
         <source>Blob limit reached - delete one from your saved blobs to save a new blob.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3267</context>
+          <context context-type="linenumber">3245</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.signIn" datatype="html">
         <source>Please sign in to save</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3285</context>
+          <context context-type="linenumber">3263</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.forbidden" datatype="html">
         <source>You do not own this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3288</context>
+          <context context-type="linenumber">3266</context>
         </context-group>
       </trans-unit>
       <trans-unit id="save.error.generic" datatype="html">
         <source>Could not save - please try again</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3290</context>
+          <context context-type="linenumber">3268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.format.snackbar.applied" datatype="html">
         <source>Formatted document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3314</context>
+          <context context-type="linenumber">3292</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.format.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3315</context>
+          <context context-type="linenumber">3293</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.minify.snackbar.applied" datatype="html">
         <source>Minified document.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3349</context>
+          <context context-type="linenumber">3327</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.minify.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3350</context>
+          <context context-type="linenumber">3328</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sort.snackbar.applied" datatype="html">
         <source>Sorted keys.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3387</context>
+          <context context-type="linenumber">3365</context>
         </context-group>
       </trans-unit>
       <trans-unit id="home.sort.snackbar.undo" datatype="html">
         <source>Undo</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3388</context>
+          <context context-type="linenumber">3366</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.success" datatype="html">
         <source>Share link copied to clipboard.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3442</context>
+          <context context-type="linenumber">3420</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.failed" datatype="html">
         <source>Failed to copy share link.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3443</context>
+          <context context-type="linenumber">3421</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.copyLink.unsupported" datatype="html">
         <source>Copy is not supported in this browser.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3444</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="share.visibility.public" datatype="html">
-        <source>Blob is now public.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3465</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="share.visibility.private" datatype="html">
-        <source>Blob is now private.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3466</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="share.visibility.failed" datatype="html">
-        <source>Failed to update visibility.</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3476</context>
+          <context context-type="linenumber">3422</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.title" datatype="html">
         <source>Delete this blob?</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3491</context>
+          <context context-type="linenumber">3434</context>
         </context-group>
       </trans-unit>
       <trans-unit id="share.delete.message" datatype="html">
         <source>&quot;<x id="name" equiv-text="label"/>&quot; will be permanently deleted. This cannot be undone.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/features/home/home.component.ts</context>
-          <context context-type="linenumber">3492</context>
+          <context context-type="linenumber">3435</context>
         </context-group>
       </trans-unit>
       <trans-unit id="formattingRules.clone.title" datatype="html">
@@ -4766,7 +4723,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">442</context>
+          <context context-type="linenumber">426</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.state.signInToSaveCompact" datatype="html">
@@ -4777,7 +4734,7 @@
         </context-group>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">441</context>
+          <context context-type="linenumber">425</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.overflow.tooltip" datatype="html">
@@ -4805,210 +4762,196 @@
         <source>Delete this blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.html</context>
-          <context context-type="linenumber">211,213</context>
+          <context context-type="linenumber">207,209</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.theme.tooltip.toDark" datatype="html">
         <source>Switch to dark theme</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">197</context>
+          <context context-type="linenumber">192</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.theme.tooltip.toSystem" datatype="html">
         <source>Match system theme</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">200</context>
+          <context context-type="linenumber">195</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.theme.tooltip.toLight" datatype="html">
         <source>Switch to light theme</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">202</context>
+          <context context-type="linenumber">197</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.syncSelection.tooltip.on" datatype="html">
         <source>Disable tree-editor selection sync</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">218</context>
+          <context context-type="linenumber">213</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.syncSelection.tooltip.off" datatype="html">
         <source>Enable tree-editor selection sync</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">219</context>
+          <context context-type="linenumber">214</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.syncSelection.aria" datatype="html">
         <source>Toggle tree-editor selection sync</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">221</context>
+          <context context-type="linenumber">216</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paneLayout.aria" datatype="html">
         <source>Pane layout</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">230</context>
+          <context context-type="linenumber">225</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paneLayout.editorOnly" datatype="html">
         <source>Show editor only</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">231</context>
+          <context context-type="linenumber">226</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paneLayout.bothHorizontal" datatype="html">
         <source>Editor and tree side-by-side</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">232</context>
+          <context context-type="linenumber">227</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paneLayout.bothVertical" datatype="html">
         <source>Editor above tree</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">233</context>
+          <context context-type="linenumber">228</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paneLayout.treeOnly" datatype="html">
         <source>Show tree only</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">234</context>
+          <context context-type="linenumber">229</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.save.asCopy" datatype="html">
         <source>Save as copy</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">251</context>
+          <context context-type="linenumber">246</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.save.label" datatype="html">
         <source>Save</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">252</context>
+          <context context-type="linenumber">247</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.title.untitled" datatype="html">
         <source>Untitled</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">255</context>
+          <context context-type="linenumber">250</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.titleSuggestion.action.aria" datatype="html">
         <source>Suggest a title</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">257</context>
+          <context context-type="linenumber">252</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.titleSuggestion.action.tooltip" datatype="html">
         <source>Suggest a title</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">258</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="toolbar.overflow.makePrivate" datatype="html">
-        <source>Make private</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">270</context>
-        </context-group>
-      </trans-unit>
-      <trans-unit id="toolbar.overflow.makePublic" datatype="html">
-        <source>Make public</source>
-        <context-group purpose="location">
-          <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">271</context>
+          <context context-type="linenumber">253</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.save.disabledTooltip" datatype="html">
         <source>No changes to save</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">276</context>
+          <context context-type="linenumber">265</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.save.asCopyTooltip" datatype="html">
         <source>Save your changes as a new blob</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">279</context>
+          <context context-type="linenumber">268</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paste.tooltip.ready" datatype="html">
         <source>Paste: <x id="PREVIEW" equiv-text="preview"/></source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">294</context>
+          <context context-type="linenumber">283</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paste.tooltip.readyNoPreview" datatype="html">
         <source>Paste from clipboard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">295</context>
+          <context context-type="linenumber">284</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paste.tooltip.empty" datatype="html">
         <source>Clipboard does not contain JSON</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">298</context>
+          <context context-type="linenumber">287</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paste.tooltip.denied" datatype="html">
         <source>Clipboard access blocked - enable it in your browser settings. Ctrl+V still works.</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">300</context>
+          <context context-type="linenumber">289</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.paste.tooltip" datatype="html">
         <source>Paste from clipboard</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">302</context>
+          <context context-type="linenumber">291</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.state.draft" datatype="html">
         <source>Draft</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">432</context>
+          <context context-type="linenumber">416</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.state.saved" datatype="html">
         <source>Saved</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">434</context>
+          <context context-type="linenumber">418</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.state.modified" datatype="html">
         <source>Modified</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">436</context>
+          <context context-type="linenumber">420</context>
         </context-group>
       </trans-unit>
       <trans-unit id="toolbar.state.saving" datatype="html">
         <source>Saving...</source>
         <context-group purpose="location">
           <context context-type="sourcefile">src/app/shared/components/toolbar/toolbar.component.ts</context>
-          <context context-type="linenumber">438</context>
+          <context context-type="linenumber">422</context>
         </context-group>
       </trans-unit>
     </body>

--- a/staticwebapp.config.json
+++ b/staticwebapp.config.json
@@ -13,6 +13,12 @@
       "allowedRoles": ["anonymous", "authenticated"]
     },
     {
+      "route": "/s/*",
+      "headers": {
+        "X-Robots-Tag": "noindex"
+      }
+    },
+    {
       "route": "/index.html",
       "headers": {
         "Cache-Control": "no-cache, must-revalidate"


### PR DESCRIPTION
Removes the `isPublic` blob visibility flag end-to-end. Investigation found this flag was a *lying flag* -- its declared "private vs public" semantic was never enforced at the access-control layer (any blob is readable by anyone with the slug; `GET /api/blobs/{idOrSlug}` has no `isPublic` check). It controlled only client-side SEO meta tags and a misleading toolbar overflow label.

## What changes

**Frontend** -- drop `isPublic` from `JsonBlob`, the toolbar overflow menu item, the `/blobs` row "public" badge, the dead CSS, the `HomeComponent` signal + 3-way merge branch + snapshot field + dirty term + `onTogglePublic` chain, the `share.created` event's `visibility` dimension, the 7 obsolete i18n strings (regenerated `messages.xlf`). Rename `clearBlobTags()` -> drop it entirely; `SeoService` shrinks to a single `setNoindex(boolean)` method (per-blob OG/Twitter retired alongside the flag).

**Backend** -- drop `isPublic` from `BlobDocument`, validators, create/update logic. **Schema-evolution Removal** per `DESIGN_SPEC` Sec.2102: `normalizeBlobDocument` strips legacy `isPublic` on read with a typed in-only field guard (preserves reference equality for non-legacy docs), and emits a deduplicated `blob.legacy.isPublic.stripped` telemetry event per blob id per process so the cleanup follow-up has a measurable exit signal. `updateBlob` gains an empty-patch early-out so a stale-client `{ isPublic: true }`-only PUT doesn't bump version/`updatedAt`.

**Crawler defense** -- three layers ship together: `Disallow: /s/` in `public/robots.txt` (pre-fetch signal), `X-Robots-Tag: noindex` header from `staticwebapp.config.json` for `/s/*` (post-fetch signal, asserted by extended `scripts/check-swa-config.mjs`), and always-on client-side `<meta name="robots" content="noindex">` on every blob load. Empirically verified before merge that no `/s/*` URLs are indexed by any major search engine (Bing/DuckDuckGo/Google `site:jotjson.com/s/` returned no matches), eliminating the orphan-index failure mode for the single-deploy rollout.

**New spec rule** -- `DESIGN_SPEC` Sec.Validation: API fields with access-control semantics MUST be enforced at the access-control layer at the time of the field's introduction. Motivating case study: this removal.

Resolves `followup-share-og` (both halves: server-visible noindex delivered via the new layers; per-blob OG retired since all blobs are unlisted).

## SemVer

**1.2.0 -> 1.3.0 (minor).** User-visible UI change (overflow item gone, badge gone), wire-shape change (REST API drops a documented field). API is consumer is internal-only (the SPA we ship atomically), so this is not a breaking external contract. Pre-1.0 carve-out does not apply.

Note: the user-approved plan said "1.1.0 (minor)" against an assumed `1.0.1` base, but the actual worktree base is `1.2.0` (the Vitest migration in commit c5416f4 bumped twice). 1.2.0 -> 1.3.0 is a minor bump per the same rule.

## Verification

- `npm run lint:all` (full DoD gate, both workspaces): PASS
- `npm test` (Vitest, frontend): 3198/3198 PASS
- `npm --prefix api test` (Jest, backend): 480/480 PASS (includes new strip + exit-signal + empty-patch tests)
- `npm run test:scripts` (Node-built-in script gates): 482/482 PASS (includes new check-swa-config asserts)
- `npm run build` (production): PASS
- `node scripts/check-prerender.mjs`: PASS (asserts robots.txt Disallow: /s/)
- `npm run extract-i18n`: regenerated cleanly

## Pre-merge required step (Layer B header survival)

The plan's pre-merge SWA verification (curl -I against a preview environment to confirm the `/s/*` route's `X-Robots-Tag` header survives `navigationFallback.rewrite` to `/shell.html`) needs to be run by whoever has preview-env access before merge -- I cannot do this from the local worktree alone.

## Plan / panel

Plan rubber-ducked through the 3-agent panel (`deep-review:skeptic` / `:advocate` / `:architect`) before implementation; **15 of 17** distinct findings adopted, 1 partial-adopt (strip placement), 1 set-aside (latent pre-existing test-coverage gap unrelated to this change). Per-panelist transcripts and the full plan are in the session-state folder.

---
**Session**
- AI-Local: `601ba393-e2de-40db-a362-1dec00bf65ec`
- AI-Cloud: (not applicable -- Copilot CLI local session, no cloud-agent ID)