### PR TITLE
Gate L2 1M-node fixture behind JOTJSON_PERF_L2_FORCE_1M env var (#437)

### DIFF
--- a/docs/perf.md
+++ b/docs/perf.md
@@ -296,9 +296,10 @@ under a perf-only Vitest configuration:
 - `tsconfig.perf-l2.json` includes `*.perf.ts` and excludes `*.test.ts`.
 - `vitest.perf.config.mts` launches Playwright Chromium with
   `--js-flags=--expose-gc` so the spec can call `globalThis.gc()`
-  between iterations, and uses a 15-minute `testTimeout` sized for
-  the default 10K + 100K tiers (the opt-in 1M tier may exceed it;
-  tracked in #437).
+  between iterations. The per-test timeout is env-gated (see
+  "L2 1M-node opt-in" below): 15 min by default, 4 hr when
+  `JOTJSON_PERF_L2_FORCE_1M=1`, or any positive integer (ms) via
+  `JOTJSON_PERF_L2_TIMEOUT_MS` escape hatch.
 
 ### L2 scenarios
 
@@ -310,17 +311,30 @@ under a perf-only Vitest configuration:
   the `.tree-body` container (each followed by a double-rAF). The
   emitted `wallNs` covers the entire post-expand scroll session, not
   the scroll alone; diff comparisons are still valid because every
-  iteration runs the same fixed sequence. **10K only** in L2 --
-  mat-tree is not virtualized in v1, so 100K/1M scroll would OOM
-  the browser. L3's `scroll-after-expand.spec.ts` runs the larger
-  sizes in a real browser.
+  iteration runs the same fixed sequence. Runs at every enabled
+  fixture size (10K by default; 100K/1M opt-in). The mat-tree
+  virtualization landed in issue #95 made the larger sizes viable
+  under L2.
 
-Default fixture matrix: deep25 + wide-aoo at 10K. Set
-`window.__perfL2Force100K = true` (or `?force100k=1`) to also bench
-at 100K, and `window.__perfL2Force1M = true` (or `?force1m=1`) to add
-1M. Each 100K iter is ~50s; the 1M iter is multiple minutes. Vitest's
-`testTimeout` is set to 15 minutes in `vitest.perf.config.mts` --
-sized for the default tiers; a 1M opt-in run may exceed it (#437).
+Default fixture matrix: deep25 + wide-aoo at 10K + 100K. Set
+`JOTJSON_PERF_L2_FORCE_1M=1` (env var on the `npm run perf:l2`
+invocation) to also bench at 1M; that env var is consumed by
+`vitest.perf.config.mts`, which adds `src/testing/perf-l2-force-1m.ts`
+to `setupFiles` so `window.__perfL2Force1M = true` is set in the
+browser context before the spec loads. For interactive DevTools use,
+set `window.__perfL2Force1M = true` directly. Each 100K iter is
+~50s; the 1M iter is multiple minutes. The per-test `testTimeout`
+in `vitest.perf.config.mts` is env-gated: 15 min default (sized for
+10K + 100K), 4 hr when `JOTJSON_PERF_L2_FORCE_1M=1`, or any positive
+integer (ms) via `JOTJSON_PERF_L2_TIMEOUT_MS` (escape hatch; takes
+priority; emits a one-time console.warn so a downstream timeout can
+be attributed). The 4 hr default is a conservative upper bound until
+#437's Phase 2 measurement provides per-iter wall-clock numbers
+worthy of a tighter cap. Re-measure (and consider re-sizing) on:
+hardware changes; node-count tier changes; iteration-count changes
+in `WARMUP_ITERS` / `TIMED_ITERS`; algorithmic changes inside
+`initial-render` or `scroll-after-expand` that change the per-iter
+work envelope.
 
 `scroll-after-expand: wide-aoo @ 10k` is additionally gated behind
 `window.__perfL2ForceWideAooScroll = true` (or `?forcewideaooscroll=1`).
@@ -510,13 +524,18 @@ npm run perf:clean -- --dry-run
   single source of truth (architect r2 tech-debt #2 adoption).
 - **No CI gate**: perf benches do not run in CI yet. Filed as
   follow-up issue (priority:low, requires self-hosted runner).
-- **L2 caps default at 10K nodes**: 100K deep25 mat-tree (NOT
-  virtualized) takes ~50s per iteration synchronously, and the
-  browser thread is blocked during the timed loop. The L2 spec
-  gates 100K behind `?force100k=1` (Vitest's `testTimeout` is set
-  to 15 minutes in `vitest.perf.config.mts` so the opt-in still
-  works).
-  1M is gated similarly behind `?force1m=1`.
+- **L2 caps default at 10K + 100K nodes**: post-#95 virtualization
+  made 100K viable under the per-test 15 min `testTimeout`. The 1M
+  tier is gated behind `JOTJSON_PERF_L2_FORCE_1M=1` (env var) which
+  routes through `vitest.perf.config.mts` to add the
+  `src/testing/perf-l2-force-1m.ts` setupFile (sets
+  `window.__perfL2Force1M = true` in the browser context) AND bumps
+  the per-test `testTimeout` to 4 hours. For DevTools-style use,
+  set `window.__perfL2Force1M = true` directly (the timeout is
+  config-time only; interactive runs are not subject to vitest's
+  per-test deadline anyway). Override with
+  `JOTJSON_PERF_L2_TIMEOUT_MS=<ms>` (must match `^\d+$`; values that
+  don't parse cleanly are ignored with a one-time warn).
 - **L2 `scroll-after-expand: wide-aoo` gated by default**: on a
   910-node depth-1 fan-out, `JsonTreeComponent.expandAll` triggers
   one synchronous CD cycle that materializes every sibling at once,
@@ -556,9 +575,12 @@ npm run perf:clean -- --dry-run
   ~5 MB / ~380K nodes. At default settings the `initial-render`
   and `scroll-after-expand` scenarios at this size risk the
   15-min Vitest `testTimeout`. The L2 spec gates this fixture
-  behind `?force5mb=1` or `window.__perfL2Force5MB = true`
-  (mirrors the existing `?force1m=1` pattern). L1 and L3
-  enforce on this fixture default-on; only L2 needs the opt-in.
+  behind `?force5mb=1` or `window.__perfL2Force5MB = true`. L1
+  and L3 enforce on this fixture default-on; only L2 needs the
+  opt-in. The 1M-node fixture uses a different opt-in path
+  (`JOTJSON_PERF_L2_FORCE_1M=1` env var; see the "Layer 2" section
+  above); a parallel env-var setupFile for 5MB can follow in a
+  separate issue if needed.
 
 See `plan.md` -> "Out of scope" in the session for the full
 follow-up issue list.

--- a/src/app/shared/components/json-tree/json-tree.component.perf.ts
+++ b/src/app/shared/components/json-tree/json-tree.component.perf.ts
@@ -60,15 +60,22 @@ function defaultFixtures(): FixtureSpec[] {
   //   - 10K + 100K are enabled by default. Virtualization made 100K
   //     viable; each iter is now bounded by the viewport window, not
   //     the full node count.
-  //   - 1M is opt-in via `window.__perfL2Force1M = true` or `?force1m=1`.
-  //     Each iter is many minutes (build/expand traversal dominates);
-  //     reserve for deliberate diagnostic runs.
+  //   - 1M is opt-in via `JOTJSON_PERF_L2_FORCE_1M=1`, which routes
+  //     through `vitest.perf.config.mts` to include the
+  //     `src/testing/perf-l2-force-1m.ts` setupFile. That setupFile
+  //     sets `window.__perfL2Force1M = true` in the browser context
+  //     before this spec loads. For interactive DevTools use, set
+  //     `window.__perfL2Force1M = true` directly. Each iter is many
+  //     minutes (build/expand traversal dominates); reserve for
+  //     deliberate diagnostic runs.
   //   - `mixed-d10 @ 380k` (the ~5 MB NFR-anchor fixture from F-2)
   //     is opt-in via `window.__perfL2Force5MB = true` or
   //     `?force5mb=1`. Per skeptic #4: at default settings a 380K-
   //     node fixture extrapolated linearly from 100K's ~50 s/iter
-  //     risks the per-test timeout. The flag mirrors the existing
-  //     `?force1m=1` pattern.
+  //     risks the per-test timeout. The flag is the 5MB opt-in path
+  //     today; an env-var setupFile parallel to
+  //     `JOTJSON_PERF_L2_FORCE_1M` can follow in a separate issue
+  //     if needed.
   // Defaults intentionally cap so unattended `npm run perf:l2`
   // stays well under the per-test timeout (15 min in
   // `vitest.perf.config.mts`).
@@ -77,7 +84,7 @@ function defaultFixtures(): FixtureSpec[] {
     __perfL2Force5MB?: boolean;
   };
   const win = window as ForceWindow;
-  const force1M = win.__perfL2Force1M === true || location.search.includes('force1m=1');
+  const force1M = win.__perfL2Force1M === true;
   const force5MB = win.__perfL2Force5MB === true || location.search.includes('force5mb=1');
   const enabledNodeCounts = new Set<number>([10_000, 100_000]);
   if (force1M) enabledNodeCounts.add(1_000_000);

--- a/src/testing/perf-l2-force-1m.ts
+++ b/src/testing/perf-l2-force-1m.ts
@@ -1,0 +1,12 @@
+// Vitest setup file: opts the L2 perf bench into the 1M-node fixture
+// tier. Included by vitest.perf.config.mts only when
+// JOTJSON_PERF_L2_FORCE_1M=1. Runs in the browser context before
+// json-tree.component.perf.ts loads, so the spec's module-level
+// defaultFixtures() call picks up the flag.
+//
+// Property name MUST match the spec's `ForceWindow` shape at
+// json-tree.component.perf.ts:75-78 (`__perfL2Force1M`, capital M).
+// A typo here silently no-ops; Phase 2 measurement scripts guard
+// against this by asserting at least one `"size":"1m"` row appears
+// in the captured log.
+(window as Window & { __perfL2Force1M?: boolean }).__perfL2Force1M = true;

--- a/tsconfig.perf-l2.json
+++ b/tsconfig.perf-l2.json
@@ -3,7 +3,7 @@
  * Owns the type-check graph for `src/`*`*`/`*.perf.ts` and
  * `perf/fixtures/`*`*`/`*.ts` when run under vitest browser mode.
  * Separate from `tsconfig.spec.json` so a perf-only ambient (e.g.
- * `window.__perfL2Force100K`) does not leak into the unit-suite
+ * `window.__perfL2Force1M`) does not leak into the unit-suite
  * type-check graph and vice versa.
  *
  * Distinct from `tsconfig.perf.json` (Layer 1 Node bench under

--- a/vitest.perf.config.mts
+++ b/vitest.perf.config.mts
@@ -8,8 +8,26 @@
 //
 // Deltas vs `vitest.config.mts`:
 //   - include perf files, exclude unit files
-//   - testTimeout: 15 minutes (sized for the default 10K + 100K
-//     tiers; the opt-in 1M tier may need more headroom -- see #437)
+//   - testTimeout (env-gated; see resolution priority below):
+//       - `JOTJSON_PERF_L2_TIMEOUT_MS=<ms>` (escape hatch) takes
+//         priority over both defaults; values must match `^\d+$`
+//         (rejects scientific notation, units, whitespace) or are
+//         ignored with a one-shot warn.
+//       - `JOTJSON_PERF_L2_FORCE_1M=1` defaults to 4 hours
+//         (conservative upper bound until #437's measurement
+//         tightens it).
+//       - Otherwise: 15 minutes (sized for the default 10K + 100K
+//         tiers; well under per-iter wall-clock at those sizes).
+//     The escape hatch emits a one-time console.warn when set so a
+//     downstream timeout failure can be attributed (mirrors
+//     `api/src/shared/auth.ts` dev-auth-bypass precedent).
+//   - 1M-node fixture opt-in: `JOTJSON_PERF_L2_FORCE_1M=1` adds
+//     `src/testing/perf-l2-force-1m.ts` to setupFiles. The setupFile
+//     sets `window.__perfL2Force1M = true` in the browser context
+//     before `json-tree.component.perf.ts` loads, so the spec's
+//     module-level `defaultFixtures()` includes the 1M tier. See
+//     `docs/perf.md` "Layer 2 -- vitest perf bench" for invocation
+//     and re-measurement-trigger discussion.
 //   - browser launch args add `--js-flags=--expose-gc` so the spec's
 //     `ensureGc()` precondition holds
 //   - browser `fileParallelism: false` so benches are not racing
@@ -29,19 +47,80 @@
 import { defineConfig } from 'vitest/config';
 import { makeBrowserConfig, sharedPlugins, sharedTestBase } from './vitest.shared.mts';
 
+// Env-var names (mirrors `vitest.config.mts:17 SEED_ENV_VAR` pattern).
+// Both follow the `JOTJSON_*` first-party prefix convention from
+// AGENTS.md S4, established by issue #436's JOTJSON_TEST_SEED rename.
+const FORCE_1M_ENV_VAR = 'JOTJSON_PERF_L2_FORCE_1M' as const;
+const TIMEOUT_OVERRIDE_ENV_VAR = 'JOTJSON_PERF_L2_TIMEOUT_MS' as const;
+
+// Boolean-parse convention follows the L3 PERF_FORCE_* family
+// (perf/browser/scenarios/paste-large.spec.ts:92, :173;
+// expand-all.spec.ts:42; scroll-after-expand.spec.ts:47). The L2/L3
+// perf tiers use strict `=== '1'`; this intentionally diverges from
+// `JOTJSON_DEV_AUTH_BYPASS` (api/src/shared/auth.ts) which uses
+// `=== 'true'` and explicitly rejects `'1'`. The perf-tier convention
+// is independent from the dev-auth-bypass convention.
+const force1M = process.env[FORCE_1M_ENV_VAR] === '1';
+
+// Strict integer-string match. `Number()` silently coerces
+// `'15min'`, `' 15 '`, `'1e308'`, etc.; we reject anything that
+// isn't pure digits so a typo can't masquerade as a tiny or
+// infinite timeout.
+const rawTimeoutOverride = process.env[TIMEOUT_OVERRIDE_ENV_VAR];
+const timeoutOverride =
+  rawTimeoutOverride && /^\d+$/.test(rawTimeoutOverride) ? Number(rawTimeoutOverride) : Number.NaN;
+
+if (Number.isFinite(timeoutOverride) && timeoutOverride > 0) {
+  // eslint-disable-next-line no-console -- intentional one-shot operator warn
+  console.warn(
+    `[vitest.perf.config] ${TIMEOUT_OVERRIDE_ENV_VAR}=${timeoutOverride} ` +
+      `overriding per-test timeout. If a test times out under this ` +
+      `override, re-check the override value before declaring a perf ` +
+      `regression.`,
+  );
+} else if (rawTimeoutOverride && !Number.isFinite(timeoutOverride)) {
+  // eslint-disable-next-line no-console -- intentional one-shot operator warn
+  console.warn(
+    `[vitest.perf.config] ${TIMEOUT_OVERRIDE_ENV_VAR}=${rawTimeoutOverride} ` +
+      `is not a positive integer string; ignored. Use plain milliseconds, ` +
+      `e.g. ${TIMEOUT_OVERRIDE_ENV_VAR}=3600000 for 1 hour.`,
+  );
+}
+
 const FIFTEEN_MINUTES_MS = 15 * 60 * 1000;
+const FOUR_HOURS_MS = 4 * 60 * 60 * 1000;
+
+// Resolution priority: explicit override > 1M default > base 15 min.
+// The 4-hour 1M default is a conservative upper bound until #437's
+// Phase 2 measurement provides per-iter wall-clock numbers; with
+// (warmup_iters + timed_iters) = 7 it allows ~30 min/iter before a
+// real run trips the cap.
+const testTimeoutMs =
+  Number.isFinite(timeoutOverride) && timeoutOverride > 0
+    ? timeoutOverride
+    : force1M
+      ? FOUR_HOURS_MS
+      : FIFTEEN_MINUTES_MS;
+
+// `sharedTestBase.setupFiles` is a readonly tuple (`as const`).
+// Spread on BOTH branches so we never share-by-reference with the
+// frozen tuple and never trip a `readonly`-variance compile error.
+const perfSetupFiles: string[] = force1M
+  ? [...sharedTestBase.setupFiles, 'src/testing/perf-l2-force-1m.ts']
+  : [...sharedTestBase.setupFiles];
 
 export default defineConfig(() => ({
   plugins: sharedPlugins,
   test: {
     ...sharedTestBase,
+    setupFiles: perfSetupFiles,
     include: ['src/**/*.perf.ts'],
     exclude: ['src/**/*.test.ts', 'node_modules/**', 'dist/**'],
     reporters: ['default'],
     coverage: { enabled: false },
     sequence: { shuffle: false },
-    testTimeout: FIFTEEN_MINUTES_MS,
-    hookTimeout: FIFTEEN_MINUTES_MS,
+    testTimeout: testTimeoutMs,
+    hookTimeout: testTimeoutMs,
     restoreMocks: false,
     unstubGlobals: false,
     unstubEnvs: false,


### PR DESCRIPTION
## Summary

Wires up an env-gated opt-in for the L2 perf bench's 1M-node fixture
so the existing 15-min per-test `testTimeout` in
`vitest.perf.config.mts` stays sized for the unattended default
(10K + 100K) while a deliberate measurement run can be kicked off
with a conservative 4 hr cap.

Closes #437.

## What's in this PR

* **`vitest.perf.config.mts`**: two new env vars consumed at
  config-load time.
  * `JOTJSON_PERF_L2_FORCE_1M=1` includes
    `src/testing/perf-l2-force-1m.ts` in `setupFiles` AND bumps the
    per-test `testTimeout` from 15 min to 4 hr (conservative upper
    bound until the Phase 2 measurement below provides per-iter
    wall-clock numbers).
  * `JOTJSON_PERF_L2_TIMEOUT_MS=<ms>` (escape hatch) overrides both
    defaults; must match `^\d+$` or is ignored with a one-shot
    `console.warn`. The override-set branch also emits a one-shot
    warn so a downstream timeout failure can be attributed.
  * Naming follows the `JOTJSON_*` prefix convention (AGENTS.md S4),
    matching #436's `JOTJSON_TEST_SEED` rename. Boolean parse uses
    `=== '1'` to match the L3 `PERF_FORCE_*` family.
  * `setupFiles` spreads `sharedTestBase.setupFiles` on BOTH
    branches so the readonly `as const` tuple from
    `vitest.shared.mts` never flows by reference.

* **`src/testing/perf-l2-force-1m.ts`** (new): tiny setupFile that
  sets `window.__perfL2Force1M = true` in the browser context
  before the spec module loads. Inline comment names the typo
  risk; the Phase 2 measurement script will assert at least one
  `"size":"1m"` row in the captured log as a row-count guard.

* **`json-tree.component.perf.ts`**: drops the URL-flag fallback
  from the 1M opt-in path. The 1M opt-in is now env-var only
  (`window.__perfL2Force1M` still works for interactive DevTools
  use). The 5MB `?force5mb=1` URL-flag clause is intentionally
  unchanged --- a parallel env-var setupFile for 5MB can follow
  in a separate issue if needed.

* **`tsconfig.perf-l2.json`**: stale `__perfL2Force100K` comment ->
  `__perfL2Force1M`.

* **`docs/perf.md`**: Layer 2 section, default-fixture-matrix
  paragraph, and the two "L2 caps" / "L2 mixed-d10" bullets in
  the "Out of scope" section now document the env vars, the 4 hr
  default cap rationale, the override semantics, and the
  re-measurement triggers.

## Verification

* `npm run lint:all` exit 0 (frontend tsc + ascii + format + spec/
  prod-patterns + lockfile + api tsc).
* `npm run lint:tsc-perf-l2` exit 0 (perf tsconfig type-checks).
* `npm run perf:l2` (default env, unset) wrote the expected 8 rows
  (deep25/wide-aoo x 10K/100K x initial-render/scroll-after-expand)
  in 235s --- no regression on the default path.
* Phase 2 1M measurement run (`JOTJSON_PERF_L2_FORCE_1M=1`) follows
  on this branch; PR is opened as DRAFT so Mergify ignores it
  during the multi-hour run. Will be marked ready-for-review once
  the measured per-iter wall-clock is known and Phase 3 has either
  (a) tightened the 4 hr cap to a data-driven value, or (b) chosen
  one of the deferred remedies (e.g., `--max-old-space-size=8192`)
  if OOM rather than wall-clock was the proximate cause.

## SemVer / Telemetry

* **SemVer**: no bump (internal perf-bench plumbing only).
* **Telemetry**: no event (config-time + dev/perf-only).

## Rubber-duck panel audit trail

Full per-panelist transcripts at
`files/plan-437.critic-{skeptic,advocate,architect}.md` in the
session folder. 14 findings adopted (architectural separation:
`=== '1'` boolean convention, regex-validated override, 4 hr
default justification, docs sweep expansion, setupFiles spread
on both branches, row-count guard for typo-silent failures).
2 findings out of scope (5MB asymmetric scope, OOM remedy (b)
deferred). See plan-437.md "Pre-presentation gate" for the full
cross-critic synthesis.

---

**Session**
- AI-Local: `5738cf62-c889-4eac-8122-cedec36842b0`
- AI-Cloud: `f37a626e-f09d-42b6-b349-79ff39cfd71d`

