### PR TITLE
Rename JASMINE_SEED env var to JOTJSON_TEST_SEED + document convention (#436)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -359,6 +359,15 @@ Events catalog.
 - Files: `kebab-case.ts`. Angular: `thing.component.ts`, `thing.service.ts`,
   `thing.pipe.ts`, `thing.guard.ts`.
 - Classes: `PascalCase`. Variables/functions: `camelCase`. Constants: `UPPER_SNAKE`.
+- **First-party environment variables use the `JOTJSON_*` prefix.**
+  Examples in the repo today: `JOTJSON_DEV_AUTH_BYPASS`,
+  `JOTJSON_BUILD_SHA`, `JOTJSON_MIGRATION_CONFIRMED`,
+  `JOTJSON_TEST_SEED`. The prefix is runner- and tool-agnostic so the
+  variable name does not couple to a current implementation choice (the
+  predecessor `JASMINE_SEED` outlived Jasmine -- see issue #436). Do not
+  introduce a `JJ_*` env-var prefix; `JJ_` is reserved for in-code
+  symbol prefixes (e.g. `JJ_MENU_IMPORTS`) and i18n placeholder tags
+  (e.g. `x-jj_icon`).
 - **Use descriptive names.** Variables, parameters, and functions must
   use whole-word, intention-revealing names - not single letters or
   ad-hoc abbreviations like `a`, `b`, `x`, `y`, `tmp`, `val`, `data2`.

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -9,14 +9,21 @@
 import { defineConfig } from 'vitest/config';
 import { makeBrowserConfig, sharedPlugins, sharedTestBase } from './vitest.shared.mts';
 
-const rawSeed = process.env['JASMINE_SEED'];
+// Env-var name for replay-seed override. Per AGENTS.md Section 4 Naming,
+// first-party env vars use the `JOTJSON_*` prefix so the name does not
+// couple to a current implementation choice (the predecessor `JASMINE_SEED`
+// outlived Jasmine; see issue #436). Defined once so the three callsites
+// below cannot drift.
+const SEED_ENV_VAR = 'JOTJSON_TEST_SEED' as const;
+
+const rawSeed = process.env[SEED_ENV_VAR];
 const trimmedSeed = typeof rawSeed === 'string' ? rawSeed.trim() : '';
 const numericSeed = trimmedSeed ? Number(trimmedSeed) : NaN;
 const seedForConfig = Number.isFinite(numericSeed) ? numericSeed : undefined;
 
 if (rawSeed !== undefined && !Number.isFinite(numericSeed)) {
   console.warn(
-    `[vitest.config] JASMINE_SEED was set but did not parse as a number; using random seed.`,
+    `[vitest.config] ${SEED_ENV_VAR} was set but did not parse as a number; using random seed.`,
   );
 }
 
@@ -27,7 +34,7 @@ class SeedReporter {
     const seedStr = String(seed);
     console.log(
       `[reporter.seed] Vitest random order, seed=${seedStr} (replay key).` +
-        ` Replay: JASMINE_SEED=${seedStr} npm test`,
+        ` Replay: ${SEED_ENV_VAR}=${seedStr} npm test`,
     );
     if (process.env['GITHUB_ACTIONS'] === 'true') {
       console.log(`::notice title=Vitest seed::seed=${seedStr} (browser chromium)`);


### PR DESCRIPTION
## Summary

`vitest.config.mts` read its replay-seed override from `JASMINE_SEED`. After the Karma -> Vitest cutover (#47 / #417 PR-B), Jasmine is no longer in the unit-test pipeline; the env var name was the last visible "Jasmine" reference and was actively misleading.

Renamed to `JOTJSON_TEST_SEED` (the established first-party env-var convention).

## Changes

- **`vitest.config.mts`**: extracted `const SEED_ENV_VAR = 'JOTJSON_TEST_SEED' as const;` so the three reference sites (process.env lookup, warn message, reporter's Replay hint) cannot drift again. All three literals now route through the constant via template interpolation.
- **`AGENTS.md` Section 4 Naming**: added an explicit bullet stating that first-party env vars use the `JOTJSON_*` prefix, citing the four current examples (`JOTJSON_DEV_AUTH_BYPASS`, `JOTJSON_BUILD_SHA`, `JOTJSON_MIGRATION_CONFIRMED`, `JOTJSON_TEST_SEED`) and the lesson from #436. Also notes that `JJ_*` is reserved for in-code symbol prefixes and i18n placeholder tags, not env vars (preventing the alternate "fix" path from being chosen).

## Migration note for local devs

If you were setting `JASMINE_SEED=...` locally to replay a seed, switch to `JOTJSON_TEST_SEED=...`. The reporter's `[reporter.seed]` line now prints the new name in the Replay hint (e.g., `Replay: JOTJSON_TEST_SEED=42 npm test`). The CI `::notice title=Vitest seed::seed=...` line is unchanged.

## Why a hard cut (no transition period)?

`git grep JASMINE_SEED` across all 18 `origin/*` branches at planning time found references only in each branch's copy of `vitest.config.mts` -- zero workflow / script / docs / CI consumers. The variable is purely developer-local, used only for manual replay. A backwards-compatibility shim accepting both names would have been pure cost.

## Verification

- `npm run lint:all`: green (16 gates: tsc app/spec/perf, ASCII, spec-patterns, prod-patterns, CSP hashes, SWA config, deploy-freshness, SW shape, deprecated-telemetry, lockfile, knip, no-sentinel-ceilings, tree-row-grid, prettier, reduced-motion, api tsc).
- **Smoke A** (value-coupled, not just name): `JOTJSON_TEST_SEED=42 npx vitest --run src/app/core/env/env-label.test.ts` -> printed `Running tests with seed "42"` AND `[reporter.seed] Vitest random order, seed=42 (replay key). Replay: JOTJSON_TEST_SEED=42 npm test`. Confirms the constant is correctly wired into vitest's `sequence.seed` (`vitest.config.mts:64`) and the reporter emits the new name.
- **Smoke B** (warn path): `JOTJSON_TEST_SEED=not-a-number npx vitest --run ...` -> emitted `[vitest.config] JOTJSON_TEST_SEED was set but did not parse as a number; using random seed.` Confirms the warn message also references the new name.

## SemVer / Telemetry

- **SemVer**: no bump. Internal tooling change; no public API, user-visible behavior, stored shape, or release-cadence impact.
- **Telemetry**: no event needed. Developer-local env var, no runtime user action.

## Plan + rubber-duck audit trail

Plan and three-panelist (skeptic / advocate / architect) review transcripts saved to session state:
- `plan-436.md`
- `plan-436.critic-skeptic.md`
- `plan-436.critic-advocate.md`
- `plan-436.critic-architect.md`

Key panel-driven plan changes:
- **Architect ADOPT**: extract `SEED_ENV_VAR` constant rather than three independent literal replacements (prevents future drift).
- **Architect ADOPT**: document the `JOTJSON_*` convention in AGENTS.md (prevents re-arming the same failure mode in another file).
- **Skeptic + Advocate ADOPT**: value-coupled smoke (set seed=42, assert printed seed=42, not just name).
- **Skeptic SET ASIDE**: drive-by edit to the `::notice` line was out of plan scope; left untouched.

Closes #436


---
**Session**
- AI-Local: `5738cf62-c889-4eac-8122-cedec36842b0`
- AI-Cloud: `f37a626e-f09d-42b6-b349-79ff39cfd71d`
