### PR TITLE
Add explicit scope to web app manifest for link capturing

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -3,6 +3,7 @@
   "short_name": "JotJSON",
   "description": "Input, store, and display JSON.",
   "start_url": "/",
+  "scope": "/",
   "display": "standalone",
   "orientation": "any",
   "background_color": "#1e1e1e",


### PR DESCRIPTION
## Summary

Adds an explicit `scope: "/"` to the web app manifest to anchor the link-capture boundary as a deliberate declaration rather than relying on the spec-default inference from `start_url`.

This may fix Edge's link-handling feature not recognizing which URLs to route to the installed PWA (link capturing was enabled but not working despite the per-app toggle being on).

`client_mode` remains `navigate-new` per DESIGN_SPEC.md to preserve file-handler safety.

## Testing

- `npm run build` passes
- `prettier --check` passes
- Manual: install PWA in Edge, verify link handling works with explicit scope

## SemVer

No bump -- manifest metadata only.

---
**Session**
- AI-Local: `cb733b3f-50b6-4ad8-b8fe-05429b0d8d8d`
- AI-Cloud: `ad06e571-c077-4500-960d-da788b231d1e`